### PR TITLE
Fix markdown in README_JA.md: Correct code block language and command…

### DIFF
--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -203,14 +203,14 @@ Open Interpreter は、OpenAI 互換サーバーを使用してモデルをロ�
 
 推論サーバーの api_base URL を指定して「interpreter」を実行するだけです (LM Studio の場合、デフォルトでは「http://localhost:1234/v1」です)。
 
-```シェル
-インタープリター --api_base "http://localhost:1234/v1" --api_key "fake_key"
+```shell
+interpreter --api_base "http://localhost:1234/v1" --api_key "fake_key"
 ```
 
 あるいは、サードパーティのソフトウェアをインストールせずに、単に実行するだけで Llamafile を使用することもできます。
 
-```シェル
-インターピーター --local
+```shell
+interpreter --local
 ```
 
 より詳細なガイドについては、[Mike Bird によるこのビデオ](https://www.youtube.com/watch?v=CEs51hGWuGU?si=cN7f6QhfT4edfG5H) をご覧ください。


### PR DESCRIPTION
## Corrections to Markdown in README_JA.md

### Changes
This Pull Request introduces corrections in `README_JA.md` focusing on the following two points:

1. **Code Block Language Specification Correction**
    - Before: The language specification in code blocks was in katakana, "シェル."
    - After: Corrected to the appropriate language specification "shell."

2. **Command Notation in English**
    - Before: The `interpreter` command was written in katakana.
    - After: Corrected the `interpreter` command notation to English.

### Purpose
These corrections aim to improve the readability and accuracy of `README_JA.md`. Specifically, accurate language specification for code blocks is intended to ensure proper Markdown rendering, making the content more comprehensible to readers.

### Additional Notes
If you have any questions or suggestions regarding these corrections, please feel free to leave a comment. We welcome your feedback.

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux

-> No tests have been run due to changes in documentation only.