### PR TITLE
Update get_config.py

### DIFF
--- a/interpreter/utils/get_config.py
+++ b/interpreter/utils/get_config.py
@@ -7,8 +7,7 @@ import shutil
 config_filename = "config.yaml"
 
 # Using appdirs to determine user-specific config path
-config_dir = appdirs.user_config_dir("Open Interpreter")
-user_config_path = os.path.join(config_dir, config_filename)
+user_config_path = os.path.join(appdirs.user_config_dir(), 'Open Interpreter', 'config.yaml')
 
 def get_config():
     if not os.path.exists(user_config_path):


### PR DESCRIPTION
Updating get_config.py to use the same code to retrieve config file as cli.py. Unintended results (C:\Users\MyUser\AppData\Local\Open Interpreter\Open Interpreter\config.yaml) were happening.

### Describe the changes you have made:
Simplified get_config.py to use the same code as cli.py which returns the correct results.
### Reference any relevant issue (Fixes #000)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [x] Windows

### AI Language Model (if applicable)
All
