### PR TITLE
Unsupported lang fix

### DIFF
--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -132,7 +132,7 @@ If LM Studio's local server is running, please try a language model with a diffe
                     interpreter.messages[-1]["language"] = "shell"
 
                 # Get a code interpreter to run it
-                language = interpreter.messages[-1]["language"].lower()
+                language = interpreter.messages[-1]["language"].lower().strip()
                 if language in language_map:
                     if language not in interpreter._code_interpreters:
                         # Create code interpreter

--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -15,6 +15,8 @@ def respond(interpreter):
     Responds until it decides not to run any more code or say anything else.
     """
 
+    last_unsupported_code = ""
+
     while True:
         system_message = interpreter.generate_system_message()
 
@@ -150,7 +152,13 @@ If LM Studio's local server is running, please try a language model with a diffe
                     # Truncate output
                     output = truncate_output(output, interpreter.max_output)
                     interpreter.messages[-1]["output"] = output.strip()
-                    break
+                    
+                    # Let the response continue so it can deal with the unsupported code in another way. Also prevent looping on the same piece of code.
+                    if code != last_unsupported_code:
+                        last_unsupported_code = code
+                        continue
+                    else:
+                        break
 
                 # Yield a message, such that the user can stop code execution if they want to
                 try:


### PR DESCRIPTION
### Describe the changes you have made:
When unsupported language is encountered, it continues the response so the model can try workarounds and continue with the remaining steps instead of immediately stopping. Also added a small check so that if the model tries to read out the code a 2nd time it doesnt loop.

### Reference any relevant issue (Fixes #000)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [x] Windows
- [ ] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [x] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
