### PR TITLE
fix: merge os.environ with llama install env_vars

### DIFF
--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -188,7 +188,7 @@ def get_hf_llm(repo_id, debug_mode, context_window):
                     env_vars["CMAKE_ARGS"] = "-DLLAMA_BLAS=ON -DLLAMA_BLAS_VENDOR=OpenBLAS"
                 
                 try:
-                    subprocess.run([sys.executable, "-m", "pip", "install", "llama-cpp-python"], env=env_vars, check=True)
+                    subprocess.run([sys.executable, "-m", "pip", "install", "llama-cpp-python"], env={**os.environ, **env_vars}, check=True)
                 except subprocess.CalledProcessError as e:
                     print(f"Error during installation with {backend}: {e}")
             


### PR DESCRIPTION
Fixes the issue with OI not being able to automatically install llama-cpp-python by merging the current environment variables with the ones needed for installing.

Steps for testing:

```
git clone https://github.com/KillianLucas/open-interpreter.git pr-338
cd pr-338
git checkout env_vars
python -m venv venv
./venv/Scripts/activate; source ./venv/bin/activate
pip install poetry
poetry install
poetry run interpreter --local
```

Choose any model, choose whether to use GPU, ensure llama-cpp-python installs without error.

To test again, uninstall llama-cpp-python first:

```
pip uninstall -y llama-cpp-python
poetry run interpreter --local
```