### PR TITLE
Option to pass paths to docs.search

### DIFF
--- a/interpreter/core/computer/docs/docs.py
+++ b/interpreter/core/computer/docs/docs.py
@@ -8,13 +8,16 @@ class Docs:
     def __init__(self, computer):
         self.computer = computer
 
-    def search(self, query, module=None):
-        if module == None:
+    def search(self, query, module=None, paths=None):
+        if paths:
+            return search(query, file_paths=paths, python_docstrings_only=True)
+
+        if module is None:
             module = self.computer
 
         # Get the path of the module
         module_path = os.path.dirname(inspect.getfile(module.__class__))
 
         # Use aifs to search over the files in the module path
-        results = search(query, module_path, python_docstrings_only=True)
+        results = search(query, path=module_path, python_docstrings_only=True)
         return results


### PR DESCRIPTION
### Describe the changes you have made:
aifs was updated to support passing file paths, so this updates the `search` function using it to also support it.

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [ ] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
