### PR TITLE
Add deployment_id parameter for Azure models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,7 +151,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # General
 .DS_Store

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -183,11 +183,6 @@ Continuing...
             params["api_key"] = self.api_key
         if self.api_base:
             params["api_base"] = self.api_base
-            # if model is azure, set the deployment_id
-            if self.model.startswith("azure/"):
-                params["deployment_id"] = self.model.split("/").pop()
-            else:
-                params["custom_llm_provider"] = "openai"
         if self.api_version:
             params["api_version"] = self.api_version
         if self.max_tokens:

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -174,6 +174,7 @@ Continuing...
             # if model is azure, set the deployment_id and model
             if self.model.startswith("azure/"):
                 params["deployment_id"] = self.model.split("/").pop()
+                params["model"] = params["deployment_id"]
             # otherwise, set only the model
             else:
                 params["model"] = self.model

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -171,10 +171,10 @@ Continuing...
         }
 
         if self.model:
-            # if model is azure, set the deployment_id instead of model
+            # if model is azure, set the deployment_id and model
             if self.model.startswith("azure/"):
                 params["deployment_id"] = self.model.split("/").pop()
-            # otherwise, set the model
+            # otherwise, set only the model
             else:
                 params["model"] = self.model
 

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -176,7 +176,11 @@ Continuing...
             params["api_key"] = self.api_key
         if self.api_base:
             params["api_base"] = self.api_base
-            params["custom_llm_provider"] = "openai"
+            # if model is azure, set the deployment_id
+            if self.model.startswith("azure/"):
+                params["deployment_id"] = self.model.split("/").pop()
+            else:
+                params["custom_llm_provider"] = "openai"
         if self.api_version:
             params["api_version"] = self.api_version
         if self.max_tokens:

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -166,10 +166,17 @@ Continuing...
         ## Start forming the request
 
         params = {
-            "model": self.model,
             "messages": messages,
             "stream": True,
         }
+
+        if self.model:
+            # if model is azure, set the deployment_id instead of model
+            if self.model.startswith("azure/"):
+                params["deployment_id"] = self.model.split("/").pop()
+            # otherwise, set the model
+            else:
+                params["model"] = self.model
 
         # Optional inputs
         if self.api_key:


### PR DESCRIPTION
### Describe the changes you have made:

Fixed an issue where Open Interpreter would fail to chat when an Azure model is specified. The cause was that the Open Interpreter uses the [litellm library](https://github.com/BerriAI/litellm), which has a parameter called `deployment_id`. Setting this parameter allows switching to Azure (see [source code](https://github.com/BerriAI/litellm/blob/58fb6b2b5924041880b9aca1a7f653653a3527a4/litellm/main.py#L593-L595)). However, the current Open Interpreter lacks the logic to set the `deployment_id` parameter, resulting in failed requests to Azure. To resolve this issue, logic has been added to set the `deployment_id` parameter when an Azure model is specified (`model == "azure/{deployment_id}"`).

### Reference any relevant issues (e.g. "Fixes #000"):

No specific issue referenced. This is a general improvement to support Azure models in Open Interpreter.

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
