### PR TITLE
Fixed issue with 3.5 Models hallucinating a function called "python", causing empty returns

### DIFF
--- a/interpreter/llm/setup_openai_coding_llm.py
+++ b/interpreter/llm/setup_openai_coding_llm.py
@@ -125,22 +125,21 @@ def setup_openai_coding_llm(interpreter):
                     arguments = parse_partial_json(arguments)
 
                     if arguments:
-                        if ("name" in arguments and arguments["name"] == "execute"):
-                            if (language is None
-                                and "language" in arguments
-                                and "code" in arguments # <- This ensures we're *finished* typing language, as opposed to partially done
-                                and arguments["language"]):
-                                language = arguments["language"]
-                                yield {"language": language}
-                            
-                            if language is not None and "code" in arguments:
-                                # Calculate the delta (new characters only)
-                                code_delta = arguments["code"][len(code):]
-                                # Update the code
-                                code = arguments["code"]
-                                # Yield the delta
-                                if code_delta:
-                                    yield {"code": code_delta}
+                        if (language is None
+                            and "language" in arguments
+                            and "code" in arguments # <- This ensures we're *finished* typing language, as opposed to partially done
+                            and arguments["language"]):
+                            language = arguments["language"]
+                            yield {"language": language}
+                        
+                        if language is not None and "code" in arguments:
+                            # Calculate the delta (new characters only)
+                            code_delta = arguments["code"][len(code):]
+                            # Update the code
+                            code = arguments["code"]
+                            # Yield the delta
+                            if code_delta:
+                                yield {"code": code_delta}
                     else:
                         if interpreter.debug_mode:
                             print("Arguments not a dict.")


### PR DESCRIPTION
### Describe the changes you have made:

I've found 3.5-turbo to be consistently hallucinating a function with the name "python", which causes an ugly UX of an empty return. Here's what it looks like:

```
{'role': 'assistant', 'content': None, 'function_call': <OpenAIObject at 0x11efe7c50> JSON: {
  "name": "python",
  "arguments": "import sys\nsys.executable"
}}
```
It turns out this is reasonably well known: https://community.openai.com/t/function-calling-a-python-function-is-frequently-called-even-though-it-does-not-exist-in-the-functions-parameter/264481/1, and that there's not a ton to be done here, other than embrace it. I've added the ability to just process that function, if it's called.

- [x] I have performed a self-review of my code:

When working on raycast open-interpreter, I test with 3.5 turbo for cost reasons (I'm running the same question like 100 times to check UI stuff). I've found the issue to be problematic both on the command line and from the library form. 

I no longer get empty replies in any of the test cases I've found that once triggered this. My main test case is: `Check what python interpreter you have access to.`.

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [x] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
