### PR TITLE
fix %load_message

### DIFF
--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -114,3 +114,5 @@ class Interpreter:
         for code_interpreter in self._code_interpreters.values():
             code_interpreter.terminate()
         self._code_interpreters = {}
+    def load(self, messages):
+        self.messages = messages


### PR DESCRIPTION
interpreter.load() missing.
Assuming it was just missed

### Describe the changes you have made:

### Reference any relevant issue (Fixes #000)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [ ] MacOS
- [x] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
