### PR TITLE
Fix a crash in get_relevant_procedures_string

### DIFF
--- a/interpreter/rag/get_relevant_procedures_string.py
+++ b/interpreter/rag/get_relevant_procedures_string.py
@@ -19,11 +19,12 @@ def get_relevant_procedures_string(interpreter):
     # Update the procedures database to reflect any changes in interpreter.procedures
     if interpreter._procedures_db.keys() != interpreter.procedures:
         updated_procedures_db = {}
-        for key in interpreter.procedures:
-            if key in interpreter._procedures_db:
-                updated_procedures_db[key] = interpreter._procedures_db[key]
-            else:
-                updated_procedures_db[key] = interpreter.embed_function(key)
+        if interpreter.procedures is not None:
+            for key in interpreter.procedures:
+                if key in interpreter._procedures_db:
+                    updated_procedures_db[key] = interpreter._procedures_db[key]
+                else:
+                    updated_procedures_db[key] = interpreter.embed_function(key)
         interpreter._procedures_db = updated_procedures_db
 
     # Assemble the procedures query string. Last two messages


### PR DESCRIPTION
### Describe the changes you have made:
Added a check if interpreter.procedures is None

### Reference any relevant issue (Fixes #000)
It crashed on the for loop on my computer

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [x] Windows
- [ ] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
