### PR TITLE
Changed model name from 16b to 13b, added tip for gpt3.5

### DIFF
--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -160,7 +160,7 @@ class Interpreter:
     # If self.local, we actually don't use self.model
     # (self.auto_run is like advanced usage, we display no messages)
     if not self.local and not self.auto_run:
-      welcome_message += f"\n> Model set to `{self.model.upper()}`\n\n**Tips:**\n To run locally, use `interpreter --local`\n To run it with GPT-3.5, use `interpreter --fast`"
+      welcome_message += f"\n> Model set to `{self.model.upper()}`\n\n**Tips:**\n To run locally, use `interpreter --local`\n To run it with GPT-3.5 (Faster), use `interpreter --fast`"
 
     if self.local:
       welcome_message += f"\n> Model set to `Code-Llama`"

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -160,7 +160,7 @@ class Interpreter:
     # If self.local, we actually don't use self.model
     # (self.auto_run is like advanced usage, we display no messages)
     if not self.local and not self.auto_run:
-      welcome_message += f"\n> Model set to `{self.model.upper()}`\n\n**Tip:** To run locally, use `interpreter --local`"
+      welcome_message += f"\n> Model set to `{self.model.upper()}`\n\n**Tips:**\n To run locally, use `interpreter --local`\n To run it with GPT-3.5, use `interpreter --fast`"
 
     if self.local:
       welcome_message += f"\n> Model set to `Code-Llama`"

--- a/interpreter/llama_2.py
+++ b/interpreter/llama_2.py
@@ -20,7 +20,7 @@ def get_llama_2_instance():
             'Medium': {'URL': 'https://huggingface.co/TheBloke/CodeLlama-7B-GGUF/resolve/main/codellama-7b.Q4_K_M.gguf', 'Size': '4.24 GB', 'RAM': '6.74 GB'},
             'High': {'URL': 'https://huggingface.co/TheBloke/CodeLlama-7B-GGUF/resolve/main/codellama-7b.Q8_0.gguf', 'Size': '7.16 GB', 'RAM': '9.66 GB'}
         },
-        '16B': {
+        '13B': {
             'Low': {'URL': 'https://huggingface.co/TheBloke/CodeLlama-13B-GGUF/resolve/main/codellama-13b.Q2_K.gguf', 'Size': '5.66 GB', 'RAM': '8.16 GB'},
             'Medium': {'URL': 'https://huggingface.co/TheBloke/CodeLlama-13B-GGUF/resolve/main/codellama-13b.Q4_K_M.gguf', 'Size': '8.06 GB', 'RAM': '10.56 GB'},
             'High': {'URL': 'https://huggingface.co/TheBloke/CodeLlama-13B-GGUF/resolve/main/codellama-13b.Q8_0.gguf', 'Size': '13.83 GB', 'RAM': '16.33 GB'}


### PR DESCRIPTION
Changed the model name from 16b as, the models released by Llama were 13b, probably a typo.
 
Also added a tip to change the model to gpt 3.5, so that people who do not have access to gpt-4 could also be able to use it