### PR TITLE
Fix cli crash during screenshot generation

### DIFF
--- a/interpreter/core/computer/display/display.py
+++ b/interpreter/core/computer/display/display.py
@@ -1,14 +1,11 @@
 import base64
-import os
 import pprint
-import tempfile
 import time
 import warnings
 from io import BytesIO
 
 import matplotlib.pyplot as plt
 import requests
-from PIL import Image
 
 from ..utils.recipient_utils import format_to_recipient
 
@@ -68,8 +65,6 @@ class Display:
             )
             return
 
-        temp_file = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
-
         if quadrant == None:
             # Implement active_app_only!
             if active_app_only:
@@ -101,31 +96,20 @@ class Display:
             else:
                 raise ValueError("Invalid quadrant. Choose between 1 and 4.")
 
-        screenshot.save(temp_file.name)
-
         # Open the image file with PIL
         # IPython interactive mode auto-displays plots, causing RGBA handling issues, possibly MacOS-specific.
-        img = Image.open(temp_file.name).convert("RGB")
-
-        # Delete the temporary file
-        try:
-            os.remove(temp_file.name)
-        except Exception as e:
-            # On windows, this can fail due to permissions stuff??
-            # (PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\killi\\AppData\\Local\\Temp\\tmpgc2wscpi.png')
-            if self.computer.verbose:
-                print(str(e))
+        screenshot = screenshot.convert("RGB")
 
         if show:
             # Show the image using matplotlib
-            plt.imshow(np.array(img))
+            plt.imshow(np.array(screenshot))
 
             with warnings.catch_warnings():
                 # It displays an annoying message about Agg not being able to display something or WHATEVER
                 warnings.simplefilter("ignore")
                 plt.show()
 
-        return img
+        return screenshot
 
     def find_text(self, text, screenshot=None):
         # Take a screenshot

--- a/interpreter/core/computer/display/display.py
+++ b/interpreter/core/computer/display/display.py
@@ -1,7 +1,6 @@
 import base64
 import os
 import pprint
-import subprocess
 import tempfile
 import time
 import warnings
@@ -17,7 +16,6 @@ from ..utils.recipient_utils import format_to_recipient
 # from utils.get_active_window import get_active_window
 
 try:
-    import cv2
     import numpy as np
     import pyautogui
 except:
@@ -106,7 +104,8 @@ class Display:
         screenshot.save(temp_file.name)
 
         # Open the image file with PIL
-        img = Image.open(temp_file.name)
+        # IPython interactive mode auto-displays plots, causing RGBA handling issues, possibly MacOS-specific.
+        img = Image.open(temp_file.name).convert("RGB")
 
         # Delete the temporary file
         try:


### PR DESCRIPTION
### Describe the changes you have made:

### Description of changes:
Implemented a fix that addresses an RGBA handling issue during screenshot generation when using IPython with auto-display.

The issue happens because `show=True` is set in `Display.snapshot`, and the screenshot generated on a Mac has an alpha channel (RGBA instead of RGB). When IPython attempts to display this image and convert it to JPEG, the process crashes (the exact cause is unclear).

This PR introduces a simple fix that enforces RGB mode in all cases.

I chose not to alter the default value of `show` because there may be use cases that depend on the current behavior, and this change is less likely to introduce new issues.

In the following commit, I performed a minor refactor related to the change I made: instead of saving/loading the image into a file that is neither used nor exposed, we now directly use the memory buffer. I separated this into another commit in case it causes any issues or if there are anticipated future uses for the file-based approach, making it easier to roll back or opt not to merge.

Thank you for the amazing project. ;)

### Reference any relevant issues (e.g. "Fixes #000"):
Fixes #878

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [X] I have read `docs/CONTRIBUTING.md`
- [X] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [X] Tested on MacOS
- [ ] Tested on Linux
