### PR TITLE
Fix: NameError: name 'computer' is not defined

### DIFF
--- a/interpreter/core/computer/terminal/terminal.py
+++ b/interpreter/core/computer/terminal/terminal.py
@@ -37,7 +37,7 @@ class Terminal:
         # If stream == False, *pull* from the stream.
         if stream == False:
             output_messages = []
-            for chunk in self._streaming_chat(language, code, stream=True):
+            for chunk in self.run(language, code, stream=True):
                 if chunk.get("format") != "active_line":
                     # Should we append this to the last message, or make a new one?
                     if (

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 import platform
-import re
 import subprocess
 import sys
 import time

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -541,11 +541,12 @@ Include `computer.display.view()` after a 2 second delay at the end of _every_ c
         #         print(chunk.get("content"))
 
         # Give it access to the computer via Python
-        interpreter.computer.run(
+        for _ in interpreter.computer.run(
             "python",
             "import time\nfrom interpreter import interpreter\ncomputer = interpreter.computer",  # We ask it to use time, so
             display=args.verbose,
-        )
+        ):
+            pass
 
         if not args.auto_run:
             display_markdown_message(

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -299,7 +299,7 @@ def start_terminal_interface(interpreter):
 
         config_directory = os.path.dirname(config_file)
 
-        print(f"Opening config directory...")
+        print("Opening config directory...")
 
         if platform.system() == "Windows":
             os.startfile(config_directory)
@@ -590,7 +590,7 @@ Once the server is running, you can begin your conversation below.
         else:
             if args.vision:
                 display_markdown_message(
-                    f"> `Local Vision` enabled (experimental)\n\nEnsure LM Studio's local server is running in the background **and using a vision-compatible model**.\n\nRun `interpreter --local` with no other arguments for a setup guide.\n"
+                    "> `Local Vision` enabled (experimental)\n\nEnsure LM Studio's local server is running in the background **and using a vision-compatible model**.\n\nRun `interpreter --local` with no other arguments for a setup guide.\n"
                 )
                 time.sleep(1)
                 display_markdown_message("---\n")
@@ -600,12 +600,12 @@ Once the server is running, you can begin your conversation below.
                 time.sleep(2.5)
                 display_markdown_message("---")
                 display_markdown_message(
-                    f"> `Local Vision` enabled (experimental)\n\nEnsure LM Studio's local server is running in the background **and using a vision-compatible model**.\n\nRun `interpreter --local` with no other arguments for a setup guide.\n"
+                    "> `Local Vision` enabled (experimental)\n\nEnsure LM Studio's local server is running in the background **and using a vision-compatible model**.\n\nRun `interpreter --local` with no other arguments for a setup guide.\n"
                 )
             else:
                 time.sleep(1)
                 display_markdown_message(
-                    f"> `Local Mode` enabled (experimental)\n\nEnsure LM Studio's local server is running in the background.\n\nRun `interpreter --local` with no other arguments for a setup guide.\n"
+                    "> `Local Mode` enabled (experimental)\n\nEnsure LM Studio's local server is running in the background.\n\nRun `interpreter --local` with no other arguments for a setup guide.\n"
                 )
 
     # Check for update
@@ -630,7 +630,7 @@ Once the server is running, you can begin your conversation below.
 
     # Set attributes on interpreter
     for argument_name, argument_value in vars(args).items():
-        if argument_value != None:
+        if argument_value is not None:
             argument_dictionary = [a for a in arguments if a["name"] == argument_name]
             if len(argument_dictionary) > 0:
                 argument_dictionary = argument_dictionary[0]


### PR DESCRIPTION
### Describe the changes you have made:
The `run` method in the `Terminal` class is a generator function that executes some code and yields the results one at a time. In a previous commit, the for loop was removed that was used to iterate over these results, which caused the `run` method to not actually be executed because its results were not being consumed. This commit adds the for loop back to ensure that the `run` method is properly executed.

### Reference any relevant issues (e.g. "Fixes #000"):
https://github.com/KillianLucas/open-interpreter/issues/875


### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
