### PR TITLE
Add option to override Azure API type

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ interpreter.api_key = "your_openai_api_key"
 interpreter.azure_api_base = "your_azure_api_base"
 interpreter.azure_api_version = "your_azure_api_version"
 interpreter.azure_deployment_name = "your_azure_deployment_name"
+interpreter.azure_api_type = "azure"
 ```
 
 ### Debug mode

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -80,6 +80,7 @@ class Interpreter:
     self.azure_api_base = None
     self.azure_api_version = None
     self.azure_deployment_name = None
+    self.azure_api_type = "azure"
 
     # Get default system message
     here = os.path.abspath(os.path.dirname(__file__))
@@ -278,6 +279,7 @@ class Interpreter:
         self.azure_api_base = os.environ['AZURE_API_BASE']
         self.azure_api_version = os.environ['AZURE_API_VERSION']
         self.azure_deployment_name = os.environ['AZURE_DEPLOYMENT_NAME']
+        self.azure_api_type = os.environ.get('AZURE_API_TYPE', 'azure')
       else:
         # This is probably their first time here!
         print('', Markdown("**Welcome to Open Interpreter.**"), '')
@@ -310,7 +312,7 @@ class Interpreter:
           time.sleep(2)
           print(Rule(style="white"))
 
-      openai.api_type = "azure"
+      openai.api_type = self.azure_api_type
       openai.api_base = self.azure_api_base
       openai.api_version = self.azure_api_version
       openai.api_key = self.api_key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "open-interpreter"
 packages = [
     {include = "interpreter"},
 ]
-version = "0.1.1"
+version = "0.1.2"
 description = "Let language models run code locally."
 authors = ["Killian Lucas <killian@drinkwater.ai>"]
 readme = "README.md"


### PR DESCRIPTION
Adding an option to explicitly override `api_type` that's passed to OpenAI when in `--azure` mode. This can be set via `export AZURE_API_TYPE=azure_ad`.

This is needed since our internal Azure instance at Airbnb requires a different "api_type" set.

<img width="394" alt="image" src="https://github.com/KillianLucas/open-interpreter/assets/175499/5dafed6b-d21f-4143-b431-a5b434467ca3">
