### PR TITLE
fix some error when start command on macos 

### DIFF
--- a/interpreter/terminal_interface/profiles/defaults/local.py
+++ b/interpreter/terminal_interface/profiles/defaults/local.py
@@ -43,7 +43,7 @@ if platform.system() != "Windows":
 
 # Run the new llamafile in the background
 if os.path.exists(llamafile_path):
-    subprocess.Popen([llamafile_path, "-ngl", "9999"])
+    subprocess.Popen(f'"{llamafile_path}" ' + ' '.join(["-ngl", "9999"]), shell=True)
 else:
     error_message = "The llamafile does not exist or is corrupted. Please ensure it has been downloaded correctly or try again."
     print(error_message)


### PR DESCRIPTION
### Describe the changes you have made:

when run local model in macos(m2 arm),  maybe occur exec format error, i need Popen with shell=True,  but when model path contain space (like me, my oi_dir is '/Users/lishuo121/Library/Application Support/open-interpreter/models/phi-2.Q5_K_M.llamafile') that not find err will occured, so i do some change to issue this problem.

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
