### PR TITLE
Add support for Ollama, Palm, Claude-2, Cohere, Replicate Llama2 CodeLlama (100+LLMs)

### DIFF
--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -10,6 +10,8 @@ import time
 import json
 import platform
 import openai
+import litellm
+from litellm import completion
 import getpass
 import requests
 import readline
@@ -307,10 +309,10 @@ class Interpreter:
           time.sleep(2)
           print(Rule(style="white"))
 
-      openai.api_type = "azure"
-      openai.api_base = self.azure_api_base
-      openai.api_version = self.azure_api_version
-      openai.api_key = self.api_key
+      litellm.api_type = "azure"
+      litellm.api_base = self.azure_api_base
+      litellm.api_version = self.azure_api_version
+      litellm.api_key = self.api_key
     else:
       if self.api_key == None:
         if 'OPENAI_API_KEY' in os.environ:
@@ -339,7 +341,7 @@ class Interpreter:
               time.sleep(2)
               print(Rule(style="white"))
 
-      openai.api_key = self.api_key
+      litellm.api_key = self.api_key
 
   def end_active_block(self):
     if self.active_block:
@@ -377,15 +379,15 @@ class Interpreter:
         try:
           
             if self.use_azure:
-              response = openai.ChatCompletion.create(
-                  engine=self.azure_deployment_name,
+              response = completion(
+                  model=self.azure_deployment_name,
                   messages=messages,
                   functions=[function_schema],
                   temperature=self.temperature,
                   stream=True,
                   )
             else:
-              response = openai.ChatCompletion.create(
+              response = completion(
                 model=self.model,
                 messages=messages,
                 functions=[function_schema],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.10"
 openai = "^0.27.8"
+litellm = "^0.1.574"
 rich = "^13.4.2"
 tiktoken = "^0.4.0"
 astor = "^0.8.1"


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 


Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```