### PR TITLE
feat: add hints to Azure model

### DIFF
--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -201,11 +201,18 @@ class Interpreter:
     if self.debug_mode:
       welcome_message += "> Entered debug mode"
 
+      
+
     # If self.local, we actually don't use self.model
     # (self.auto_run is like advanced usage, we display no messages)
     if not self.local and not self.auto_run:
-      welcome_message += f"\n> Model set to `{self.model.upper()}`\n\n**Tip:** To run locally, use `interpreter --local`"
-    
+      if self.use_azure:
+        notice_model = f"Azure({self.azure_deployment_name})"
+      else:
+        notice_model = f"{self.model.upper()}"
+      welcome_message += f"\n> Model set to `{notice_model}`\n\n**Tip:** To run locally, use `interpreter --local`"
+      
+      
     if self.local:
       welcome_message += f"\n> Model set to `{self.model}`"
     


### PR DESCRIPTION
Hi, I don't think Azure is necessarily using the GPT-4 model or GPT-3.5-turbo, so I added a separate model hint for Azure. For making it more friendly

Model: `Azure(deployment-name)`

<img width="1078" alt="Screenshot 2023-09-10 at 18 21 17" src="https://github.com/KillianLucas/open-interpreter/assets/67408722/b2928ce5-5fc3-4b15-9c4c-ecbb5cb2c34b">
