### PR TITLE
Update local model docs

### DIFF
--- a/docs/language-model-setup/local-models/llamafile.mdx
+++ b/docs/language-model-setup/local-models/llamafile.mdx
@@ -19,7 +19,7 @@ chmod +x mixtral-8x7b-instruct-v0.1.Q5_K_M-server.llamafile
 
 # In a separate terminal window, run OI and point it at the llamafile server
 
-interpreter --api_base https://localhost:8080
+interpreter --api_base https://localhost:8080/v1
 ```
 
 Please note that if you are using a Mac with Apple Silicon, you'll need to have Xcode installed.

--- a/docs/language-model-setup/local-models/ollama.mdx
+++ b/docs/language-model-setup/local-models/ollama.mdx
@@ -21,7 +21,7 @@ ollama run <model-name>
 <CodeGroup>
 
 ```bash Terminal
-interpreter --model ollama/<model-name> --api_base http://localhost:11434
+interpreter --model ollama/<model-name>
 ```
 
 ```python Python

--- a/docs/language-model-setup/local-models/ollama.mdx
+++ b/docs/language-model-setup/local-models/ollama.mdx
@@ -21,7 +21,7 @@ ollama run <model-name>
 <CodeGroup>
 
 ```bash Terminal
-interpreter --model ollama_chat/<model-name> --api_base http://localhost:11434
+interpreter --model ollama/<model-name> --api_base http://localhost:11434
 ```
 
 ```python Python


### PR DESCRIPTION
### Describe the changes you have made:
Updated the ollama docs for an updated command.

I've just been using `ollama` without issue and someone in the Discord had issues with `ollama_chat` which was resolved by changing to `ollama`.

You no longer need the --api-base argument when connecting to a local Ollama model endpoint because LiteLLM will automatically handle it.

llamafile path needed to have `/v1` at the end

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
