### PR TITLE
Falcon // Any 🤗 model via `--model meta/llama`

### DIFF
--- a/interpreter/cli.py
+++ b/interpreter/cli.py
@@ -44,7 +44,10 @@ def cli(interpreter):
     
     # Temporarily, for backwards (behavioral) compatability, we've moved this part of llama_2.py here.
     # This way, when folks hit interpreter --local, they get the same experience as before.
-
+    from rich import print
+    from rich.markdown import Markdown
+    import inquirer
+    
     print('', Markdown("**Open Interpreter** will use `Code Llama` for local execution. Use your arrow keys to set up the model."), '')
         
     models = {

--- a/interpreter/cli.py
+++ b/interpreter/cli.py
@@ -72,7 +72,7 @@ def cli(interpreter):
     interpreter.use_azure = True
     interpreter.local = False
   if args.model != "":
-    self.model = args.model
+    interpreter.model = args.model
     interpreter.local = True
 
   # Run the chat method

--- a/interpreter/cli.py
+++ b/interpreter/cli.py
@@ -27,7 +27,11 @@ def cli(interpreter):
                       action='store_true',
                       help='prints extra information')
   parser.add_argument('--use-azure', action='store_true', help='use Azure OpenAI Services')
+  
+  parser.add_argument('--model', type=str, help='HuggingFace repo id', default="", required=False)
+  
   args = parser.parse_args()
+
 
   # Modify interpreter according to command line flags
   if args.yes:
@@ -35,12 +39,38 @@ def cli(interpreter):
   if args.fast:
     interpreter.model = "gpt-3.5-turbo"
   if args.local:
+
+
+    
+    # Temporarily, for backwards (behavioral) compatability, we've moved this part of llama_2.py here.
+    # This way, when folks hit interpreter --local, they get the same experience as before.
+
+    print('', Markdown("**Open Interpreter** will use `Code Llama` for local execution. Use your arrow keys to set up the model."), '')
+        
+    models = {
+        '7B': 'TheBloke/CodeLlama-7B-Instruct-GGUF',
+        '13B': 'TheBloke/CodeLlama-13B-Instruct-GGUF',
+        '34B': 'TheBloke/CodeLlama-34B-Instruct-GGUF'
+    }
+    
+    parameter_choices = list(models.keys())
+    questions = [inquirer.List('param', message="Parameter count (smaller is faster, larger is more capable)", choices=parameter_choices)]
+    answers = inquirer.prompt(questions)
+    chosen_param = answers['param']
+
+    # THIS is more in line with the future. You just say the model you want by name:
+    self.model = models[chosen_param]
     interpreter.local = True
+
+  
   if args.debug:
     interpreter.debug_mode = True
   if args.use_azure:
     interpreter.use_azure = True
     interpreter.local = False
+  if args.model != "":
+    self.model = args.model
+    interpreter.local = True
 
   # Run the chat method
   interpreter.chat()

--- a/interpreter/cli.py
+++ b/interpreter/cli.py
@@ -62,7 +62,7 @@ def cli(interpreter):
     chosen_param = answers['param']
 
     # THIS is more in line with the future. You just say the model you want by name:
-    self.model = models[chosen_param]
+    interpreter.model = models[chosen_param]
     interpreter.local = True
 
   

--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -12,7 +12,7 @@ import inquirer
 from huggingface_hub import list_files_info, hf_hub_download
 
 
-def get_hf_llm(repo_id):
+def get_hf_llm(repo_id, debug_mode):
 
     if "TheBloke/CodeLlama-" not in repo_id:
       # ^ This means it was prob through the old --local, so we have already displayed this message.
@@ -174,7 +174,7 @@ def get_hf_llm(repo_id):
             return None
 
     # Initialize and return Code-Llama
-    llama_2 = Llama(model_path=model_path, n_gpu_layers=n_gpu_layers, verbose=False, n_ctx=1800) # n_ctx = context window. smaller is faster
+    llama_2 = Llama(model_path=model_path, n_gpu_layers=n_gpu_layers, verbose=debug_mode, n_ctx=1800) # n_ctx = context window. smaller is faster
       
     return llama_2
 

--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -75,12 +75,12 @@ def get_hf_llm(repo_id, debug_mode):
             if len(split_files) > 1:
                 # Download splits
                 for split_file in split_files:
-                    hf_hub_download(repo_id=repo_id, filename=split_file, local_dir=default_path)
+                    hf_hub_download(repo_id=repo_id, filename=split_file, local_dir=default_path, local_dir_use_symlinks=False)
                 
                 # Combine and delete splits
                 actually_combine_files(selected_model, split_files)
             else:
-                hf_hub_download(repo_id=repo_id, filename=selected_model, local_dir=default_path)
+                hf_hub_download(repo_id=repo_id, filename=selected_model, local_dir=default_path, local_dir_use_symlinks=False)
 
             model_path = download_path
         

--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -89,7 +89,7 @@ def get_hf_llm(repo_id):
             return None
 
     # This is helpful for folks looking to delete corrupted ones and such
-    print(f"Model found at {download_path}")
+    print(f"Model found at {model_path}")
   
     try:
         from llama_cpp import Llama

--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -75,12 +75,12 @@ def get_hf_llm(repo_id):
             if len(split_files) > 1:
                 # Download splits
                 for split_file in split_files:
-                    hf_hub_download(repo_id=repo_id, filename=split_file, local_dir=download_path)
+                    hf_hub_download(repo_id=repo_id, filename=split_file, local_dir=default_path)
                 
                 # Combine and delete splits
                 actually_combine_files(selected_model, split_files)
             else:
-                hf_hub_download(repo_id=repo_id, filename=selected_model, local_dir=download_path)
+                hf_hub_download(repo_id=repo_id, filename=selected_model, local_dir=default_path)
 
             model_path = download_path
         

--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -32,7 +32,7 @@ def get_hf_llm(repo_id):
     answers = inquirer.prompt(questions)
     for model in combined_models:
         if format_quality_choice(model) == answers["selected_model"]:
-            filename = model["filename"]
+            selected_model = model["filename"]
             break
 
     # Third stage: GPU confirm
@@ -58,18 +58,16 @@ def get_hf_llm(repo_id):
 
     # Check for the file in each directory
     for directory in directories_to_check:
-        path = os.path.join(directory, filename)
+        path = os.path.join(directory, selected_model)
         if os.path.exists(path):
             model_path = path
             break
     else:
         # If the file was not found, ask for confirmation to download it
-        download_path = os.path.join(default_path, filename)
+        download_path = os.path.join(default_path, selected_model)
       
-        print("This language model was not found on your system.")
-        message = f"Would you like to download it to {default_path}?"
-        
-        if confirm_action(message):
+        print("This language model was not found on your system.\n\nDownload to {default_path}?\n\n", "")
+        if confirm_action(""):
           
             # Check if model was originally split
             split_files = [model["filename"] for model in raw_models if selected_model in model["filename"]]

--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -66,7 +66,7 @@ def get_hf_llm(repo_id):
         # If the file was not found, ask for confirmation to download it
         download_path = os.path.join(default_path, selected_model)
       
-        print("This language model was not found on your system.\n\nDownload to {default_path}?\n\n", "")
+        print(f"This language model was not found on your system.\n\nDownload to {default_path}?", "")
         if confirm_action(""):
           
             # Check if model was originally split
@@ -81,6 +81,8 @@ def get_hf_llm(repo_id):
                 actually_combine_files(selected_model, split_files)
             else:
                 hf_hub_download(repo_id=repo_id, filename=selected_model)
+
+            model_path = download_path
         
         else:
             print('\n', "Download cancelled. Exiting.", '\n')

--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -75,12 +75,12 @@ def get_hf_llm(repo_id):
             if len(split_files) > 1:
                 # Download splits
                 for split_file in split_files:
-                    hf_hub_download(repo_id=repo_id, filename=split_file)
+                    hf_hub_download(repo_id=repo_id, filename=split_file, local_dir=download_path)
                 
                 # Combine and delete splits
                 actually_combine_files(selected_model, split_files)
             else:
-                hf_hub_download(repo_id=repo_id, filename=selected_model)
+                hf_hub_download(repo_id=repo_id, filename=selected_model, local_dir=download_path)
 
             model_path = download_path
         

--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -16,6 +16,7 @@ def get_hf_llm(repo_id, debug_mode):
 
     if "TheBloke/CodeLlama-" not in repo_id:
       # ^ This means it was prob through the old --local, so we have already displayed this message.
+      # Hacky. Not happy with this
       print('', Markdown(f"**Open Interpreter** will use `{repo_id}` for local execution. Use your arrow keys to set up the model."), '')
 
     raw_models = list_gguf_files(repo_id)

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -423,7 +423,7 @@ class Interpreter:
           
           formatted_messages = ""
           for message in messages:
-            formatted_messages += f"{message['role'].capitalize()}: {message['content']}"\n)
+            formatted_messages += f"{message['role'].capitalize()}: {message['content']}\n")
           formatted_messages = formatted_messages.strip()
 
         else:

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -423,7 +423,7 @@ class Interpreter:
           
           formatted_messages = ""
           for message in messages:
-            formatted_messages += f"{message['role'].capitalize()}: {message['content']}\n")
+            formatted_messages += f"{message['role'].capitalize()}: {message['content']}\n"
           formatted_messages = formatted_messages.strip()
 
         else:

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -3,7 +3,7 @@ from .utils import merge_deltas, parse_partial_json
 from .message_block import MessageBlock
 from .code_block import CodeBlock
 from .code_interpreter import CodeInterpreter
-from .llama_2 import get_llama_2_instance
+from .get_hf_llm import get_hf_llm
 
 import os
 import time
@@ -167,14 +167,13 @@ class Interpreter:
 
     # ^ verify_api_key may set self.local to True, so we run this as an 'if', not 'elif':
     if self.local:
-      self.model = "code-llama"
       
       # Code-Llama
       if self.llama_instance == None:
         
         # Find or install Code-Llama
         try:
-          self.llama_instance = get_llama_2_instance()
+          self.llama_instance = get_hf_llm(self.model)
         except:
           # If it didn't work, apologize and switch to GPT-4
           

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -174,7 +174,7 @@ class Interpreter:
         
         # Find or install Code-Llama
         try:
-          self.llama_instance = get_hf_llm(self.model)
+          self.llama_instance = get_hf_llm(self.model, self.debug_mode)
         except:
           traceback.print_exc()
           # If it didn't work, apologize and switch to GPT-4

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -7,6 +7,7 @@ from .get_hf_llm import get_hf_llm
 
 import os
 import time
+import traceback
 import json
 import platform
 import openai
@@ -175,6 +176,7 @@ class Interpreter:
         try:
           self.llama_instance = get_hf_llm(self.model)
         except:
+          traceback.print_exc()
           # If it didn't work, apologize and switch to GPT-4
           
           print(Markdown("".join([

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -410,30 +410,44 @@ class Interpreter:
       # (This only works if the first message is the only system message)
 
       def messages_to_prompt(messages):
-        # Extracting the system prompt and initializing the formatted string with it.
-        system_prompt = messages[0]['content']
-        formatted_messages = f"<s>[INST] <<SYS>>\n{system_prompt}\n<</SYS>>\n"
 
+        
         for message in messages:
           # Happens if it immediatly writes code
           if "role" not in message:
             message["role"] = "assistant"
-        
-        # Loop starting from the first user message
-        for index, item in enumerate(messages[1:]):
-            role = item['role']
-            content = item['content']
-            
-            if role == 'user':
-                formatted_messages += f"{content} [/INST] "
-            elif role == 'function':
-                formatted_messages += f"Output: {content} [/INST] "
-            elif role == 'assistant':
-                formatted_messages += f"{content} </s><s>[INST] "
-    
-        # Remove the trailing '<s>[INST] ' from the final output
-        if formatted_messages.endswith("<s>[INST] "):
-            formatted_messages = formatted_messages[:-10]
+
+
+        # Falcon prompt template
+        if "falcon" in self.model.lower():
+          
+          formatted_messages = ""
+          for message in messages:
+            formatted_messages += f"{message['role'].capitalize()}: {message['content']}"\n)
+          formatted_messages = formatted_messages.strip()
+
+        else:
+          # Llama prompt template
+          
+          # Extracting the system prompt and initializing the formatted string with it.
+          system_prompt = messages[0]['content']
+          formatted_messages = f"<s>[INST] <<SYS>>\n{system_prompt}\n<</SYS>>\n"
+          
+          # Loop starting from the first user message
+          for index, item in enumerate(messages[1:]):
+              role = item['role']
+              content = item['content']
+              
+              if role == 'user':
+                  formatted_messages += f"{content} [/INST] "
+              elif role == 'function':
+                  formatted_messages += f"Output: {content} [/INST] "
+              elif role == 'assistant':
+                  formatted_messages += f"{content} </s><s>[INST] "
+      
+          # Remove the trailing '<s>[INST] ' from the final output
+          if formatted_messages.endswith("<s>[INST] "):
+              formatted_messages = formatted_messages[:-10]
         
         return formatted_messages
 

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -355,7 +355,7 @@ class Interpreter:
     # This is hacky, as we should have a different (minified) prompt for CodeLLama,
     # but for now, to make the prompt shorter and remove "run_code" references, just get the first 2 lines:
     if self.local:
-      self.system_message = "\n".join(self.system_message.split("\n")[:3])
+      self.system_message = "\n".join(self.system_message.split("\n")[:2])
       self.system_message += "\nOnly do what the user asks you to do, then ask what they'd like to do next."
     
     system_message = self.system_message + "\n\n" + info

--- a/poetry.lock
+++ b/poetry.lock
@@ -321,6 +321,24 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "filelock"
+version = "3.12.3"
+description = "A platform independent file lock."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "filelock-3.12.3-py3-none-any.whl", hash = "sha256:f067e40ccc40f2b48395a80fcbd4728262fab54e232e090a4063ab804179efeb"},
+    {file = "filelock-3.12.3.tar.gz", hash = "sha256:0ecc1dd2ec4672a10c8550a8182f1bd0c0a5088470ecd5a125e45f49472fac3d"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.7.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+docs = ["furo (>=2023.7.26)", "sphinx (>=7.1.2)", "sphinx-autodoc-typehints (>=1.24)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3)", "diff-cover (>=7.7)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)", "pytest-timeout (>=2.1)"]
+
+[[package]]
 name = "frozenlist"
 version = "1.4.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -391,6 +409,41 @@ files = [
 ]
 
 [[package]]
+name = "fsspec"
+version = "2023.9.0"
+description = "File-system specification"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "fsspec-2023.9.0-py3-none-any.whl", hash = "sha256:d55b9ab2a4c1f2b759888ae9f93e40c2aa72c0808132e87e282b549f9e6c4254"},
+    {file = "fsspec-2023.9.0.tar.gz", hash = "sha256:4dbf0fefee035b7c6d3bbbe6bc99b2f201f40d4dca95b67c2b719be77bcd917f"},
+]
+
+[package.extras]
+abfs = ["adlfs"]
+adl = ["adlfs"]
+arrow = ["pyarrow (>=1)"]
+dask = ["dask", "distributed"]
+devel = ["pytest", "pytest-cov"]
+dropbox = ["dropbox", "dropboxdrivefs", "requests"]
+full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "dask", "distributed", "dropbox", "dropboxdrivefs", "fusepy", "gcsfs", "libarchive-c", "ocifs", "panel", "paramiko", "pyarrow (>=1)", "pygit2", "requests", "s3fs", "smbprotocol", "tqdm"]
+fuse = ["fusepy"]
+gcs = ["gcsfs"]
+git = ["pygit2"]
+github = ["requests"]
+gs = ["gcsfs"]
+gui = ["panel"]
+hdfs = ["pyarrow (>=1)"]
+http = ["aiohttp (!=4.0.0a0,!=4.0.0a1)", "requests"]
+libarchive = ["libarchive-c"]
+oci = ["ocifs"]
+s3 = ["s3fs"]
+sftp = ["paramiko"]
+smb = ["smbprotocol"]
+ssh = ["paramiko"]
+tqdm = ["tqdm"]
+
+[[package]]
 name = "git-python"
 version = "1.0.3"
 description = "combination and simplification of some useful git commands"
@@ -431,6 +484,38 @@ files = [
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
+
+[[package]]
+name = "huggingface-hub"
+version = "0.16.4"
+description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "huggingface_hub-0.16.4-py3-none-any.whl", hash = "sha256:0d3df29932f334fead024afc7cb4cc5149d955238b8b5e42dcf9740d6995a349"},
+    {file = "huggingface_hub-0.16.4.tar.gz", hash = "sha256:608c7d4f3d368b326d1747f91523dbd1f692871e8e2e7a4750314a2dd8b63e14"},
+]
+
+[package.dependencies]
+filelock = "*"
+fsspec = "*"
+packaging = ">=20.9"
+pyyaml = ">=5.1"
+requests = "*"
+tqdm = ">=4.42.1"
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+all = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "black (>=23.1,<24.0)", "gradio", "jedi", "mypy (==0.982)", "numpy", "pydantic", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-vcr", "pytest-xdist", "ruff (>=0.0.241)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "urllib3 (<2.0)"]
+cli = ["InquirerPy (==0.3.4)"]
+dev = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "black (>=23.1,<24.0)", "gradio", "jedi", "mypy (==0.982)", "numpy", "pydantic", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-vcr", "pytest-xdist", "ruff (>=0.0.241)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "urllib3 (<2.0)"]
+fastai = ["fastai (>=2.4)", "fastcore (>=1.3.27)", "toml"]
+inference = ["aiohttp", "pydantic"]
+quality = ["black (>=23.1,<24.0)", "mypy (==0.982)", "ruff (>=0.0.241)"]
+tensorflow = ["graphviz", "pydot", "tensorflow"]
+testing = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "gradio", "jedi", "numpy", "pydantic", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-vcr", "pytest-xdist", "soundfile", "urllib3 (<2.0)"]
+torch = ["torch"]
+typing = ["pydantic", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3"]
 
 [[package]]
 name = "idna"
@@ -707,6 +792,65 @@ files = [
     {file = "python-editor-1.0.4.tar.gz", hash = "sha256:51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b"},
     {file = "python_editor-1.0.4-py2-none-any.whl", hash = "sha256:5f98b069316ea1c2ed3f67e7f5df6c0d8f10b689964a4a811ff64f0106819ec8"},
     {file = "python_editor-1.0.4-py3-none-any.whl", hash = "sha256:1bf6e860a8ad52a14c3ee1252d5dc25b2030618ed80c022598f00176adc8367d"},
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.1"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
+    {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
+    {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
+    {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
+    {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
+    {file = "PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
+    {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
+    {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-win32.whl", hash = "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-win32.whl", hash = "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867"},
+    {file = "PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
+    {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
+    {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
+    {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
+    {file = "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
+    {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
+    {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
 ]
 
 [[package]]
@@ -988,6 +1132,17 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
+name = "typing-extensions"
+version = "4.7.1"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
+    {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.0.4"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1115,4 +1270,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a2192f76322052742e162ebfea533f87a76782ea5986f65ed892be7fc0d39311"
+content-hash = "369b105f57be91ddc79dcffe2c40cb4d133fb6401a6363a4937cc9e3d8a858df"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ six = "^1.16.0"
 # On windows, `pyreadline3` replaces that, so you can also just `import readline`.
 inquirer = "^3.1.3"
 wget = "^3.2"
+huggingface-hub = "^0.16.4"
 [tool.poetry.dependencies.pyreadline3]
 version = "^3.4.1"
 markers = "sys_platform == 'win32'"


### PR DESCRIPTION
Still would really like to refactor into something cleaner, but this does appear to do the trick.

Mimics what we had with CodeLlama— put in `interpreter --model TheBloke/CodeLlama-7B-GGUF`, flip through all the quantization options available for that model, downloads it. Cool!

Works with WizardCoder, Falcon, Llama, Samantha, etc.

Also solved a lot of 'silent download failures' by not using wget or curl, but `huggingface_hub` itself to get the models.