### PR TITLE
Multi-line input support.

### DIFF
--- a/docs/usage/terminal/arguments.mdx
+++ b/docs/usage/terminal/arguments.mdx
@@ -16,7 +16,7 @@ title: Arguments
 
 **[Options](/docs/usage/terminal/arguments#options)**
 
-`--safe_mode`, `--auto_run`, `--force_task_completion`, `--verbose`, `--max_budget`, `--speak_messages`.
+`--safe_mode`, `--auto_run`, `--force_task_completion`, `--verbose`, `--max_budget`, `--speak_messages`, `--multi_line`.
 
 **[Other](/docs/usage/terminal/arguments#other)**
 
@@ -414,6 +414,21 @@ interpreter --speak_messages
 
 ```yaml Config
 speak_messages: true
+```
+
+</CodeGroup>
+
+#### `--multi_line` or `-ml`
+
+Enable multi-line inputs starting and ending with ` ``` `
+
+<CodeGroup>
+```bash Terminal
+interpreter --multi_line
+```
+
+```yaml Config
+multi_line: true
 ```
 
 </CodeGroup>

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -64,6 +64,7 @@ class OpenInterpreter:
         import_computer_api=True,
         skills_path=None,
         import_skills=True,
+        multi_line=False,
     ):
         # State
         self.messages = [] if messages is None else messages
@@ -80,6 +81,7 @@ class OpenInterpreter:
         self.force_task_completion = force_task_completion
         self.anonymous_telemetry = anonymous_telemetry
         self.in_terminal_interface = in_terminal_interface
+        self.multi_line = multi_line
 
         # Conversation history
         self.conversation_history = conversation_history

--- a/interpreter/terminal_interface/profiles/defaults/default.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/default.yaml
@@ -15,6 +15,7 @@ llm:
 # safe_mode: "off"  # The safety mode for the LLM — one of "off", "ask", "auto"
 # offline: False  # If True, will disable some online features like checking for updates
 # verbose: False  # If True, will print detailed logs
+# multi_line: False # If True, you can input multiple lines starting and ending with ```
 
 # All options: https://docs.openinterpreter.com/settings
 

--- a/interpreter/terminal_interface/profiles/defaults/fast.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/fast.yaml
@@ -15,6 +15,7 @@ custom_instructions: "The user has set you to FAST mode. **No talk, just code.**
 # safe_mode: "off"  # The safety mode for the LLM — one of "off", "ask", "auto"
 # offline: False  # If True, will disable some online features like checking for updates
 # verbose: False  # If True, will print detailed logs
+# multi_line: False # If True, you can input multiple lines starting and ending with ```
 
 # All options: https://docs.openinterpreter.com/settings
 

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -178,6 +178,13 @@ def start_terminal_interface(interpreter):
             "type": bool,
         },
         {
+            "name": "multi_line",
+            "nickname": "ml",
+            "help_text": "enable multi-line inputs starting and ending with ```",
+            "type": bool,
+            "attribute": {"object": interpreter, "attr_name": "multi_line"},
+        },
+        {
             "name": "local",
             "nickname": "l",
             "help_text": "experimentally run the LLM locally via LM Studio (this changes many more settings than `--offline`)",

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -25,6 +25,7 @@ from .utils.check_for_package import check_for_package
 from .utils.display_markdown_message import display_markdown_message
 from .utils.display_output import display_output
 from .utils.find_image_path import find_image_path
+from .utils.cli_input import cli_input
 
 # Add examples to the readline history
 examples = [
@@ -75,7 +76,7 @@ def terminal_interface(interpreter, message):
         try:
             if interactive:
                 ### This is the primary input for Open Interpreter.
-                message = input("> ").strip()
+                message = cli_input("> ").strip()
 
                 try:
                     # This lets users hit the up arrow key for past messages

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -76,7 +76,7 @@ def terminal_interface(interpreter, message):
         try:
             if interactive:
                 ### This is the primary input for Open Interpreter.
-                message = cli_input("> ").strip()
+                message = cli_input("> ").strip() if interpreter.multi_line else input("> ").strip()
 
                 try:
                     # This lets users hit the up arrow key for past messages

--- a/interpreter/terminal_interface/utils/cli_input.py
+++ b/interpreter/terminal_interface/utils/cli_input.py
@@ -1,0 +1,17 @@
+def cli_input(prompt: str = "") -> str:
+    start_marker = "```"
+    end_marker = "```"
+    message = input(prompt)
+
+    # Multi-line input mode
+    if start_marker in message:
+        lines = [message]
+        while True:
+            line = input()
+            lines.append(line)
+            if end_marker in line:
+                break
+        return "\n".join(lines)
+
+    # Single-line input mode
+    return message


### PR DESCRIPTION
### Describe the changes you have made:
Support multi-line input by defining the function `cli_input`, which detects special combo (`start_marker`) in user's input like ` ``` ` to await more input until get an another special combo (`end_marker`). In this way, users can input multiple lines at one single input, which is very helpful when the users try to chat about pieces of code copied from their text editors. To enable this new feature, you can use `interpreter --multi_line` or `interpreter -ml` to launch OI, or you can simply set `multi_line: True` in your profile.

Although this new feature is ready to go for most cases, there's still some improvements can be done:
1. If the multi-line part contains the `end_marker` string, it will cause an unexpected ending of the current input, which means you can't have ` ``` ` contained in your multi-line inputs.
2. This new feature can be mis-triggered and get users trapped in the multi-line input loop. (This one is not a problem for now because this new feature is disabled by default in args.)

Here's an example, the first conversation was launched with this new feature disabled by default, and the second one was launched with this new feature enabled:
<img width="2141" alt="截屏2024-03-02 01 26 50" src="https://github.com/KillianLucas/open-interpreter/assets/84221016/40c9c57e-176b-42a5-b67a-b7369b02f36b">

### Reference any relevant issues (e.g. "Fixes #000"):
#1046 
### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [x] Tested on MacOS
- [x] Tested on Linux
