### PR TITLE
Remembering Local Models for Faster Access

### DIFF
--- a/interpreter/cli.py
+++ b/interpreter/cli.py
@@ -135,29 +135,35 @@ def cli(interpreter):
     interpreter.auto_run = True
   if args.fast:
     interpreter.model = "gpt-3.5-turbo"
+    
   if args.local and not args.falcon:
-
-
-
     # Temporarily, for backwards (behavioral) compatability, we've moved this part of llama_2.py here.
     # This way, when folks hit interpreter --local, they get the same experience as before.
     
-    rprint('', Markdown("**Open Interpreter** will use `Code Llama` for local execution. Use your arrow keys to set up the model."), '')
-        
-    models = {
-        '7B': 'TheBloke/CodeLlama-7B-Instruct-GGUF',
-        '13B': 'TheBloke/CodeLlama-13B-Instruct-GGUF',
-        '34B': 'TheBloke/CodeLlama-34B-Instruct-GGUF'
-    }
-    
-    parameter_choices = list(models.keys())
-    questions = [inquirer.List('param', message="Parameter count (smaller is faster, larger is more capable)", choices=parameter_choices)]
-    answers = inquirer.prompt(questions)
-    chosen_param = answers['param']
+    # Load the model configuration
+    model_name, model_path = interpreter.load_model_config()
+    if model_name is not None and model_path is not None:
+      interpreter.model = model_name
+      interpreter.model_path = model_path
+      interpreter.local = True # Set local mode to true.
+      
+    else:
+      rprint('', Markdown("**Open Interpreter** will use `Code Llama` for local execution. Use your arrow keys to set up the model."), '')
+          
+      models = {
+          '7B': 'TheBloke/CodeLlama-7B-Instruct-GGUF',
+          '13B': 'TheBloke/CodeLlama-13B-Instruct-GGUF',
+          '34B': 'TheBloke/CodeLlama-34B-Instruct-GGUF'
+      }
+      
+      parameter_choices = list(models.keys())
+      questions = [inquirer.List('param', message="Parameter count (smaller is faster, larger is more capable)", choices=parameter_choices)]
+      answers = inquirer.prompt(questions)
+      chosen_param = answers['param']
 
-    # THIS is more in line with the future. You just say the model you want by name:
-    interpreter.model = models[chosen_param]
-    interpreter.local = True
+      # THIS is more in line with the future. You just say the model you want by name:
+      interpreter.model = models[chosen_param]
+      interpreter.local = True
 
   
   if args.debug:

--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -31,8 +31,28 @@ import shutil
 from huggingface_hub import list_files_info, hf_hub_download
 
 
-def get_hf_llm(repo_id, debug_mode, context_window):
+def get_hf_llm(repo_id, debug_mode, context_window,model_path=None):
 
+    # Check if model path has already been loaded.
+    if model_path:
+        # Third stage: GPU confirm
+        if confirm_action("Use GPU? (Large models might crash on GPU, but will run more quickly)"):
+            n_gpu_layers = -1
+        else:
+            n_gpu_layers = 0
+            
+        # Import the Llama Cpp
+        try:
+            from llama_cpp import Llama
+        except:
+            if debug_mode:
+                traceback.print_exc()
+        
+        # Set the Llama model from saved path.
+        assert os.path.isfile(model_path)
+        llama_2 = Llama(model_path=model_path, n_gpu_layers=n_gpu_layers, verbose=debug_mode, n_ctx=context_window)
+        return llama_2,model_path
+    
     if "TheBloke/CodeLlama-" not in repo_id:
       # ^ This means it was prob through the old --local, so we have already displayed this message.
       # Hacky. Not happy with this
@@ -246,7 +266,7 @@ def get_hf_llm(repo_id, debug_mode, context_window):
     assert os.path.isfile(model_path)
     llama_2 = Llama(model_path=model_path, n_gpu_layers=n_gpu_layers, verbose=debug_mode, n_ctx=context_window)
       
-    return llama_2
+    return llama_2,model_path
 
 def confirm_action(message):
     question = [

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -97,6 +97,7 @@ class Interpreter:
     self.auto_run = False
     self.local = False
     self.model = "gpt-4"
+    self.model_path = ""
     self.debug_mode = False
     self.api_base = None # Will set it to whatever OpenAI wants
     self.context_window = 2000 # For local models only
@@ -129,6 +130,43 @@ class Interpreter:
     # The cli takes the current instance of Interpreter,
     # modifies it according to command line flags, then runs chat.
     cli(self)
+
+
+  def save_model_config(self, model_name, model_path, config_file='model_config.json'):
+      # Check if model_name and model_path are not empty
+      if not model_name or not model_path:
+          raise ValueError("Model name and model path cannot be empty.")
+      try:
+          configs = []
+
+          # Add new configuration
+          config = {
+              'model_name': model_name,
+              'model_path': model_path
+          }
+          configs.append(config)
+
+          # Save configurations
+          with open(config_file, 'w') as file:
+              json.dump({'config': configs}, file)
+      except:
+          traceback.print_exc()
+
+  def load_model_config(self, config_file='model_config.json'):
+      try:
+          if os.path.exists(config_file) and os.path.getsize(config_file) > 0:
+              with open(config_file, 'r') as file:
+                  configs = json.load(file)['config']
+                  if configs:
+                      for config in configs:
+                          if 'model_name' in config and 'model_path' in config:
+                              # Check if model_name and model_path are not empty strings
+                              if config['model_name'].strip() and config['model_path'].strip():
+                                  return config['model_name'], config['model_path']
+          return None, None
+      except:
+          return None, None
+      
 
   def get_info_for_system_message(self):
     """
@@ -306,7 +344,6 @@ class Interpreter:
     action(arguments)  # Execute the function
 
   def chat(self, message=None, return_messages=False):
-
     # Connect to an LLM (an large language model)
     if not self.local:
       # gpt-4
@@ -315,15 +352,28 @@ class Interpreter:
     # ^ verify_api_key may set self.local to True, so we run this as an 'if', not 'elif':
     if self.local:
 
+      # Load the model configuration
+      model_name, model_path = self.load_model_config()
+
+      # If a model configuration was loaded, use it to set the llama_instance
+      if model_name is not None and model_path is not None:
+          self.model = model_name
+          self.model_path = model_path
+          print(f"Loading local model from saved state \nModel: '{self.model}',\nPath: '{self.model_path}'")
+          self.llama_instance,self.model_path = get_hf_llm(self.model, self.debug_mode, self.context_window,self.model_path)
+
       # Code-Llama
       if self.llama_instance == None:
-
+        
         # Find or install Code-Llama
         try:
-          self.llama_instance = get_hf_llm(self.model, self.debug_mode, self.context_window)
+          self.llama_instance,self.model_path = get_hf_llm(self.model, self.debug_mode, self.context_window)
           if self.llama_instance == None:
             # They cancelled.
             return
+          else:
+            # Save the model configuration
+            self.save_model_config(self.model, self.model_path)
         except:
           traceback.print_exc()
           # If it didn't work, apologize and switch to GPT-4


### PR DESCRIPTION
### Describe the changes you have made:
This pull request addresses a bug where the system repeatedly prompts the user to select a local model, even after it has been downloaded once. The issue arises due to the lack of persistent storage for the model information. To enhance user experience and streamline local model usage, this PR introduces a solution that involves saving the Model Name and Model Path to a JSON file. By doing so, we ensure that the system remembers the locally downloaded model, eliminating the need for redundant user input and making local model usage faster and more user-friendly.

This is the new config file that is saved into local machine for local model information.
```json
{
    "config": [
        {
            "model_name": "TheBloke/CodeLlama-7B-Instruct-GGUF",
            "model_path": "/Users/haseeb-mir/codellama-7b-instruct.Q4_K_M.gguf"
        }
    ]
}
```

### Reference any relevant issue 
This is the issue mentioned here.
[Issue#358](https://github.com/KillianLucas/open-interpreter/issues/358)</br>

- [x] I have performed a self-review of my code:
I have reviewed my code with proper error and exception handling and for test cases for every situation to handle them and it passes them.

### I have tested the code on the following OS:
- [x] MacOS
