### PR TITLE
Consider hiding the api-key

### DIFF
--- a/interpreter/terminal_interface/validate_llm_settings.py
+++ b/interpreter/terminal_interface/validate_llm_settings.py
@@ -3,6 +3,7 @@ from ..utils.display_markdown_message import display_markdown_message
 import time
 import inquirer
 import litellm
+import getpass
 
 def validate_llm_settings(interpreter):
     """
@@ -71,7 +72,8 @@ def validate_llm_settings(interpreter):
                     ---
                     """)
 
-                    response = input("OpenAI API key: ")
+                    response = getpass.getpass("OpenAI API key: ")
+                    print(f"OpenAI API key: {response[:4]}...{response[-4:]}")
 
                     if response == "":
                         # User pressed `enter`, requesting Mistral-7B


### PR DESCRIPTION
Some people share screenshots with their API key visible.
Using getpass to hide the key should be considered

### Describe the changes you have made:
Added getpass to hide the key.

### Reference any relevant issue (Fixes #000)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [x] Windows
- [ ] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
