### PR TITLE
fix: allow args to have choices and defaults

### DIFF
--- a/interpreter/cli/cli.py
+++ b/interpreter/cli/cli.py
@@ -84,7 +84,10 @@ def cli(interpreter):
         if arg["type"] == bool:
             parser.add_argument(f'-{arg["nickname"]}', f'--{arg["name"]}', dest=arg["name"], help=arg["help_text"], action='store_true')
         else:
-            parser.add_argument(f'-{arg["nickname"]}', f'--{arg["name"]}', dest=arg["name"], help=arg["help_text"], type=arg["type"])
+            choices = arg["choices"] if "choices" in arg else None
+            default = arg["default"] if "default" in arg else None
+
+            parser.add_argument(f'-{arg["nickname"]}', f'--{arg["name"]}', dest=arg["name"], help=arg["help_text"], type=arg["type"], choices=choices, default=default)
 
     # Add special arguments
     parser.add_argument('--config', dest='config', action='store_true', help='open config.yaml file in text editor')


### PR DESCRIPTION
### Describe the changes you have made:

This allows non-boolean args to define possible options and default values, which were ignored previously.

### Reference any relevant issue (Fixes #510)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)

Companion PR to #508 discovered while working on adding a new feature.