### PR TITLE
Fix GNU readline support for user input

### DIFF
--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -3,6 +3,11 @@ The terminal interface is just a view. Just handles the very top layer.
 If you were to build a frontend this would be a way to do it
 """
 
+try:
+    import readline
+except ImportError:
+    pass
+
 from .components.code_block import CodeBlock
 from .components.message_block import MessageBlock
 from .magic_commands import handle_magic_command


### PR DESCRIPTION
### Describe the changes you have made:

This commit adds an import for the readline module at the top of terminal_interface.py to provide GNU readline support for user input. This will allow Unix users to edit their input and browse their command history like in a UNIX shell. The readline module is imported conditionally, so the script does not break for Windows users where this module is typically not available.

pyproject.toml already mentions the ability to do this when declaring the pyreadline dependency and interpreter.py also imports readline, but it doesn't work unless the import is in the same module using the input function.

And I must credit my co-developer Open Interpreter for identifying the correct file and making the change at my direction.

### Reference any relevant issue (Fixes #000)

- [X] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [ ] MacOS
- [X] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
