### PR TITLE
Add package mismatches info to system_debug_info

### DIFF
--- a/interpreter/core/utils/system_debug_info.py
+++ b/interpreter/core/utils/system_debug_info.py
@@ -3,6 +3,7 @@ import subprocess
 
 import pkg_resources
 import psutil
+import toml
 
 
 def get_python_version():
@@ -45,6 +46,30 @@ def get_ram_info():
     return f"{total_ram_gb:.2f} GB, used: {used_ram_gb:.2f}, free: {free_ram_gb:.2f}"
 
 
+def get_package_mismatches(file_path='pyproject.toml'):
+    with open(file_path, 'r') as file:
+        pyproject = toml.load(file)
+    dependencies = pyproject['tool']['poetry']['dependencies']
+    dev_dependencies = pyproject['tool']['poetry']['group']['dev']['dependencies']
+    dependencies.update(dev_dependencies)
+
+    installed_packages = {pkg.key: pkg.version for pkg in pkg_resources.working_set}
+
+    mismatches = []
+    for package, version_info in dependencies.items():
+        if isinstance(version_info, dict):
+            version_info = version_info['version']
+        installed_version = installed_packages.get(package)
+        if installed_version and version_info.startswith('^'):
+            expected_version = version_info[1:]
+            if not installed_version.startswith(expected_version):
+                mismatches.append(f'\t  {package}: Mismatch, pyproject.toml={expected_version}, pip={installed_version}')
+        else:
+            mismatches.append(f'\t  {package}: Not found in pip list')
+
+    return '\n' + '\n'.join(mismatches)
+
+
 def interpreter_info(interpreter):
     try:
         if interpreter.local:
@@ -85,6 +110,8 @@ def system_info(interpreter):
         OS Version and Architecture: {get_os_version()}
         CPU Info: {get_cpu_info()}
         RAM Info: {get_ram_info()}
+        Package Version Mismatches:
+        {get_package_mismatches()}
         {interpreter_info(interpreter)}
     """
     )


### PR DESCRIPTION
### Describe the changes you have made:

Added package mismatches between poetry and pip to system_debug_info
Here is the result.

```
>>> from interpreter.core.utils.system_debug_info import system_info
>>> import interpreter
>>> system_info(interpreter)

        Python Version: 3.10.12
        Pip Version: 23.2.1
        Open-interpreter Version: cmd:Interpreter, pkg: 0.1.16
        OS Version and Architecture: macOS-14.1.1-arm64-i386-64bit
        CPU Info: i386
        RAM Info: 16.00 GB, used: 5.02, free: 0.20
        Package Version Mismatches:
        
          python: Not found in pip list
          litellm: Not found in pip list
          openai: Mismatch, pyproject.toml=0.28.0, pip=0.28.1
          rich: Mismatch, pyproject.toml=13.4.2, pip=13.6.0
          pyreadline3: Not found in pip list
          black: Mismatch, pyproject.toml=23.10.1, pip=23.11.0
          pytest: Mismatch, pyproject.toml=7.4.0, pip=7.4.3
        

        Interpreter Info
        Vision: False
        Model: gpt-4
        Function calling: None
        Context window: None
        Max tokens: None

        Auto run: False
        API base: None
        Local: False

        Curl output: Not local
    
    
>>> 
```

Please check issue #796 

### Reference any relevant issue (Fixes #796 )

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
