### PR TITLE
feat:define local models in config.yml

### DIFF
--- a/interpreter/config.yaml
+++ b/interpreter/config.yaml
@@ -15,3 +15,11 @@ system_message: |
 local: false
 model: "gpt-4"
 temperature: 0
+local_models:
+  llama:
+    7B-CodeLlama: "TheBloke/CodeLlama-7B-Instruct-GGUF"
+    13B-CodeLlama: "TheBloke/CodeLlama-13B-Instruct-GGUF"
+    34B-CodeLlama: "TheBloke/CodeLlama-34B-Instruct-GGUF"
+    7B-Xwin-LM: "TheBloke/Xwin-LM-7B-V0.1-GGUF"
+    13B-Xwin-LM: "TheBloke/Xwin-LM-13B-V0.1-GGUF"
+    70B-Xwin-LM: "TheBloke/Xwin-LM-70B-V0.1-GGUF"

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -39,6 +39,7 @@ class Interpreter:
         # LLM settings
         self.model = ""
         self.temperature = 0
+        self.local_models = {}
         self.system_message = ""
         self.context_window = None
         self.max_tokens = None

--- a/interpreter/terminal_interface/validate_llm_settings.py
+++ b/interpreter/terminal_interface/validate_llm_settings.py
@@ -24,18 +24,14 @@ def validate_llm_settings(interpreter):
                 **Open Interpreter** will use `Code Llama` for local execution. Use your arrow keys to set up the model.
                 """)
 
-                models = {
-                    '7B': 'TheBloke/CodeLlama-7B-Instruct-GGUF',
-                    '13B': 'TheBloke/CodeLlama-13B-Instruct-GGUF',
-                    '34B': 'TheBloke/CodeLlama-34B-Instruct-GGUF'
-                }
-
-                parameter_choices = list(models.keys())
+                print("interpreter.local_models", interpreter.local_models)
+                print("type(interpreter.local_models)", type(interpreter.local_models))
+                parameter_choices = list(interpreter.local_models['llama'].keys())
                 questions = [inquirer.List('param', message="Parameter count (smaller is faster, larger is more capable)", choices=parameter_choices)]
                 answers = inquirer.prompt(questions)
                 chosen_param = answers['param']
 
-                interpreter.model = "huggingface/" + models[chosen_param]
+                interpreter.model = "huggingface/" + interpreter.local_models['llama'][chosen_param]
                 break
 
             else:

--- a/interpreter/terminal_interface/validate_llm_settings.py
+++ b/interpreter/terminal_interface/validate_llm_settings.py
@@ -24,8 +24,6 @@ def validate_llm_settings(interpreter):
                 **Open Interpreter** will use `Code Llama` for local execution. Use your arrow keys to set up the model.
                 """)
 
-                print("interpreter.local_models", interpreter.local_models)
-                print("type(interpreter.local_models)", type(interpreter.local_models))
                 parameter_choices = list(interpreter.local_models['llama'].keys())
                 questions = [inquirer.List('param', message="Parameter count (smaller is faster, larger is more capable)", choices=parameter_choices)]
                 answers = inquirer.prompt(questions)


### PR DESCRIPTION
### Describe the changes you have made:
Move model definitions to hardcoding -> config.yml. Models supported by `hf_hub_download` and `llama-cpp-python` can be used in `terminal_interface` by defining them in `local_models > llama`.
Define the following in config.yml
```yml
local_models:
  llama:
    7B-CodeLlama: "TheBloke/CodeLlama-7B-Instruct-GGUF"
    13B-CodeLlama: "TheBloke/CodeLlama-13B-Instruct-GGUF"
    34B-CodeLlama: "TheBloke/CodeLlama-34B-Instruct-GGUF"
    7B-Xwin-LM: "TheBloke/Xwin-LM-7B-V0.1-GGUF"
    13B-Xwin-LM: "TheBloke/Xwin-LM-13B-V0.1-GGUF"
    70B-Xwin-LM: "TheBloke/Xwin-LM-70B-V0.1-GGUF"
```
### Reference any relevant issue (Fixes #000)
None

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [x] Huggingface model (Please specify which one)
1. TheBloke/Xwin-LM-7B-V0.1-GGUF
2. TheBloke/Xwin-LM-70B-V0.1-GGUF