### PR TITLE
added --system-message flag which appends a system message to the existing interpreter.system_message

### DIFF
--- a/interpreter/archive/cli.py
+++ b/interpreter/archive/cli.py
@@ -189,7 +189,7 @@ def cli(interpreter):
     interpreter.api_base = args.api_base
 
   if args.system_message:
-    interpreter.system_message = args.api_base
+    interpreter.system_message = args.system_message
 
   if args.falcon or args.model == "tiiuae/falcon-180B": # because i tweeted <-this by accident lol, we actually need TheBloke's quantized version of Falcon:
 

--- a/interpreter/archive/cli.py
+++ b/interpreter/archive/cli.py
@@ -109,6 +109,12 @@ def cli(interpreter):
                       default="",
                       required=False)
   
+  parser.add_argument('--system_message',
+                      type=str,
+                      help='append the given string to the beginning of every message',
+                      default="",
+                      required=False)
+  
   parser.add_argument('--use-azure',
                       action='store_true',
                       default=USE_AZURE,
@@ -181,6 +187,9 @@ def cli(interpreter):
 
   if args.api_base:
     interpreter.api_base = args.api_base
+
+  if args.system_message:
+    interpreter.system_message = args.api_base
 
   if args.falcon or args.model == "tiiuae/falcon-180B": # because i tweeted <-this by accident lol, we actually need TheBloke's quantized version of Falcon:
 


### PR DESCRIPTION
### Describe the changes you have made:

cli.py 112-116
```
  parser.add_argument('--system_message',
                      type=str,
                      help='append the given string to the beginning of every message',
                      default="",
                      required=False)
```

cli.py 191.192
```
  if args.system_message:
    interpreter.system_message = args.system_message
```

### Reference any relevant issue (Fixes #000)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [x] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
