### PR TITLE
Enhance integration capabilities by enabling passing of initial prompt to LLM from command line

### DIFF
--- a/docs/settings/all-settings.mdx
+++ b/docs/settings/all-settings.mdx
@@ -523,6 +523,18 @@ system_message: "You are Open Interpreter..."
 
 </CodeGroup>
 
+### Load Message
+
+You can pass the first prompt at startup via a text file. This is achieved by using the `--load_message` flag.
+
+<CodeGroup>
+
+```bash Terminal
+interpreter --load_message prompt.txt
+```
+
+</CodeGroup>
+
 ### Disable Telemetry
 
 Opt out of [telemetry](telemetry/telemetry).

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -137,7 +137,7 @@ class OpenInterpreter:
         # Return new messages
         return self.messages[self.last_messages_count :]
 
-    def chat(self, message=None, display=True, stream=False, blocking=True):
+    def chat(self, message=None, display=True, stream=False, blocking=True, loaded_message=None):
         try:
             self.responding = True
             if self.anonymous_telemetry and not self.offline:
@@ -161,10 +161,10 @@ class OpenInterpreter:
                 return
 
             if stream:
-                return self._streaming_chat(message=message, display=display)
+                return self._streaming_chat(message=message, display=display, loaded_message=loaded_message)
 
             # If stream=False, *pull* from the stream.
-            for _ in self._streaming_chat(message=message, display=display):
+            for _ in self._streaming_chat(message=message, display=display, loaded_message=loaded_message):
                 pass
 
             # Return new messages
@@ -187,13 +187,13 @@ class OpenInterpreter:
 
             raise
 
-    def _streaming_chat(self, message=None, display=True):
+    def _streaming_chat(self, message=None, display=True, loaded_message=None):
         # Sometimes a little more code -> a much better experience!
         # Display mode actually runs interpreter.chat(display=False, stream=True) from within the terminal_interface.
         # wraps the vanilla .chat(display=False) generator in a display.
         # Quite different from the plain generator stuff. So redirect to that
         if display:
-            yield from terminal_interface(self, message)
+            yield from terminal_interface(self, message, loaded_message)
             return
 
         # One-off message

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -137,7 +137,7 @@ class OpenInterpreter:
         # Return new messages
         return self.messages[self.last_messages_count :]
 
-    def chat(self, message=None, display=True, stream=False, blocking=True, loaded_message=None):
+    def chat(self, message=None, display=True, stream=False, blocking=True):
         try:
             self.responding = True
             if self.anonymous_telemetry and not self.offline:
@@ -161,10 +161,10 @@ class OpenInterpreter:
                 return
 
             if stream:
-                return self._streaming_chat(message=message, display=display, loaded_message=loaded_message)
+                return self._streaming_chat(message=message, display=display)
 
             # If stream=False, *pull* from the stream.
-            for _ in self._streaming_chat(message=message, display=display, loaded_message=loaded_message):
+            for _ in self._streaming_chat(message=message, display=display):
                 pass
 
             # Return new messages
@@ -187,13 +187,13 @@ class OpenInterpreter:
 
             raise
 
-    def _streaming_chat(self, message=None, display=True, loaded_message=None):
+    def _streaming_chat(self, message=None, display=True):
         # Sometimes a little more code -> a much better experience!
         # Display mode actually runs interpreter.chat(display=False, stream=True) from within the terminal_interface.
         # wraps the vanilla .chat(display=False) generator in a display.
         # Quite different from the plain generator stuff. So redirect to that
         if display:
-            yield from terminal_interface(self, message, loaded_message)
+            yield from terminal_interface(self, message)
             return
 
         # One-off message

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -233,6 +233,12 @@ def start_terminal_interface(interpreter):
             "help_text": "get Open Interpreter's version number",
             "type": bool,
         },
+        {
+            "name": "load_message",
+            "help_text": "load a first prompt from a file",
+            "type": str,
+            "default": None,
+        },
     ]
 
     # Check for deprecated flags before parsing arguments
@@ -386,11 +392,16 @@ def start_terminal_interface(interpreter):
         interpreter.server()
         return
 
+    loaded_message = None
+    if args.load_message:
+        with open(args.load_message, "r") as f:
+            loaded_message = f.read()
+
     validate_llm_settings(interpreter)
 
     interpreter.in_terminal_interface = True
 
-    interpreter.chat()
+    interpreter.chat(loaded_message=loaded_message)
 
 
 def set_attributes(args, arguments):

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -400,8 +400,7 @@ def start_terminal_interface(interpreter):
     validate_llm_settings(interpreter)
 
     interpreter.in_terminal_interface = True
-
-    interpreter.chat(loaded_message=loaded_message)
+    interpreter.chat(message=loaded_message)
 
 
 def set_attributes(args, arguments):

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -43,11 +43,13 @@ except:
     # If they don't have readline, that's fine
     pass
 
+def has_loaded_message(interpreter, message):
+    return bool(message) and len(interpreter.messages) == 0
+
 
 def terminal_interface(
         interpreter,
         message,
-        loaded_message: str = None,
     ):
     # Auto run and offline (this.. this isnt right) don't display messages.
     # Probably worth abstracting this to something like "debug_cli" at some point.
@@ -72,6 +74,8 @@ def terminal_interface(
         interactive = False
     else:
         interactive = True
+    if has_loaded_message(interpreter, message):
+        interactive = True
 
     active_block = None
     voice_subprocess = None
@@ -80,9 +84,7 @@ def terminal_interface(
         try:
             if interactive:
                 ### This is the primary input for Open Interpreter.
-                if loaded_message and len(interpreter.messages) == 0: # When the first chat, interpreter has no messages
-                    message = loaded_message
-                else:
+                if not has_loaded_message(interpreter, message): # When the first chat, interpreter has no messages
                     message = cli_input("> ").strip() if interpreter.multi_line else input("> ").strip()
 
                 try:

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -44,7 +44,11 @@ except:
     pass
 
 
-def terminal_interface(interpreter, message):
+def terminal_interface(
+        interpreter,
+        message,
+        loaded_message: str = None,
+    ):
     # Auto run and offline (this.. this isnt right) don't display messages.
     # Probably worth abstracting this to something like "debug_cli" at some point.
     if not interpreter.auto_run and not interpreter.offline:
@@ -76,7 +80,10 @@ def terminal_interface(interpreter, message):
         try:
             if interactive:
                 ### This is the primary input for Open Interpreter.
-                message = cli_input("> ").strip() if interpreter.multi_line else input("> ").strip()
+                if loaded_message and len(interpreter.messages) == 0: # When the first chat, interpreter has no messages
+                    message = loaded_message
+                else:
+                    message = cli_input("> ").strip() if interpreter.multi_line else input("> ").strip()
 
                 try:
                     # This lets users hit the up arrow key for past messages


### PR DESCRIPTION
### Describe the changes you have made:
I have added the ability to pass initial prompts from the command line to the LLM to improve integration with other files and processes.

For example, when I write DDL in a web application, I can make the work more routine to have the model file and its tests written.

Here is what I do when I am developing a Rails application.
After writing the DDL, I create the model files, add validation, write mock, and add type information for GraphQL.

<details>
<summary>exmaple(click me)</summary>

```shell
$ cat db/schemata/books.schema
create_table "books" do |t|
  t.string 'title'
  t.timestamps
end

$ TABLE="books.schema" bundle exec rake llm:generate
$ cat prompt.txt
    I am developing a web service using Rails, ridgepole, and graphql-ruby.
    Please read db/schemata/#{model_name}.schema and carry out the following tasks:

    - Create a model file in app/models
    - Create a GraphQL type file in app/graphql/types
    - Create a mock using FactoryBot in spec/factories

    For example, if the schema is db/schemata/quests.schema,

    create_table 'quests',
                 id: :integer,
                 unsigned: true,
                 force: :cascade,
                 options: 'ENGINE=InnoDB' do |t|
      t.string 'title', null: false
      t.text 'description', null: false

      t.bigint 'user_id', null: false, unsigned: true
      t.bigint 'category_id', null: false, unsigned: true

      t.datetime 'start_at', null: false
      t.datetime 'end_at', null: false

      t.timestamps

      t.index ['category_id']
    end

    Then the following should be created:

    ## Create a model file in app/models

    Create app/models/quest.rb with,

    # frozen_string_literal: true

    class Quest < ApplicationRecord
      belongs_to :user
      belongs_to :category

      validates :title, presence: true
      validates :description, presence: true
      validates :start_at, presence: true
      validates :end_at, presence: true
    end

    written inside.

    ## Create a GraphQL type file in app/graphql/types

    Create app/graphql/types/quest_type.rb with,

    # frozen_string_literal: true

    module Types
      class QuestType < Types::BaseObject
        field :id, Integer, null: false

        field :description, String, null: false
        field :title, String, null: false

        field :category, Types::CategoryType, null: false
        field :user, Types::UserType, null: false

        field :end_at, GraphQL::Types::ISO8601DateTime, null: false
        field :start_at, GraphQL::Types::ISO8601DateTime, null: false

        field :created_at, GraphQL::Types::ISO8601DateTime, null: false
        field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
      end
    end

    written inside.

    ## Create a mock using FactoryBot in spec/factories

    Create spec/factories/quests.rb with,

    # frozen_string_literal: true

    FactoryBot.define do
      factory :quest do
        title { 'MyString' }
        description { 'MyText' }

        start_at { Time.zone.now - 1.year }
        end_at { Time.zone.now + 1.year }

        association :user, factory: :user
        association :category, factory: :category
      end
    end

    written inside.

$ interpreter -y --load_message=prompt.txt
(...)
```
</details>

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
