### PR TITLE
Update interpreter.py for multi OS request

### DIFF
--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -6,6 +6,7 @@ from .code_interpreter import CodeInterpreter
 from .llama_2 import get_llama_2_instance
 
 import os
+import platform #new, see OS request line 99
 import openai
 import getpass
 import requests
@@ -95,7 +96,9 @@ class Interpreter:
     # Add user info
     username = getpass.getuser()
     current_working_directory = os.getcwd()
-    operating_system = os.name if os.name != 'nt' else os.uname().sysname
+
+    #Retrieve OS in a way that fine on both Win and Linux etc OS 
+    operating_system = os.name if os.name != 'nt' else platform.system()
     info += f"\n\n[User Info]\nName: {username}\nCWD: {current_working_directory}\nOS: {operating_system}"
 
     if not self.local:


### PR DESCRIPTION
Hi, i got following error after your last commits (and trying them out :-) ) :

> _File "E:\Python311\Lib\site-packages\interpreter\interpreter.py", line 98, in get_info_for_system_message
> operating_system = os.name if os.name != 'nt' else os.uname().sysname                                                 
> AttributeError: module 'os' has no attribute 'uname'. Did you mean: 'name'?_

After some time looking into it:

Its trying to call the method `os.uname()` on a Win system. However, the `os.uname()` function is not available on Windows systems, which is why the AttributeError is triggered.
-> A possible solution is to use the `platform ` library to query the operating system, 

These ( 1x import lib, 1x another os call ) I have changed (and tested on two Win machines). But iam just hobby coding, most probably you know another approach without using an additional package. Just wanted to help! :-)