### PR TITLE
Fix azure openai coding error

### DIFF
--- a/docs/usage/terminal/arguments.mdx
+++ b/docs/usage/terminal/arguments.mdx
@@ -230,6 +230,16 @@ llm_supports_functions: true
 ```
 
 </CodeGroup>
+#### `--no-llm_supports_functions` 
+
+Inform Open Interpreter that the language model you're using does not support function calling.
+
+<CodeGroup>
+```bash Terminal
+interpreter --no-llm_supports_functions
+```
+</CodeGroup>
+
 #### `--llm_supports_vision` or `-lsv`
 
 Inform Open Interpreter that the language model you're using supports vision.

--- a/interpreter/core/llm/run_function_calling_llm.py
+++ b/interpreter/core/llm/run_function_calling_llm.py
@@ -47,7 +47,7 @@ def run_function_calling_llm(llm, request_params):
             continue
 
         delta = chunk["choices"][0]["delta"]
-      
+
         # Accumulate deltas
         accumulated_deltas = merge_deltas(accumulated_deltas, delta)
 
@@ -59,13 +59,11 @@ def run_function_calling_llm(llm, request_params):
             and "arguments" in accumulated_deltas["function_call"]
             and accumulated_deltas["function_call"]["arguments"]
         ):
-            
             if (
                 "name" in accumulated_deltas["function_call"]
                 and accumulated_deltas["function_call"]["name"] == "execute"
             ):
                 arguments = accumulated_deltas["function_call"]["arguments"]
-                
                 arguments = parse_partial_json(arguments)
 
                 if arguments:

--- a/interpreter/core/llm/run_function_calling_llm.py
+++ b/interpreter/core/llm/run_function_calling_llm.py
@@ -1,6 +1,5 @@
 from .utils.merge_deltas import merge_deltas
 from .utils.parse_partial_json import parse_partial_json
-import json
 
 function_schema = {
     "name": "execute",

--- a/interpreter/core/llm/run_function_calling_llm.py
+++ b/interpreter/core/llm/run_function_calling_llm.py
@@ -1,5 +1,6 @@
 from .utils.merge_deltas import merge_deltas
 from .utils.parse_partial_json import parse_partial_json
+import json
 
 function_schema = {
     "name": "execute",
@@ -47,7 +48,7 @@ def run_function_calling_llm(llm, request_params):
             continue
 
         delta = chunk["choices"][0]["delta"]
-
+      
         # Accumulate deltas
         accumulated_deltas = merge_deltas(accumulated_deltas, delta)
 
@@ -57,12 +58,15 @@ def run_function_calling_llm(llm, request_params):
         if (
             accumulated_deltas.get("function_call")
             and "arguments" in accumulated_deltas["function_call"]
+            and accumulated_deltas["function_call"]["arguments"]
         ):
+            
             if (
                 "name" in accumulated_deltas["function_call"]
                 and accumulated_deltas["function_call"]["name"] == "execute"
             ):
                 arguments = accumulated_deltas["function_call"]["arguments"]
+                
                 arguments = parse_partial_json(arguments)
 
                 if arguments:

--- a/interpreter/core/llm/utils/merge_deltas.py
+++ b/interpreter/core/llm/utils/merge_deltas.py
@@ -9,7 +9,7 @@ def merge_deltas(original, delta):
         if value != None:
             if isinstance(value, str):
                 if key in original:
-                    original[key] += value
+                    original[key] = (original[key] or "") + (value or "")
                 else:
                     original[key] = value
             else:

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -83,7 +83,7 @@ def start_terminal_interface(interpreter):
             "name": "llm_supports_functions",
             "nickname": "lsf",
             "help_text": "inform OI that your model supports OpenAI-style functions, and can make function calls",
-            "type": bool,
+            "type": lambda s: s.lower() in ['true', 't', 'yes', '1'],
             "attribute": {"object": interpreter.llm, "attr_name": "supports_functions"},
         },
         {

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -83,7 +83,8 @@ def start_terminal_interface(interpreter):
             "name": "llm_supports_functions",
             "nickname": "lsf",
             "help_text": "inform OI that your model supports OpenAI-style functions, and can make function calls",
-            "type": lambda s: s.lower() in ['true', 't', 'yes', '1'],
+            "type": bool,
+            "action": argparse.BooleanOptionalAction,
             "attribute": {"object": interpreter.llm, "attr_name": "supports_functions"},
         },
         {


### PR DESCRIPTION
### Describe the changes you have made:

1. Fix `merge_delta` error while trying to concatenate None value to str.
2. Add an argument `--no_llm_supports_function_calls`. 
   Some of Azure OpenAI models don't support functions calling. 
   Current implementation logic to auto detect function-calling support is based on name matching. If a model is wrongly detected as supporting function_calls, it will throw error when it aptampts to execute code.

### Reference any relevant issues (e.g. "Fixes #000"):
Fixes 
#919 
#899 

### Pre-Submission Checklist (optional but appreciated):

- [ x] I have included relevant documentation updates (stored in /docs)
- [ x] I have read `docs/CONTRIBUTING.md`
- [ x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
