### PR TITLE
fix(ui): fix the display problem of welcome message

### DIFF
--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -834,4 +834,4 @@ class Interpreter:
 
   def _print_welcome_message(self):
     current_version = pkg_resources.get_distribution("open-interpreter").version
-    print(f"\n Hello, Welcome to [bold white]⬤ Open Interpreter[/bold white]. (v{current_version})\n")
+    print(f"\n Hello, Welcome to [bold]● Open Interpreter[/bold]. (v{current_version})\n")


### PR DESCRIPTION
When I used macos to test after returning home today, I found that there was a problem with the reality of the welcome message.
The first is to remove the white font, otherwise it will not be displayed in the terminal with a white background.
The second is to modify the ASCII icon of the logo, because in zsh the space after the icon will disappear, but in the shell there is no such problem. So I chose to replace it with an ASCII icon (this one might be smaller)