### PR TITLE
Quickfix .lower()

### DIFF
--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -130,7 +130,7 @@ If LM Studio's local server is running, please try a language model with a diffe
                     interpreter.messages[-1]["language"] = "shell"
 
                 # Get a code interpreter to run it
-                language = interpreter.messages[-1]["language"]
+                language = interpreter.messages[-1]["language"].lower()
                 if language in language_map:
                     if language not in interpreter._code_interpreters:
                         # Create code interpreter


### PR DESCRIPTION
### Describe the changes you have made:
language_map has "r" not "R"
When trying to run code with "```R" it fails:
"Error: Open Interpreter does not currently support R."

### Reference any relevant issue (Fixes #000)
https://discord.com/channels/1146610656779440188/1147665339266650133/1172572430183706674

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [x] Windows
- [ ] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
