### PR TITLE
Fixed the case where UnicodeDecodeError

### DIFF
--- a/interpreter/terminal_interface/utils/get_config.py
+++ b/interpreter/terminal_interface/utils/get_config.py
@@ -55,14 +55,21 @@ def get_config(path=user_config_path):
     config = None
 
     try:
-        with open(path, "r") as file:
+        with open(path, "r", encoding='utf-8') as file:
             config = yaml.safe_load(file)
             if config is not None:
                 return config
-    except:
+    except UnicodeDecodeError:
         print("")
         print(
-            "WARNING: Config file can't be read. Ensure it adheres to YAML format. Run `interpreter --reset_config` to reset it."
+            "WARNING: Config file can't be read due to a Unicode decoding error. Ensure it is saved in UTF-8 format. Run `interpreter --reset_config` to reset it."
+        )
+        print("")
+        return {}
+    except Exception as e:
+        print("")
+        print(
+            f"WARNING: An error occurred while reading the config file: {e}. Run `interpreter --reset_config` to reset it."
         )
         print("")
         return {}
@@ -71,6 +78,6 @@ def get_config(path=user_config_path):
         # Deleting empty file because get_config_path copies the default if file is missing
         os.remove(path)
         path = get_config_path(path)
-        with open(path, "r") as file:
+        with open(path, "r", encoding='utf-8') as file:
             config = yaml.safe_load(file)
             return config


### PR DESCRIPTION
'gbk' codec can't decode byt…e 0x94 in position 353: illegal multibyte sequence

### Describe the changes you have made:
Forces the specified yaml file to be read using the utf-8 file stream, avoiding encoding errors when the yaml package gets the information

### Reference any relevant issues (e.g. "Fixes #000"):
Fixes #860
### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [ ] I have read `docs/CONTRIBUTING.md`
- [ ] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [√ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
