### PR TITLE
Fix %tokens command crash

### DIFF
--- a/interpreter/terminal_interface/utils/count_tokens.py
+++ b/interpreter/terminal_interface/utils/count_tokens.py
@@ -7,7 +7,7 @@ def count_tokens(text="", model="gpt-4"):
     Count the number of tokens in a string
     """
 
-    # Fix bug where models starting with openai/ for example can'git t find tokenizer
+    # Fix bug where models starting with openai/ for example can't find tokenizer
     if '/' in model:
         model = model.split('/')[-1]
 

--- a/interpreter/terminal_interface/utils/count_tokens.py
+++ b/interpreter/terminal_interface/utils/count_tokens.py
@@ -7,7 +7,16 @@ def count_tokens(text="", model="gpt-4"):
     Count the number of tokens in a string
     """
 
-    encoder = tiktoken.encoding_for_model(model)
+    # Fix bug where models starting with openai/ for example can'git t find tokenizer
+    if '/' in model:
+        model = model.split('/')[-1]
+
+    # At least give an estimate if we can't find the tokenizer
+    try:
+        encoder = tiktoken.encoding_for_model(model)
+    except KeyError:
+        print(f"Could not find tokenizer for {model}. Defaulting to gpt-4 tokenizer.")
+        encoder = tiktoken.encoding_for_model("gpt-4")
 
     return len(encoder.encode(text))
 


### PR DESCRIPTION
### Describe the changes you have made:
- Fixed %tokens command where count_tokens fails to find tokenizer because of openai/ in the model name
- If tokenizer for a model isn't found, defaults to gpt-4 tokenizer

### Reference any relevant issue (Fixes #000)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [x] Windows
- [ ] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [x] GPT4
- [x] GPT3
- [x] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
