### PR TITLE
add type hintings to improve code readability

### DIFF
--- a/interpreter/cli.py
+++ b/interpreter/cli.py
@@ -31,7 +31,7 @@ import inquirer
 # Load .env file
 load_dotenv()
 
-def check_for_update():
+def check_for_update() -> bool:
     # Fetch the latest version from the PyPI API
     response = requests.get(f'https://pypi.org/pypi/open-interpreter/json')
     latest_version = response.json()['info']['version']

--- a/interpreter/code_block.py
+++ b/interpreter/code_block.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from rich.live import Live
 from rich.panel import Panel
 from rich.box import MINIMAL
@@ -22,7 +24,7 @@ class CodeBlock:
     self.live = Live(auto_refresh=False, console=Console(), vertical_overflow="visible")
     self.live.start()
 
-  def update_from_message(self, message):
+  def update_from_message(self, message: Dict):
     if "function_call" in message and "parsed_arguments" in message[
         "function_call"]:
 
@@ -40,7 +42,7 @@ class CodeBlock:
     # Destroys live display
     self.live.stop()
 
-  def refresh(self, cursor=True):
+  def refresh(self, cursor: bool =True):
     # Get code, return if there is none
     code = self.code
     if not code:

--- a/interpreter/code_interpreter.py
+++ b/interpreter/code_interpreter.py
@@ -92,7 +92,7 @@ class CodeInterpreter:
   They can control code blocks on the terminal, then be executed to produce an output which will be displayed in real-time.
   """
 
-  def __init__(self, language, debug_mode):
+  def __init__(self, language: str, debug_mode: bool):
     self.language = language
     self.proc = None
     self.active_line = None
@@ -131,7 +131,7 @@ class CodeInterpreter:
       self.active_block.output = self.output
       self.active_block.refresh()
 
-  def run(self):
+  def run(self) -> str:
     """
     Executes code.
     """
@@ -257,7 +257,7 @@ class CodeInterpreter:
     # Return code output
     return self.output
 
-  def add_active_line_prints(self, code):
+  def add_active_line_prints(self, code: str) -> str:
     """
     This function takes a code snippet and adds print statements before each line,
     indicating the active line number during execution. The print statements respect
@@ -313,7 +313,7 @@ class CodeInterpreter:
     code = "\n".join(modified_code_lines)
     return code
 
-  def save_and_display_stream(self, stream, is_error_stream):
+  def save_and_display_stream(self, stream, is_error_stream: bool):
     # Handle each line of output
     for line in iter(stream.readline, ''):
 
@@ -361,7 +361,7 @@ class CodeInterpreter:
 
       self.update_active_block()
 
-def truncate_output(data):
+def truncate_output(data: str):
   needs_truncation = False
 
   # In the future, this will come from a config file
@@ -389,7 +389,7 @@ class AddLinePrints(ast.NodeTransformer):
     before every executable line in the AST.
     """
 
-    def insert_print_statement(self, line_number):
+    def insert_print_statement(self, line_number: int):
         """Inserts a print statement for a given line number."""
         return ast.Expr(
             value=ast.Call(
@@ -435,7 +435,7 @@ class AddLinePrints(ast.NodeTransformer):
 
         return new_node
 
-def add_active_line_prints_to_python(code):
+def add_active_line_prints_to_python(code: str) -> str:
     """
     Add print statements indicating line numbers to a python string.
     """
@@ -444,7 +444,7 @@ def add_active_line_prints_to_python(code):
     new_tree = transformer.visit(tree)
     return ast.unparse(new_tree)
 
-def wrap_in_try_except(code):
+def wrap_in_try_except(code: str) -> str:
     # Add import traceback
     code = "import traceback\n" + code
 

--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -31,7 +31,7 @@ import inquirer
 from huggingface_hub import list_files_info, hf_hub_download
 
 
-def get_hf_llm(repo_id, debug_mode, context_window):
+def get_hf_llm(repo_id: str, debug_mode: bool, context_window: int):
 
     if "TheBloke/CodeLlama-" not in repo_id:
       # ^ This means it was prob through the old --local, so we have already displayed this message.
@@ -330,7 +330,7 @@ def actually_combine_files(default_path: str, base_name: str, files: List[str]) 
                 outfile.write(infile.read())
             os.remove(file_path)
 
-def format_quality_choice(model, name_override = None) -> str:
+def format_quality_choice(model: Dict, name_override: Optional[str] = None) -> str:
     """
     Formats the model choice for display in the inquirer prompt.
     """

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -17,6 +17,7 @@ Especially if you have ideas and **EXCITEMENT** about the future of this project
 
 - killian
 """
+from typing import Dict, List, Optional
 
 from .cli import cli
 from .utils import merge_deltas, parse_partial_json
@@ -131,7 +132,7 @@ class Interpreter:
     # modifies it according to command line flags, then runs chat.
     cli(self)
 
-  def get_info_for_system_message(self):
+  def get_info_for_system_message(self) -> str:
     """
     Gets relevent information for the system message.
     """
@@ -183,10 +184,10 @@ class Interpreter:
     self.messages = []
     self.code_interpreters = {}
 
-  def load(self, messages):
+  def load(self, messages: List[Dict]):
     self.messages = messages
 
-  def chat(self, message=None, return_messages=False):
+  def chat(self, message: Optional[List[Dict]] = None, return_messages: bool = False) -> Optional[List[Dict]]:
 
     # Connect to an LLM (an large language model)
     if not self.local:

--- a/interpreter/message_block.py
+++ b/interpreter/message_block.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from rich.console import Console
 from rich.live import Live
 from rich.panel import Panel
@@ -13,7 +15,7 @@ class MessageBlock:
     self.live.start()
     self.content = ""
 
-  def update_from_message(self, message):
+  def update_from_message(self, message: Dict):
     self.content = message.get("content", "")
     if self.content:
       self.refresh()
@@ -22,7 +24,7 @@ class MessageBlock:
     self.refresh(cursor=False)
     self.live.stop()
 
-  def refresh(self, cursor=True):
+  def refresh(self, cursor: bool = True):
     # De-stylize any code blocks in markdown,
     # to differentiate from our Code Blocks
     content = textify_markdown_code_blocks(self.content)
@@ -36,7 +38,7 @@ class MessageBlock:
     self.live.refresh()
 
 
-def textify_markdown_code_blocks(text):
+def textify_markdown_code_blocks(text: str) -> str:
   """
   To distinguish CodeBlocks from markdown code, we simply turn all markdown code
   (like '```python...') into text code blocks ('```text') which makes the code black and white.

--- a/interpreter/utils.py
+++ b/interpreter/utils.py
@@ -1,7 +1,9 @@
 import json
 import re
+from typing import Dict, List, Union, Optional
 
-def merge_deltas(original, delta):
+
+def merge_deltas(original: Dict, delta: Dict) -> Dict:
     """
     Pushes the delta into the original and returns that.
 
@@ -20,7 +22,7 @@ def merge_deltas(original, delta):
                 original[key] = value
     return original
 
-def parse_partial_json(s):
+def parse_partial_json(s: str) -> Optional[Union[Dict, List]]:
 
     # Attempt to parse the string as-is.
     try:


### PR DESCRIPTION
# What
- This is to add type hintings to arguments and return vars for functions in the interpreter to improve code readability.