### PR TITLE
fix: stop overwriting boolean config values

### DIFF
--- a/interpreter/cli/cli.py
+++ b/interpreter/cli/cli.py
@@ -82,7 +82,7 @@ def cli(interpreter):
     # Add arguments
     for arg in arguments:
         if arg["type"] == bool:
-            parser.add_argument(f'-{arg["nickname"]}', f'--{arg["name"]}', dest=arg["name"], help=arg["help_text"], action='store_true')
+            parser.add_argument(f'-{arg["nickname"]}', f'--{arg["name"]}', dest=arg["name"], help=arg["help_text"], action='store_true', default=None)
         else:
             parser.add_argument(f'-{arg["nickname"]}', f'--{arg["name"]}', dest=arg["name"], help=arg["help_text"], type=arg["type"])
 


### PR DESCRIPTION
### Describe the changes you have made:

Without the default set to `None`, any boolean CLI flag that isn't passed manually via `-` or `--` reverts to its`False` even if it is configured in the `config.yaml` file.

### Reference any relevant issue (Fixes #507 )

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
