### PR TITLE
fix: default to 0 if temperature is unset

### DIFF
--- a/interpreter/llm/setup_openai_coding_llm.py
+++ b/interpreter/llm/setup_openai_coding_llm.py
@@ -80,7 +80,9 @@ def setup_openai_coding_llm(interpreter):
             params["max_tokens"] = interpreter.max_tokens
         if interpreter.temperature is not None:
             params["temperature"] = interpreter.temperature
-        
+        else:
+            params["temperature"] = 0.0
+
         # These are set directly on LiteLLM
         if interpreter.max_budget:
             litellm.max_budget = interpreter.max_budget

--- a/interpreter/llm/setup_text_llm.py
+++ b/interpreter/llm/setup_text_llm.py
@@ -103,6 +103,8 @@ def setup_text_llm(interpreter):
             params["max_tokens"] = interpreter.max_tokens
         if interpreter.temperature is not None:
             params["temperature"] = interpreter.temperature
+        else:
+            params["temperature"] = 0.0
 
         # These are set directly on LiteLLM
         if interpreter.max_budget:


### PR DESCRIPTION
### Describe the changes you have made:

Based on the discussion in #687 we need to ensure that the default temperature of `0` is used when the user does not provide a temperature.

### Reference any relevant issue (Fixes #000)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [ ] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
