### PR TITLE
Fix the conversation restoration problem in version 0.2.0 New Computer

### DIFF
--- a/interpreter/terminal_interface/conversation_navigator.py
+++ b/interpreter/terminal_interface/conversation_navigator.py
@@ -64,6 +64,10 @@ def conversation_navigator(interpreter):
     ]
     answers = inquirer.prompt(questions)
 
+    # User chose to exit
+    if not answers:
+        return
+
     # If the user selected to open the folder, do so and return
     if answers["name"] == "> Open folder":
         open_folder(conversations_dir)

--- a/interpreter/terminal_interface/conversation_navigator.py
+++ b/interpreter/terminal_interface/conversation_navigator.py
@@ -15,9 +15,6 @@ from .utils.local_storage_path import get_storage_path
 
 
 def conversation_navigator(interpreter):
-    # print(
-    #     "This feature is not working as of 0.2.0 (The New Computer Update). Please consider submitting a PR to repair it with the new streaming format."
-    # )
     import time
 
     time.sleep(5)

--- a/interpreter/terminal_interface/conversation_navigator.py
+++ b/interpreter/terminal_interface/conversation_navigator.py
@@ -15,9 +15,9 @@ from .utils.local_storage_path import get_storage_path
 
 
 def conversation_navigator(interpreter):
-    print(
-        "This feature is not working as of 0.2.0 (The New Computer Update). Please consider submitting a PR to repair it with the new streaming format."
-    )
+    # print(
+    #     "This feature is not working as of 0.2.0 (The New Computer Update). Please consider submitting a PR to repair it with the new streaming format."
+    # )
     import time
 
     time.sleep(5)

--- a/interpreter/terminal_interface/render_past_conversation.py
+++ b/interpreter/terminal_interface/render_past_conversation.py
@@ -16,26 +16,27 @@ def render_past_conversation(messages):
     render_cursor = False
     ran_code_block = False
 
+    print(messages)
     for chunk in messages:
         # Only addition to the terminal interface:
         if chunk["role"] == "user":
             if active_block:
                 active_block.end()
                 active_block = None
-            print(">", chunk["message"])
+            print(">", chunk["content"])
             continue
 
         # Message
-        if "message" in chunk:
+        if chunk["type"] == "message":
             if active_block is None:
                 active_block = MessageBlock()
             if active_block.type != "message":
                 active_block.end()
                 active_block = MessageBlock()
-            active_block.message += chunk["message"]
+            active_block.message += chunk["content"]
 
         # Code
-        if "code" in chunk or "language" in chunk:
+        if chunk["type"] == "code":
             if active_block is None:
                 active_block = CodeBlock()
             if active_block.type != "code" or ran_code_block:
@@ -46,18 +47,18 @@ def render_past_conversation(messages):
             ran_code_block = False
             render_cursor = True
 
-        if "language" in chunk:
-            active_block.language = chunk["language"]
-        if "code" in chunk:
-            active_block.code += chunk["code"]
-        if "active_line" in chunk:
-            active_block.active_line = chunk["active_line"]
+            if "format" in chunk:
+                active_block.language = chunk["format"]
+            if "content" in chunk:
+                active_block.code += chunk["content"]
+            if "active_line" in chunk:
+                active_block.active_line = chunk["active_line"]
 
-        # Output
-        if "output" in chunk:
+        # Console
+        if chunk["type"] == "console":
             ran_code_block = True
             render_cursor = False
-            active_block.output += "\n" + chunk["output"]
+            active_block.output += "\n" + chunk["content"]
             active_block.output = active_block.output.strip()  # <- Aesthetic choice
 
         if active_block:

--- a/interpreter/terminal_interface/render_past_conversation.py
+++ b/interpreter/terminal_interface/render_past_conversation.py
@@ -16,7 +16,6 @@ def render_past_conversation(messages):
     render_cursor = False
     ran_code_block = False
 
-    print(messages)
     for chunk in messages:
         # Only addition to the terminal interface:
         if chunk["role"] == "user":


### PR DESCRIPTION
### Describe the changes you have made:
Fix the conversation restoration function with argument `--conversations` by updating rander_past_conversation logic.

### Reference any relevant issues (e.g. "Fixes #000"):
Fixes #962

### Pre-Submission Checklist (optional but appreciated):

- [x]  I have included relevant documentation updates (stored in /docs)
- [x]  I have read `docs/CONTRIBUTING.md`
- [x]  I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [x]  Tested on MacOS
- [x]  Tested on Linux
