### PR TITLE
set `encoding` and `errors` in `Popen` to avoid `UnicodeDecodeError`

### DIFF
--- a/interpreter/core/code_interpreters/subprocess_code_interpreter.py
+++ b/interpreter/core/code_interpreters/subprocess_code_interpreter.py
@@ -54,6 +54,8 @@ class SubprocessCodeInterpreter(BaseCodeInterpreter):
             bufsize=0,
             universal_newlines=True,
             env=my_env,
+            encoding="utf-8",
+            errors="replace",
         )
         threading.Thread(
             target=self.handle_stream_output,


### PR DESCRIPTION

### Describe the changes you have made:
I believe #742 perhaps only works on non-Windows OS.

By setting `encoding="utf-8"` and `errors="replace"` in `subprocess.Popen`, we can finally suspend this `UnicodeDecodeError` - It might not be the best solution, but the users will no longer be blocked at least.

Tested on Windows 11 `zh-CN` locale (cp936, gbk), and WSL2 Pengwin.

### Reference any relevant issue (Fixes #000)
Fixes #739 #440  #209 #93 

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [x] Windows
- [ ] MacOS
- [x] Linux

### AI Language Model (if applicable)
- [x] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
