### PR TITLE
[LiteLLM Fix] Fix using litellm.api_base, litellm.api_key, litellm.api_version 

### DIFF
--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -43,7 +43,7 @@ from rich import print
 from rich.markdown import Markdown
 from rich.rule import Rule
 
-# Function schema for gpt-4 
+# Function schema for gpt-4
 function_schema = {
   "name": "run_code",
   "description":

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -43,7 +43,7 @@ from rich import print
 from rich.markdown import Markdown
 from rich.rule import Rule
 
-# Function schema for gpt-4
+# Function schema for gpt-4 
 function_schema = {
   "name": "run_code",
   "description":

--- a/poetry.lock
+++ b/poetry.lock
@@ -590,13 +590,13 @@ ansicon = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "litellm"
-version = "0.1.583"
+version = "0.1.591"
 description = "Library to easily interface with LLM API providers"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "litellm-0.1.583-py3-none-any.whl", hash = "sha256:7ec36b8eac32a8338dac879114a17108585b31bc9cd1793c2ee345d5eeac8b61"},
-    {file = "litellm-0.1.583.tar.gz", hash = "sha256:91536f08dd5d210cee339afd26750a193fd9d0a6f6ef131a6fb2c8bfd1495e39"},
+    {file = "litellm-0.1.591-py3-none-any.whl", hash = "sha256:f75176043f96c3b2448ae2829c26dd2e20b0d40a404c1f5191beefd0df728ac4"},
+    {file = "litellm-0.1.591.tar.gz", hash = "sha256:008ffdbf5ba4ae7936f14fa592b03bf20c064d97be5113ef445839c25f192015"},
 ]
 
 [package.dependencies]
@@ -1055,19 +1055,19 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "setuptools"
-version = "68.2.0"
+version = "68.2.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-68.2.0-py3-none-any.whl", hash = "sha256:af3d5949030c3f493f550876b2fd1dd5ec66689c4ee5d5344f009746f71fd5a8"},
-    {file = "setuptools-68.2.0.tar.gz", hash = "sha256:00478ca80aeebeecb2f288d3206b0de568df5cd2b8fada1209843cc9a8d88a48"},
+    {file = "setuptools-68.2.1-py3-none-any.whl", hash = "sha256:eff96148eb336377ab11beee0c73ed84f1709a40c0b870298b0d058828761bae"},
+    {file = "setuptools-68.2.1.tar.gz", hash = "sha256:56ee14884fd8d0cd015411f4a13f40b4356775a0aefd9ebc1d3bfb9a1acb32f1"},
 ]
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
 testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -1335,4 +1335,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d2e10cbba339652111b7ff5ad74b1d55ad0116c12189046588f12ed5677bbe7e"
+content-hash = "191050f6787e57128effdacebb5d82a76a3e94ba9126aa436e7032aff4b1d254"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ python-dotenv = "^1.0.0"
 inquirer = "^3.1.3"
 wget = "^3.2"
 huggingface-hub = "^0.16.4"
-litellm = "^0.1.578"
+litellm = "^0.1.590"
 [tool.poetry.dependencies.pyreadline3]
 version = "^3.4.1"
 markers = "sys_platform == 'win32'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ python-dotenv = "^1.0.0"
 inquirer = "^3.1.3"
 wget = "^3.2"
 huggingface-hub = "^0.16.4"
-litellm = "^0.1.589"
+litellm = "^0.1.590"
 [tool.poetry.dependencies.pyreadline3]
 version = "^3.4.1"
 markers = "sys_platform == 'win32'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ python-dotenv = "^1.0.0"
 inquirer = "^3.1.3"
 wget = "^3.2"
 huggingface-hub = "^0.16.4"
-litellm = "^0.1.590"
+litellm = "^0.1.589"
 [tool.poetry.dependencies.pyreadline3]
 version = "^3.4.1"
 markers = "sys_platform == 'win32'"


### PR DESCRIPTION
Users reported not being able to correctly use

```python
 litellm.api_type = self.azure_api_type 
 litellm.api_base = self.azure_api_base 
 litellm.api_version = self.azure_api_version 
 litellm.api_key = self.api_key 
```

This PR bumps the version of litellm to ensure this setting works 

Litellm 0.1.590 has the fix 

Fixes #263
Fixes #258