### PR TITLE
Clear messages on %reset instead of instantiating a new Interpreter

### DIFF
--- a/docs/usage/terminal/magic-commands.mdx
+++ b/docs/usage/terminal/magic-commands.mdx
@@ -4,9 +4,9 @@ title: Magic Commands
 
 Magic commands can be used to control the interpreter's behavior in interactive mode:
 
-- `%% [commands]`: Run commands in system shell
+- `%% [commands]`: Run commands in system shell.
 - `%verbose [true/false]`: Toggle verbose mode. Without arguments or with 'true', it enters verbose mode. With 'false', it exits verbose mode.
-- `%reset`: Reset the current session
+- `%reset`: Resets the current session's conversation.
 - `%undo`: Remove previous messages and its response from the message history.
 - `%save_message [path]`: Saves messages to a specified JSON path. If no path is provided, it defaults to 'messages.json'.
 - `%load_message [path]`: Loads messages from a specified JSON path. If no path is provided, it defaults to 'messages.json'.

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -352,7 +352,7 @@ class OpenInterpreter:
 
     def reset(self):
         self.computer.terminate()  # Terminates all languages
-        self.__init__()
+        self.messages = []
 
     def display_message(self, markdown):
         # This is just handy for start_script in profiles.

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -353,6 +353,7 @@ class OpenInterpreter:
     def reset(self):
         self.computer.terminate()  # Terminates all languages
         self.messages = []
+        self.last_messages_count = 0
 
     def display_message(self, markdown):
         # This is just handy for start_script in profiles.


### PR DESCRIPTION
### Describe the changes you have made:
Instead of `self.__init__()` where all parameters are cleared, now `self.messages =[]` is ran, which will clear all the messages of the conversation but will preserve the parameters, such as `api_base`, `api_key`, and more. 

### Outstanding question
This does not clear the conversation history when `conversation_history=True`. That can be added easily. Is that expected behaviour?

### Reference any relevant issues (e.g. "Fixes #000"):
https://github.com/KillianLucas/open-interpreter/issues/1090

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
