### PR TITLE
feat: install CUDA support on Windows if available

### DIFF
--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -188,7 +188,7 @@ def get_hf_llm(repo_id, debug_mode, context_window):
                     env_vars["CMAKE_ARGS"] = "-DLLAMA_BLAS=ON -DLLAMA_BLAS_VENDOR=OpenBLAS"
                 
                 try:
-                    subprocess.run([sys.executable, "-m", "pip", "install", "llama-cpp-python"], env=env_vars, check=True)
+                    subprocess.run([sys.executable, "-m", "pip", "install", "llama-cpp-python"], env={**os.environ, **env_vars}, check=True)
                 except subprocess.CalledProcessError as e:
                     print(f"Error during installation with {backend}: {e}")
             

--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -161,7 +161,7 @@ def get_hf_llm(repo_id, debug_mode, context_window):
         if os.path.exists(nvidia_root):
             cudart_path = os.path.join(nvidia_root, 'cuda_runtime', 'bin')
             cublas_path = os.path.join(nvidia_root, 'cublas', 'bin')
-            os.environ["PATH"] = cudart_path + os.pathsep + cublas_path + os.pathsep + os.environ["PATH"]
+            os.environ["PATH"] = os.pathsep([cudart_path, cublas_path, os.environ["PATH"]])
 
         from llama_cpp import Llama
     except:

--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -155,7 +155,7 @@ def get_hf_llm(repo_id, debug_mode, context_window):
         # Add CUDA binaries to temporary PATH in case CUDA is supported on this machine.
         # Has no effect otherwise.
         import sysconfig
-        nvidia_root = os.path.join(sysconfig.get_paths()["purelib"], 'nvidia')
+        nvidia_root = os.path.join(sysconfig.get_paths("purelib"), 'nvidia')
         cudart_path = os.path.join(nvidia_root, 'cuda_runtime', 'bin')
         cublas_path = os.path.join(nvidia_root, 'cublas', 'bin')
         os.environ["PATH"] = cudart_path + os.pathsep + cublas_path + os.pathsep + os.environ["PATH"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -772,6 +772,17 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+description = "Get CPU info with pure Python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690"},
+    {file = "py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5"},
+]
+
+[[package]]
 name = "pygments"
 version = "2.16.1"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -1335,4 +1346,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "191050f6787e57128effdacebb5d82a76a3e94ba9126aa436e7032aff4b1d254"
+content-hash = "72adf53db4d1efcf9b503ee5ec717bb79096d8b81de0c41ac68cbdeebb6a8a34"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ inquirer = "^3.1.3"
 wget = "^3.2"
 huggingface-hub = "^0.16.4"
 litellm = "^0.1.590"
+py-cpuinfo = "^9.0.0"
 [tool.poetry.dependencies.pyreadline3]
 version = "^3.4.1"
 markers = "sys_platform == 'win32'"


### PR DESCRIPTION
This PR installs official NVIDIA wheels for CUDA support so the CUDA Toolkit does not need to be installed.

It also installs precompiled llama-cpp-python wheels that support CUDA so VS / dev tools don't need to be present on the computer.

The install is also much faster since nothing needs to be compiled.

Based on #338 which should be merged first.

Steps for testing:

```
git clone https://github.com/jordanbtucker/open-interpreter.git pr-339
cd pr-339
git checkout cuda
python -m venv venv
./venv/Scripts/activate; source ./venv/bin/activate
pip install poetry
poetry install
poetry run interpreter --local
```

Choose any model, choose yes for GPU, ensure llama-cpp-python installs without error, ensure GPU is utilized after the first request.

To test again, uninstall llama-cpp-python first:

```
pip uninstall -y llama-cpp-python
poetry run interpreter --local
```