### PR TITLE
Update interpreter.py - windows file system adjustment

### DIFF
--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -10,7 +10,13 @@ import platform
 import openai
 import getpass
 import requests
-import readline
+try:
+    if platform.system() == 'Windows':
+        import pyreadline3 as readline
+    else:
+        import readline
+except ImportError:
+    print("Windows file system detected, please pip install pyreadline3.")
 import urllib.parse
 import tokentrim as tt
 from rich import print


### PR DESCRIPTION
Hi!

I replaced (if/else condition...) the use of the `readline` library with `pyreadline3` bfor Windows compatibility. `readline` is Unix-specific and not working with windows file system, while `pyreadline3` provides similar functionality on Windows.

( Maybe there are better solutions, like checking at building via poetry? Or maybe its fine for now)