### PR TITLE
Add pyautogui mouse click functions and parameters

### DIFF
--- a/interpreter/core/computer/mouse/mouse.py
+++ b/interpreter/core/computer/mouse/mouse.py
@@ -34,10 +34,25 @@ class Mouse:
 
         pyautogui.moveTo(x, y, duration=0.5)
 
-    def click(self, *args, **kwargs):
+    def click(self, *args, button="left", clicks=1, interval=0.1, **kwargs):
         if args or kwargs:
             self.move(*args, **kwargs)
-        pyautogui.click()
+        pyautogui.click(button=button, clicks=clicks, interval=interval)
+
+    def double_click(self, *args, button="left", interval=0.1, **kwargs):
+        if args or kwargs:
+            self.move(*args, **kwargs)
+        pyautogui.doubleClick(button=button, interval=interval)
+
+    def triple_click(self, *args, button="left", interval=0.1, **kwargs):
+        if args or kwargs:
+            self.move(*args, **kwargs)
+        pyautogui.tripleClick(button=button, interval=interval)
+
+    def right_click(self, *args, **kwargs):
+        if args or kwargs:
+            self.move(*args, **kwargs)
+        pyautogui.rightClick()
 
     def down(self):
         pyautogui.mouseDown()


### PR DESCRIPTION
### Describe the changes you have made:

I have added [PyAutoGUI mouse click functions](https://pyautogui.readthedocs.io/en/latest/mouse.html#mouse-clicks). I noticed that Open Interpreter would attempt to call the `double_click` function or pass in `clicks=2` which are both valid in PyAutoGUI.

Added:

- double click
- triple click
- right click
- ability to pass in button, clicks, interval params to `click` function

### Reference any relevant issue (Fixes #000)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [x] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
