### PR TITLE
Fixed a bug in setup_text_llm.py

### DIFF
--- a/interpreter/llm/setup_text_llm.py
+++ b/interpreter/llm/setup_text_llm.py
@@ -71,7 +71,7 @@ def setup_text_llm(interpreter):
         system_message += "\n\nTo execute code on the user's machine, write a markdown code block *with a language*, i.e ```python, ```shell, ```r, ```html, or ```javascript. You will recieve the code output."
 
         # TODO swap tt.trim for litellm util
-        
+        messages = messages[1:]
         if interpreter.context_window and interpreter.max_tokens:
             trim_to_be_this_many_tokens = interpreter.context_window - interpreter.max_tokens - 25 # arbitrary buffer
             messages = tt.trim(messages, system_message=system_message, max_tokens=trim_to_be_this_many_tokens)


### PR DESCRIPTION
### Describe the changes you have made:
Remove the system message from the message list
Otherwise the system message will show up twice

This is similar to the treatment in this openai [case](https://github.com/KillianLucas/open-interpreter/blob/7a3f54d688e46dabde58f698574f300791b1944a/interpreter/llm/setup_openai_coding_llm.py#L48C30-L48C30)
### Reference any relevant issue (Fixes #000)

- [ ] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [ x] MacOS
- [ x] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ x] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
