### PR TITLE
Fix bug when trying to use local non-CodeLlama model

### DIFF
--- a/interpreter/llm/setup_local_text_llm.py
+++ b/interpreter/llm/setup_local_text_llm.py
@@ -23,7 +23,7 @@ def setup_local_text_llm(interpreter):
     DEFAULT_CONTEXT_WINDOW = 2000
     DEFAULT_MAX_TOKENS = 1000
 
-    repo_id = interpreter.model.split("huggingface/")[1]
+    repo_id = interpreter.model.replace("huggingface/", "")
 
     if "TheBloke/CodeLlama-" not in repo_id:
       # ^ This means it was prob through the old --local, so we have already displayed this message.


### PR DESCRIPTION
Python split method and indexing into the second element in the list does not work when the string pattern is not found; there would be only one element in the resulting list.

### Describe the changes you have made:
changed from using `split` method to using `replace` method.

### Reference any relevant issue (Fixes #000)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [x] Huggingface model (Please specify which one): TheBloke/Mistral-7B-Instruct-v0.1-GGUF
