### PR TITLE
chore: add vscode debug support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python",
+            "type": "python",
+            "request": "launch",
+            "module": "poetry",
+            "justMyCode": true,
+            "args": [
+                "run",
+                "interpreter"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Describe the changes you have made:

Adds support for debugging in vscode.

To debug, ensure poetry is installed globally, preferably with pipx, and set the `virtualenvs.in-project` config value to `true`.

```
python -m pip install --user pipx
python -m pipx ensurepath
```

Restart your terminal if instructed, then run:

```
pipx install poetry
poetry config virtualenvs.in-project true
```

Then, inside the project directory, run:
```
poetry shell
poetry install
```

This will create a `.venv` directory inside the project and automatically activate it. In vscode, you can just press <kbd>F5</kbd> to start debugging.

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [x] Windows
- [ ] MacOS
- [ ] Linux
