### PR TITLE
add custom_llm_provider option for litellm 

### DIFF
--- a/interpreter/cli/cli.py
+++ b/interpreter/cli/cli.py
@@ -72,6 +72,12 @@ arguments = [
         "nickname": "ak",
         "help_text": "optionally set the API key for your llm calls (this will override environment variables)",
         "type": str
+    },
+    {
+        "name": "custom_llm_provider",
+        "nickname": "cp",
+        "help_text": "custom llm provider name, used for litellm",
+        "type": str
     }
 ]
 

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -46,6 +46,7 @@ class Interpreter:
         self.api_key = None
         self.max_budget = None
         self._llm = None
+        self.custom_llm_provider = None
 
         # Load config defaults
         config = get_config()

--- a/interpreter/llm/setup_text_llm.py
+++ b/interpreter/llm/setup_text_llm.py
@@ -71,7 +71,7 @@ def setup_text_llm(interpreter):
         system_message += "\n\nTo execute code on the user's machine, write a markdown code block *with a language*, i.e ```python, ```shell, ```r, ```html, or ```javascript. You will recieve the code output."
 
         # TODO swap tt.trim for litellm util
-        
+        messages = messages[1:]
         if interpreter.context_window and interpreter.max_tokens:
             trim_to_be_this_many_tokens = interpreter.context_window - interpreter.max_tokens - 25 # arbitrary buffer
             messages = tt.trim(messages, system_message=system_message, max_tokens=trim_to_be_this_many_tokens)
@@ -90,6 +90,7 @@ def setup_text_llm(interpreter):
             'model': interpreter.model,
             'messages': messages,
             'stream': True,
+	        'custom_llm_provider': interpreter.custom_llm_provider
         }
 
         # Optional inputs


### PR DESCRIPTION
### Describe the changes you have made:
1, Add custom_llm_provider which will be used for litellm for custom openai usage (like [Anyscale Endpoint](https://app.endpoints.anyscale.com/landing))
2, Fixed a bug in setup_text_llm which didn't remove the first message. 
### Reference any relevant issue (Fixes #000)

- [x ] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x ] MacOS
- [ x] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ x] GPT3
- [ x] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
