### PR TITLE
MOD: close subprocess and its file handles when reset

### DIFF
--- a/interpreter/code_interpreters/subprocess_code_interpreter.py
+++ b/interpreter/code_interpreters/subprocess_code_interpreter.py
@@ -35,6 +35,8 @@ class SubprocessCodeInterpreter(BaseCodeInterpreter):
 
     def terminate(self):
         self.process.terminate()
+        self.proc.stdin.close()
+        self.proc.stdout.close()
 
     def start_process(self):
         if self.process:


### PR DESCRIPTION
### Describe the changes you have made:

Problem I encountered: When I use the same Interpreter instance to complete multiple code-writing tasks in a row within a process, I try to use Interpreter.reset() to reset the context and Interpreter state between each task. However, after several runs, I ran into the problem of too many open file handles.

Solution I provide: So in this pr, Interpreter.reset closes the child process and closes its open file handles.

### Reference any relevant issue (Fixes #000)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [x] Windows
- [x] MacOS
- [x] Linux

### AI Language Model (if applicable)
- [x] GPT4
- [x] GPT3
- [x] Llama 7B
- [x] Llama 13B
- [x] Llama 34B
- [x] Huggingface model (Please specify which one)
