### PR TITLE
fix: make sure safe_mode is disabled by default

### DIFF
--- a/interpreter/cli/cli.py
+++ b/interpreter/cli/cli.py
@@ -76,6 +76,7 @@ arguments = [
         "help_text": "optionally enable safety mechanisms like code scanning; valid options are off, ask, and auto",
         "type": str,
         "choices": ["off", "ask", "auto"],
+        "default": "off"
     },
     {
         "name": "gguf_quality",
@@ -203,7 +204,7 @@ def cli(interpreter):
                 setattr(interpreter, attr_name, attr_value)
 
     # if safe_mode and auto_run are enabled, safe_mode disables auto_run
-    if interpreter.auto_run and not interpreter.safe_mode == "off":
+    if interpreter.auto_run and (interpreter.safe_mode == "ask" or interpreter.safe_mode == "auto"):
         setattr(interpreter, "auto_run", False)
 
     # Default to Mistral if --local is on but --model is unset


### PR DESCRIPTION
### Describe the changes you have made:

Something was causing safe_mode to be enabled by default.

This PR just ensures that it is disabled until explicitly enabled by the user via the CLI arguments or config file setting.

It also makes the `safe_mode` vs `auto_run` toggle more explicit in case `safe_mode` ends up undefined or something.

### Reference any relevant issue (Fixes #000)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
