### PR TITLE
feat: add guarddog option for scanning packages

### DIFF
--- a/interpreter/cli/cli.py
+++ b/interpreter/cli/cli.py
@@ -72,7 +72,13 @@ arguments = [
         "nickname": "ak",
         "help_text": "optionally set the API key for your llm calls (this will override environment variables)",
         "type": str
-    }
+    },
+    {
+        "name": "guarddog",
+        "nickname": "guarddog",
+        "help_text": "scan PyPI and npm packages for malicious code with guarddog",
+        "type": bool,
+    },
 ]
 
 def cli(interpreter):

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -30,6 +30,7 @@ class Interpreter:
         self.auto_run = False
         self.debug_mode = False
         self.max_output = 2000
+        self.guarddog = False
 
         # Conversation history
         self.conversation_history = True


### PR DESCRIPTION
### Describe the changes you have made:

This adds a `--guarddog` flag that instructs the model to use [guarddog](https://github.com/datadog/guarddog) to scan any `npm` or `pip` packages before installing them.

### Reference any relevant issue (Replaces #24)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)

**NOTE**: This depends on #508 in order to allow the `guard_dog` setting in the `config.yaml` to work as expected.

