### PR TITLE
Fix openrouter url

### DIFF
--- a/docs/language-model-setup/hosted-models/openrouter.mdx
+++ b/docs/language-model-setup/hosted-models/openrouter.mdx
@@ -21,7 +21,7 @@ interpreter.chat()
 
 # Supported Models
 
-We support any model on [OpenRouter's models page:](https://openrouter.com/models)
+We support any model on [OpenRouter's models page:](https://openrouter.ai/models)
 
 <CodeGroup>
 
@@ -59,6 +59,6 @@ Set the following environment variables [(click here to learn how)](https://chat
 
 | Environment Variable  | Description  | Where to Find  |
 | --------------------- | ------------ | -------------- |
-| `OPENROUTER_API_KEY`       | The API key for authenticating to OpenRouter's services. | [OpenRouter Account Page](https://openrouter.com/account/api-keys) |
-| `OR_SITE_URL`      | The site URL for OpenRouter's services. | [OpenRouter Account Page](https://openrouter.com/account/api-keys) |
-| `OR_APP_NAME`   | The app name for OpenRouter's services. | [OpenRouter Account Page](https://openrouter.com/account/api-keys) |
+| `OPENROUTER_API_KEY`       | The API key for authenticating to OpenRouter's services. | [OpenRouter Account Page](https://openrouter.ai/keys) |
+| `OR_SITE_URL`      | The site URL for OpenRouter's services. | [OpenRouter Account Page](https://openrouter.ai/keys) |
+| `OR_APP_NAME`   | The app name for OpenRouter's services. | [OpenRouter Account Page](https://openrouter.ai/keys) |


### PR DESCRIPTION
The old url was for a completely different domain

### Describe the changes you have made:
Documentation update

