### PR TITLE
Fix ARM64 llama-cpp-python Install on Apple Silicon

### DIFF
--- a/docs/MACOS.md
+++ b/docs/MACOS.md
@@ -4,42 +4,80 @@ When running Open Interpreter on macOS with Code-Llama (either because you did
 not enter an OpenAI API key or you ran `interpreter --local`) you may want to
 make sure it works correctly by following the instructions below.
 
-Tested on **MacOS Ventura 13.5** with **M2 Pro Chip**.
+Tested on **MacOS Ventura 13.5** with **M2 Pro Chip** and **MacOS Ventura 13.5.1** with **M1 Max**.
 
 I use conda as a virtual environment but you can choose whatever you want. If you go with conda you will find the Apple M1 version of miniconda here: [Link](https://docs.conda.io/projects/miniconda/en/latest/)
 
-```
+```bash
 conda create -n openinterpreter python=3.11.4
 ```
 
 **Activate your environment:**
 
-```
+```bash
 conda activate openinterpreter
 ```
 
 **Install open-interpreter:**
 
-```
+```bash
 pip install open-interpreter
 ```
 
 **Uninstall any previously installed llama-cpp-python packages:**
 
-```
+```bash
 pip uninstall llama-cpp-python -y
 ```
 
-**Install llama-cpp-python with Apple Silicon support:**
+## Install llama-cpp-python with Apple Silicon support
 
-Part 1
+### Prerequisites: Xcode Command Line Tools
 
+Before running the `CMAKE_ARGS` command to install `llama-cpp-python`, make sure you have Xcode Command Line Tools installed on your system. These tools include compilers and build systems essential for source code compilation.
+
+Before proceeding, make sure you have the Xcode Command Line Tools installed. You can check whether they are installed by running:
+
+```bash
+xcode-select -p
 ```
-CMAKE_ARGS="-DLLAMA_METAL=on" FORCE_CMAKE=1 pip install -U llama-cpp-python --no-cache-dir
+
+If this command returns a path, then the Xcode Command Line Tools are already installed. If not, you'll get an error message, and you can install them by running:
+
+```bash
+xcode-select --install
 ```
 
-Part 2
+Follow the on-screen instructions to complete the installation. Once installed, you can proceed with installing an Apple Silicon compatible `llama-cpp-python`.
 
+---
+### Step 1: Installing llama-cpp-python with ARM64 Architecture and Metal Support
+
+
+```bash
+CMAKE_ARGS="-DCMAKE_OSX_ARCHITECTURES=arm64 -DLLAMA_METAL=on" FORCE_CMAKE=1 pip install --upgrade --force-reinstall llama-cpp-python --no-cache-dir
+--no-cache-dir
 ```
+
+### Step 2: Verifying Installation of llama-cpp-python with ARM64 Support
+
+After completing the installation, you can verify that `llama-cpp-python` was correctly installed with ARM64 architecture support by running the following command:
+
+```bash
+lipo -info /path/to/libllama.dylib
+```
+
+Replace `/path/to/` with the actual path to the `libllama.dylib` file. You should see output similar to:
+
+```bash
+Non-fat file: /Users/[user]/miniconda3/envs/openinterpreter/lib/python3.11/site-packages/llama_cpp/libllama.dylib is architecture: arm64
+```
+
+If the architecture is indicated as `arm64`, then you've successfully installed the ARM64 version of `llama-cpp-python`.
+
+### Step 3: Installing Server Components for llama-cpp-python
+
+
+```bash
 pip install 'llama-cpp-python[server]'
 ```


### PR DESCRIPTION
### Describe the changes you have made:

This commit updates the `MACOS.md` documentation to include detailed steps for correctly installing `llama-cpp-python` with ARM64 architecture support on Apple Silicon-based macOS systems. The update provides:

- Specified `bash` as language for fenced code blocks.
- A prerequisite check for Xcode Command Line Tools.
- Step-by-step installation instructions for `llama-cpp-python` with ARM64 and Metal support.
- A verification step to confirm the correct installation of `llama-cpp-python` for ARM64 architecture.
- Continues with additional step for installing server components for `llama-cpp-python`.

### Reference any relevant issue (Fixes #503)

This commit resolves the issue described in `ARM64 Installation Issue with llama-cpp-python on Apple Silicon Macs for interpreter --local #503`.

### I have performed a self-review of my code:
- [x] Yes
- [ ] No

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [x] Llama 7B
- [x] Llama 13B
- [x] Llama 34B
- [ ] Huggingface model (Please specify which one)
