### PR TITLE
feat: add AZURE_API_KEY that falls back to OPENAI_API_KEY

### DIFF
--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -265,13 +265,16 @@ class Interpreter:
 
   def verify_api_key(self):
     """
-    Makes sure we have an OPENAI_API_KEY.
+    Makes sure we have an AZURE_API_KEY or OPENAI_API_KEY.
     """
     if self.use_azure:
-      all_env_available = ('OPENAI_API_KEY' in os.environ and 'AZURE_API_BASE' in os.environ
-                           and 'AZURE_API_VERSION' in os.environ and 'AZURE_DEPLOYMENT_NAME' in os.environ)
+      all_env_available = (
+        ('AZURE_API_KEY' in os.environ or 'OPENAI_API_KEY' in os.environ) and
+        'AZURE_API_BASE' in os.environ and
+        'AZURE_API_VERSION' in os.environ and
+        'AZURE_DEPLOYMENT_NAME' in os.environ)
       if all_env_available:
-        self.api_key = os.environ['OPENAI_API_KEY']
+        self.api_key = os.environ.get('AZURE_API_KEY') or os.environ['OPENAI_API_KEY']
         self.azure_api_base = os.environ['AZURE_API_BASE']
         self.azure_api_version = os.environ['AZURE_API_VERSION']
         self.azure_deployment_name = os.environ['AZURE_DEPLOYMENT_NAME']
@@ -302,7 +305,7 @@ class Interpreter:
           self.azure_deployment_name = input("Azure OpenAI deployment name of GPT: ")
           self.azure_api_version = input("Azure OpenAI API version: ")
           print('', Markdown(
-            "**Tip:** To save this key for later, run `export OPENAI_API_KEY=your_api_key AZURE_API_BASE=your_api_base AZURE_API_VERSION=your_api_version AZURE_DEPLOYMENT_NAME=your_gpt_deployment_name` on Mac/Linux or `setx OPENAI_API_KEY your_api_key AZURE_API_BASE your_api_base AZURE_API_VERSION your_api_version AZURE_DEPLOYMENT_NAME your_gpt_deployment_name` on Windows."),
+            "**Tip:** To save this key for later, run `export AZURE_API_KEY=your_api_key AZURE_API_BASE=your_api_base AZURE_API_VERSION=your_api_version AZURE_DEPLOYMENT_NAME=your_gpt_deployment_name` on Mac/Linux or `setx AZURE_API_KEY your_api_key AZURE_API_BASE your_api_base AZURE_API_VERSION your_api_version AZURE_DEPLOYMENT_NAME your_gpt_deployment_name` on Windows."),
                 '')
           time.sleep(2)
           print(Rule(style="white"))


### PR DESCRIPTION
The `--use-azure` flag coopts the `OPENAI_API_KEY` environment variable. This makes it impossible to have an OpenAI configuration and an Azure configuration on the same machine without swapping the `OPENAI_API_KEY` environment variable.

This PR adds support for a new environment variable `AZURE_API_KEY` that falls back to `OPENAI_API_KEY` if not found.

```
# Use OpenAI
OPENAI_API_KEY=key interpreter

# Use Azure
AZURE_API_KEY=key AZURE_API_BASE=base AZURE_API_VERSION=version AZURE_DEPLOYMENT_NAME=name interpreter --use-azure

# Use Azure but fallback to OPENAI_API_KEY for backward compatibilty
OPENAI_API_KEY=key AZURE_API_BASE=base AZURE_API_VERSION=version AZURE_DEPLOYMENT_NAME=name interpreter --use-azure
```