### PR TITLE
chore: remove extraneous chroma package; clean up dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 pip install open-interpreter
 ```
 
+**⚠️ Note: Open Interpreter currently supports Python 3.10 and 3.11.**
+
 ```shell
 interpreter
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -388,16 +388,6 @@ files = [
 ]
 
 [[package]]
-name = "chroma"
-version = "0.2.0"
-description = "Color handling made simple."
-optional = false
-python-versions = "*"
-files = [
-    {file = "Chroma-0.2.0.tar.gz", hash = "sha256:e265bcd503e2b35c4448b83257467166c252ecf3ab610492432780691cdfb286"},
-]
-
-[[package]]
 name = "chroma-hnswlib"
 version = "0.7.3"
 description = "Chromas fork of hnswlib"
@@ -2248,20 +2238,19 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.7"
+version = "1.26.18"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
-    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
+    {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
+    {file = "urllib3-1.26.18.tar.gz", hash = "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
-secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
-socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uvicorn"
@@ -2643,5 +2632,5 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.10"
-content-hash = "2ea4e2d34f63c6d07bbf5adcc477ab74cb6991270c1f319a45ce2c7a209459a1"
+python-versions = ">=3.10,<3.12"
+content-hash = "f606809376aa7dfb5f402c750579f85993681d28279c6b75b64ef39568b45b8e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,33 +9,25 @@ authors = ["Killian Lucas <killian@openinterpreter.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
-openai = "^0.28.0"
-rich = "^13.4.2"
-tiktoken = "^0.4.0"
-astor = "^0.8.1"
-git-python = "^1.0.3"
-tokentrim = "^0.1.9"
+python = ">=3.10,<3.12"
+
 appdirs = "^1.4.4"
-six = "^1.16.0"
-python-dotenv = "^1.0.0"
-
-inquirer = "^3.1.3"
-wget = "^3.2"
-huggingface-hub = "^0.17.3"
-litellm = "0.8.6"
-pyyaml = "^6.0.1"
-yaspin = "^3.0.1"
-ooba = "^0.0.21"
-chroma = "^0.2.0"
+astor = "^0.8.1"
 chromadb = "^0.4.14"
-
-# DISABLED # but perhaps we should re-enable soon. Windows + readline errors sometimes, need more testing
-# On non-windows systems, you can just `import readline`.
-# On windows, `pyreadline3` replaces that, so you can also just `import readline`.
-# [tool.poetry.dependencies.pyreadline3]
-# version = "^3.4.1"
-# markers = "sys_platform == 'win32'"
+git-python = "^1.0.3"
+huggingface-hub = "^0.17.3"
+inquirer = "^3.1.3"
+litellm = "0.8.6"
+ooba = "^0.0.21"
+openai = "^0.28.0"
+python-dotenv = "^1.0.0"
+pyyaml = "^6.0.1"
+rich = "^13.4.2"
+six = "^1.16.0"
+tiktoken = "^0.4.0"
+tokentrim = "^0.1.9"
+wget = "^3.2"
+yaspin = "^3.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
### Describe the changes you have made:

Based on #356 I tested to see if we could drop support down to Python `3.9`, but there were errors while trying to run the current version of interpreter - so I think we can close that one, and based on #627 and the many issues that pop up here and on Discord, we should explicitly state which versions are supported and indicate that `3.12` is not one of them at the moment.

Once all depencies support `3.12`, we can make the upper bound inclusive instead of exclusive.

`aiohttp` is an underlying dependency that is [still working on 3.12 support](https://github.com/aio-libs/aiohttp/issues/7675) and there may be others, too.

I believe the `chroma` package was installed in error as it isn't referenced anywhere, so I removed that and put the rest of the dependencies in alphabetical order (with the `python` version described first).

I also removed the commented out `pyreadline3` stuff to clean up the `pyproject.toml` as we can grab that from the git history if we need it again.

### Reference any relevant issue

Closes #356

- [ ] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [ ] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
