### PR TITLE
fix: stop overwriting safe_mode config.yaml setting with default in args

### DIFF
--- a/interpreter/cli/cli.py
+++ b/interpreter/cli/cli.py
@@ -79,7 +79,6 @@ arguments = [
         "nickname": "safe",
         "help_text": "optionally enable safety mechanisms like code scanning; valid options are off, ask, and auto",
         "type": str,
-        "default": "off",
         "choices": ["off", "ask", "auto"]
     }
 ]


### PR DESCRIPTION
### Describe the changes you have made:

`safe_mode` from `config.yaml` was being overwritten by the `default` option set in the arguments config. I forgot that we already have a default value in the `core.py` `Interpreter` instance and the way args were being handled meant that the default value functionality I added in #511 was actually overriding the value from `config.yaml`.

### Reference any relevant issue (Updates #484)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
