### PR TITLE
Feature: add cli environment variable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,14 @@
+# Set to 'True' or 'False' to determine if the code should execute without user confirmation
+INTERPRETER_CLI_AUTO_RUN=False
+
+# Set to 'True' or 'False' to determine if gpt-3.5-turbo should be used instead of gpt-4
+INTERPRETER_CLI_FAST_MODE=False
+
+# Set to 'True' or 'False' to determine if the code should run fully local with code-llama
+INTERPRETER_CLI_LOCAL_RUN=False
+
+# Set to 'True' or 'False' to enable or disable debug mode
+INTERPRETER_CLI_DEBUG=False
+
+# Set to 'True' or 'False' to determine if Azure OpenAI Services should be used
+INTERPRETER_CLI_USE_AZURE=False

--- a/README.md
+++ b/README.md
@@ -196,6 +196,27 @@ $ interpreter
 > %debug # <- Turns on debug mode
 ```
 
+### Configuration with .env
+Open Interpreter allows you to set default behaviors using a .env file. This provides a flexible way to configure the interpreter without changing command-line arguments every time.
+
+Here's a sample .env configuration:
+
+```
+INTERPRETER_CLI_AUTO_RUN=False
+INTERPRETER_CLI_FAST_MODE=False
+INTERPRETER_CLI_LOCAL_RUN=False
+INTERPRETER_CLI_DEBUG=False
+INTERPRETER_CLI_USE_AZURE=False
+```
+
+- INTERPRETER_CLI_AUTO_RUN: If set to True, the interpreter will execute code without user confirmation.
+- INTERPRETER_CLI_FAST_MODE: If set to True, the interpreter will use gpt-3.5-turbo instead of gpt-4.
+- INTERPRETER_CLI_LOCAL_RUN: If set to True, the interpreter will run fully locally with Code Llama.
+- INTERPRETER_CLI_DEBUG: If set to True, the interpreter will print extra debugging information.
+- INTERPRETER_CLI_USE_AZURE: If set to True, the interpreter will use Azure OpenAI Services.
+
+You can modify these values in the .env file to change the default behavior of the Open Interpreter.
+
 ## Safety Notice
 
 Since generated code is executed in your local environment, it can interact with your files and system settings, potentially leading to unexpected outcomes like data loss or security risks.

--- a/interpreter/cli.py
+++ b/interpreter/cli.py
@@ -1,5 +1,10 @@
 import argparse
 import inquirer
+import os
+from dotenv import load_dotenv
+
+# Load .env file
+load_dotenv()
 
 def cli(interpreter):
   """
@@ -7,26 +12,40 @@ def cli(interpreter):
   Modifies it according to command line flags, then runs chat.
   """
 
+  # Load values from .env file with the new names
+  AUTO_RUN = os.getenv('INTERPRETER_CLI_AUTO_RUN', 'False') == 'True'
+  FAST_MODE = os.getenv('INTERPRETER_CLI_FAST_MODE', 'False') == 'True'
+  LOCAL_RUN = os.getenv('INTERPRETER_CLI_LOCAL_RUN', 'False') == 'True'
+  DEBUG = os.getenv('INTERPRETER_CLI_DEBUG', 'False') == 'True'
+  USE_AZURE = os.getenv('INTERPRETER_CLI_USE_AZURE', 'False') == 'True'
+
   # Setup CLI
   parser = argparse.ArgumentParser(description='Chat with Open Interpreter.')
   
   parser.add_argument('-y',
                       '--yes',
                       action='store_true',
+                      default=AUTO_RUN,
                       help='execute code without user confirmation')
   parser.add_argument('-f',
                       '--fast',
                       action='store_true',
+                      default=FAST_MODE,
                       help='use gpt-3.5-turbo instead of gpt-4')
   parser.add_argument('-l',
                       '--local',
                       action='store_true',
+                      default=LOCAL_RUN,
                       help='run fully local with code-llama')
   parser.add_argument('-d',
                       '--debug',
                       action='store_true',
+                      default=DEBUG,
                       help='prints extra information')
-  parser.add_argument('--use-azure', action='store_true', help='use Azure OpenAI Services')
+  parser.add_argument('--use-azure',
+                      action='store_true',
+                      default=USE_AZURE,
+                      help='use Azure OpenAI Services')
   args = parser.parse_args()
 
   # Modify interpreter according to command line flags

--- a/poetry.lock
+++ b/poetry.lock
@@ -698,6 +698,20 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "python-dotenv"
+version = "1.0.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.0.tar.gz", hash = "sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba"},
+    {file = "python_dotenv-1.0.0-py3-none-any.whl", hash = "sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "python-editor"
 version = "1.0.4"
 description = "Programmatically open an editor, capture the result."
@@ -1115,4 +1129,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a2192f76322052742e162ebfea533f87a76782ea5986f65ed892be7fc0d39311"
+content-hash = "07ed0f6abc37fcd06424b9129346ddfcde00bf52bc417a4e2fd229477eb8f8be"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ git-python = "^1.0.3"
 tokentrim = "^0.1.9"
 appdirs = "^1.4.4"
 six = "^1.16.0"
+python-dotenv = "^1.0.0"
 
 # On non-windows systems, you can just `import readline`.
 # On windows, `pyreadline3` replaces that, so you can also just `import readline`.


### PR DESCRIPTION
I've implemented a feature that allows the interpreter cli to load configurations either directly from environment variables or from a .env file. 

This enhancement aims to streamline the workflow by setting default values in the shell, eliminating the need to repeatedly input parameters via the CLI.

I'd greatly appreciate any feedback or suggestions you might have regarding these changes. 