### PR TITLE
fix crash on unknwon command on call to display help message

### DIFF
--- a/interpreter/terminal_interface/magic_commands.py
+++ b/interpreter/terminal_interface/magic_commands.py
@@ -78,7 +78,7 @@ def handle_reset(self, arguments):
 
 def default_handle(self, arguments):
     display_markdown_message("> Unknown command")
-    self.handle_help(arguments)
+    handle_help(self,arguments)    
 
 def handle_save_message(self, json_path):
     if json_path == "":

--- a/interpreter/terminal_interface/magic_commands.py
+++ b/interpreter/terminal_interface/magic_commands.py
@@ -78,7 +78,7 @@ def handle_reset(self, arguments):
 
 def default_handle(self, arguments):
     display_markdown_message("> Unknown command")
-    handle_help(self,arguments)    
+    handle_help(self,arguments)
 
 def handle_save_message(self, json_path):
     if json_path == "":


### PR DESCRIPTION
### Describe the changes you have made:
change the default_handle to display help message properly. 
the previous code would crash when entering % or any %unknown_⌘

### Reference any relevant issue (Fixes #000)

- [ x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [ x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
