### PR TITLE
Added conditional support for Windows, computer not found error

### DIFF
--- a/interpreter/core/computer/terminal/terminal.py
+++ b/interpreter/core/computer/terminal/terminal.py
@@ -38,7 +38,8 @@ class Terminal:
 
     def run(self, language, code, stream=False, display=False):
         if language == "python":
-            if self.computer.import_computer_api and not self.computer._has_imported_computer_api and "computer" in code:
+            # If the code contains the word "computer", we will import the computer API if it hasn't been imported yet. (Fix #1225)
+            if (self.computer.import_computer_api or not self.computer._has_imported_computer_api) and "computer" in code:
                 self.computer._has_imported_computer_api = True
                 # Give it access to the computer via Python
                 self.computer.run(


### PR DESCRIPTION
Changed one of the conditional statements to account for the import of computer module.

Fixes #1225 

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
