### PR TITLE
Remove space from language

### DIFF
--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -2,6 +2,7 @@ from ..code_interpreters.create_code_interpreter import create_code_interpreter
 from ..utils.merge_deltas import merge_deltas
 from ..utils.display_markdown_message import display_markdown_message
 from ..utils.truncate_output import truncate_output
+from ..code_interpreters.language_map import language_map
 import traceback
 import litellm
 
@@ -113,12 +114,12 @@ def respond(interpreter):
 
                 # Get a code interpreter to run it
                 language = interpreter.messages[-1]["language"]
-                if language not in interpreter._code_interpreters:
-                    try:
+                if language in language_map:
+                    if language not in interpreter._code_interpreters:
                         interpreter._code_interpreters[language] = create_code_interpreter(language)
-                    except:
-                        print(f"Error: tried to create a code_interpreter with: '{language}'")
-                code_interpreter = interpreter._code_interpreters[language]
+                    code_interpreter = interpreter._code_interpreters[language]
+                else:
+                    print(f"{language} not in supported languagess.")
 
                 # Yield a message, such that the user can stop code execution if they want to
                 try:

--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -112,9 +112,12 @@ def respond(interpreter):
                     interpreter.messages[-1]["language"] = "shell"
 
                 # Get a code interpreter to run it
-                language = interpreter.messages[-1]["language"]
+                language = interpreter.messages[-1]["language"].replace(" ", "")
                 if language not in interpreter._code_interpreters:
-                    interpreter._code_interpreters[language] = create_code_interpreter(language)
+                    try:
+                        interpreter._code_interpreters[language] = create_code_interpreter(language)
+                    except:
+                        print(f"Error: tried to create a code_interpreter with: '{language}'")
                 code_interpreter = interpreter._code_interpreters[language]
 
                 # Yield a message, such that the user can stop code execution if they want to

--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -112,7 +112,7 @@ def respond(interpreter):
                     interpreter.messages[-1]["language"] = "shell"
 
                 # Get a code interpreter to run it
-                language = interpreter.messages[-1]["language"].replace(" ", "")
+                language = interpreter.messages[-1]["language"]
                 if language not in interpreter._code_interpreters:
                     try:
                         interpreter._code_interpreters[language] = create_code_interpreter(language)

--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -120,10 +120,11 @@ def respond(interpreter):
                     code_interpreter = interpreter._code_interpreters[language]
                 else:
                     #This still prints the code but don't allow code to run. Let's Open-Interpreter know through output message
-                    print(f"Error: Open-Interpreter do not currently support {language}.")
+                    error_output = f"Error: Open Interpreter does not currently support {language}."
+                    print(error_output)
 
                     interpreter.messages[-1]["output"] = ""
-                    output = "\n" + f"Error: Open-Interpreter do not currently support {language}."
+                    output = "\n" + error_output
 
                     # Truncate output
                     output = truncate_output(output, interpreter.max_output)

--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -119,7 +119,9 @@ def respond(interpreter):
                         interpreter._code_interpreters[language] = create_code_interpreter(language)
                     code_interpreter = interpreter._code_interpreters[language]
                 else:
-                    print(f"{language} not in supported languages.")
+                    #This still prints the code but don't allow Y/N
+                    print(f"Error: Open-Interpreter do not currently support {language}.")
+                    break
 
                 # Yield a message, such that the user can stop code execution if they want to
                 try:

--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -119,8 +119,15 @@ def respond(interpreter):
                         interpreter._code_interpreters[language] = create_code_interpreter(language)
                     code_interpreter = interpreter._code_interpreters[language]
                 else:
-                    #This still prints the code but don't allow Y/N
+                    #This still prints the code but don't allow code to run. Let's Open-Interpreter know through output message
                     print(f"Error: Open-Interpreter do not currently support {language}.")
+
+                    interpreter.messages[-1]["output"] = ""
+                    output = "\n" + f"Error: Open-Interpreter do not currently support {language}."
+
+                    # Truncate output
+                    output = truncate_output(output, interpreter.max_output)
+                    interpreter.messages[-1]["output"] = output.strip()
                     break
 
                 # Yield a message, such that the user can stop code execution if they want to

--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -119,7 +119,7 @@ def respond(interpreter):
                         interpreter._code_interpreters[language] = create_code_interpreter(language)
                     code_interpreter = interpreter._code_interpreters[language]
                 else:
-                    print(f"{language} not in supported languagess.")
+                    print(f"{language} not in supported languages.")
 
                 # Yield a message, such that the user can stop code execution if they want to
                 try:

--- a/interpreter/llm/convert_to_coding_llm.py
+++ b/interpreter/llm/convert_to_coding_llm.py
@@ -52,6 +52,9 @@ def convert_to_coding_llm(text_llm, debug_mode=False):
                     # Default to python if not specified
                     if language == "":
                         language = "python"
+                    else:
+                        #Removes hallucinations containing spaces or non letters.
+                        language = ''.join(char for char in language if char.isalpha())
 
                     output = {"language": language}
 


### PR DESCRIPTION
The LLM might have put a space between code block start and language: "``` python ". Added Error handling to get better error messages.

### Describe the changes you have made:
Remove space from "language"
Added try/except to handle other errors with better error message.

### Reference any relevant issue (Fixes #000)
Discord issue
https://discord.com/channels/1146610656779440188/1164496324591353946/1164496324591353946

- [ ] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [x] Windows
- [ ] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
