### PR TITLE
 return empty dict if config file is empty

### DIFF
--- a/interpreter/terminal_interface/utils/get_config.py
+++ b/interpreter/terminal_interface/utils/get_config.py
@@ -47,9 +47,18 @@ def get_config_path(path=user_config_path):
 
 def get_config(path=user_config_path):
     path = get_config_path(path)
+    
+    config = None
 
     with open(path, "r") as file:
         config = yaml.safe_load(file)
-        if config is None:
-            config = {}
-        return config
+        if not config is None:
+            return config
+
+    if config is None:
+        # Deleting empty file because get_config_path copies the default if file is missing
+        os.remove(path)
+        path = get_config_path(path)
+        with open(path, "r") as file:
+            config = yaml.safe_load(file)
+            return config

--- a/interpreter/terminal_interface/utils/get_config.py
+++ b/interpreter/terminal_interface/utils/get_config.py
@@ -49,4 +49,7 @@ def get_config(path=user_config_path):
     path = get_config_path(path)
 
     with open(path, "r") as file:
-        return yaml.safe_load(file)
+        config = yaml.safe_load(file)
+        if config is None:
+            config = {}
+        return config

--- a/interpreter/terminal_interface/utils/get_config.py
+++ b/interpreter/terminal_interface/utils/get_config.py
@@ -42,6 +42,8 @@ def get_config_path(path=user_config_path):
                 # Copying the file using shutil.copy
                 new_file = shutil.copy(default_config_path, path)
 
+                print("Copied the default config file to the user's directory because the user's config file was not found.")
+
     return path
 
 

--- a/interpreter/terminal_interface/utils/get_config.py
+++ b/interpreter/terminal_interface/utils/get_config.py
@@ -52,7 +52,7 @@ def get_config(path=user_config_path):
 
     with open(path, "r") as file:
         config = yaml.safe_load(file)
-        if not config is None:
+        if config is not None:
             return config
 
     if config is None:


### PR DESCRIPTION
### Describe the changes you have made:
`yaml.safe_load` returns `None` from the `get_config` function if the config file is empty. This change checks for `None` value and instead returns `{}` so `extend_config` call doesn't throw exception when config file is empty.

### Reference any relevant issue (Fixes #000)
https://github.com/KillianLucas/open-interpreter/issues/794

- [ ] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
