### PR TITLE
fix parsing of a function

### DIFF
--- a/interpreter/core/computer/terminal/languages/jupyter_language.py
+++ b/interpreter/core/computer/terminal/languages/jupyter_language.py
@@ -415,10 +415,12 @@ def string_to_python(code_as_string):
             if docstring:
                 body = body[1:]
 
+            code_body = ast.unparse(body[0]).replace("\n", "\n    ")
+
             func_info = {
                 "name": node.name,
                 "docstring": docstring,
-                "body": "\n    ".join(ast.unparse(stmt) for stmt in body),
+                "body": code_body,
             }
             functions.append(func_info)
 

--- a/interpreter/core/computer/terminal/languages/jupyter_language.py
+++ b/interpreter/core/computer/terminal/languages/jupyter_language.py
@@ -75,18 +75,15 @@ matplotlib.use('{backend}')
             functions = {}
 
         if self.computer.save_skills and functions:
-            skill_library_path = self.computer.skills.path
+            skill_library_path = self.computer.skills.skills_dir
 
             if not os.path.exists(skill_library_path):
                 os.makedirs(skill_library_path)
 
-            for filename, code in functions.items():
+            for filename, function_code in functions.items():
                 with open(f"{skill_library_path}/{filename}.py", "w") as file:
-                    file.write(code)
+                    file.write(function_code)
 
-        # lel
-        # exec(code)
-        # return
         self.finish_flag = False
         try:
             try:
@@ -413,12 +410,15 @@ def string_to_python(code_as_string):
             if node.name.startswith("_"):
                 # ignore private functions
                 continue
+            docstring = ast.get_docstring(node)
+            body = node.body
+            if docstring:
+                body = body[1:]
+
             func_info = {
                 "name": node.name,
-                "docstring": ast.get_docstring(node),
-                "body": "\n    ".join(
-                    ast.unparse(stmt) for stmt in node.body[1:]
-                ),  # Excludes the docstring
+                "docstring": docstring,
+                "body": "\n    ".join(ast.unparse(stmt) for stmt in body),
             }
             functions.append(func_info)
 


### PR DESCRIPTION
### Describe the changes you have made:
- Fixes the parsing of a function when there's no docstring
- use `function_name` instead of `code` to avoid overwriting existing variable
- use `skills.skills_dir` instead of `skills.path`

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [ ] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
