### PR TITLE
Handle %load_message failure in interpreter.py

### DIFF
--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -287,10 +287,13 @@ class Interpreter:
       json_path = "messages.json"
     if not json_path.endswith(".json"):
       json_path += ".json"
-    with open(json_path, 'r') as f:
-      self.load(json.load(f))
+    if os.path.exists(json_path):
+      with open(json_path, 'r') as f:
+        self.load(json.load(f))
+      print(Markdown(f"> messages json loaded from {os.path.abspath(json_path)}"))
+    else:
+      print(Markdown("No file found, please check the path and try again."))
 
-    print(Markdown(f"> messages json loaded from {os.path.abspath(json_path)}"))
 
   def handle_command(self, user_input):
     # split the command into the command and the arguments, by the first whitespace


### PR DESCRIPTION
### Issue

When the path for the %load_message doesn't exist, it currently errors out and causes Open Interpreter to come to a hard stop. 

### Proposed Solution

I've prevented the error by simply adding a condition to catch the exception and printing a message explaining the failure.

### Reference any relevant issue (Fixes #000)

- [✅ ] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [✅ ] MacOS
- [ ] Linux

### AI Language Model
- N/A
