### PR TITLE
fix: reenable arrow keys by importing readline

### DIFF
--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -3,6 +3,7 @@ The terminal interface is just a view. Just handles the very top layer.
 If you were to build a frontend this would be a way to do it
 """
 
+import readline
 from .components.code_block import CodeBlock
 from .components.message_block import MessageBlock
 from .magic_commands import handle_magic_command

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -111,6 +111,9 @@ def terminal_interface(interpreter, message):
 
                                 if response.strip().lower() == "y":
                                     should_scan_code = True
+                                
+                                # remove y/n from history so that user can more easily find last command
+                                readline.remove_history_item(readline.get_current_history_length() - 1)
 
                         if should_scan_code:
                             # Get code language and actual code from the chunk
@@ -137,6 +140,9 @@ def terminal_interface(interpreter, message):
                                 "message": "I have declined to run this code."
                             })
                             break
+
+                        # remove y/n from history so that user can more easily find last command
+                        readline.remove_history_item(readline.get_current_history_length() - 1)
 
                 # Output
                 if "output" in chunk:


### PR DESCRIPTION
### Describe the changes you have made:

I've found the inability to easily edit the command I had entered to be a source of constant frustration, and propose adding `readline` back to the project as a quality of life improvement.

This adds `import readline` back to the `interpreter/terminal_interface/terminal_interface.py` to enable the use of the Arrow keys for navigating your cursor, exploring command history, etc.

![OpenInterpreter-Readline](https://github.com/KillianLucas/open-interpreter/assets/1667415/03116ba1-48f9-4dc1-af4c-959b3b39028a)

I've also added a second commit (which we can discard if we want to) that removes the `y`/`n` answer from the `Do you want to scan this code?` and `Do you want to run this code?` questions because it felt like it was just polluting the command history.

![OpenInterpreter-Readline-NoYN](https://github.com/KillianLucas/open-interpreter/assets/1667415/7f7fb35c-f2fb-42f4-a84f-250ac68d0a3e)

### Reference any relevant issue (Fixes #000)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [x] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
