### PR TITLE
Add llm_drop_params setting to avoid AnthropicException

### DIFF
--- a/docs/settings/all-settings.mdx
+++ b/docs/settings/all-settings.mdx
@@ -805,4 +805,45 @@ computer.import_computer_api: True
 ```
 
 </CodeGroup>
-````
+
+### LLM Drop Params
+
+Inform llm to drop unknown params like "functions".
+It supports to easy debug of llm errors.
+
+<CodeGroup>
+
+```bash Terminal
+interpreter --llm_drop_params
+```
+
+```python Python
+interpreter.llm_drop_params = True
+```
+
+```yaml Profile
+llm_drop_params: true
+```
+
+</CodeGroup>
+
+### LLM Modify Params
+
+Inform llm to modify params or messages.
+It supports to easy debug of llm errors.
+
+<CodeGroup>
+
+```bash Terminal
+interpreter --llm_modify_params
+```
+
+```python Python
+interpreter.llm_modify_params = True
+```
+
+```yaml Profile
+llm_modify_params: true
+```
+
+</CodeGroup>

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -79,6 +79,7 @@ class OpenInterpreter:
         import_skills=False,
         multi_line=False,
         contribute_conversation=False,
+        llm_drop_params=False,
     ):
         # State
         self.messages = [] if messages is None else messages
@@ -97,6 +98,7 @@ class OpenInterpreter:
         self.in_terminal_interface = in_terminal_interface
         self.multi_line = multi_line
         self.contribute_conversation = contribute_conversation
+        self.llm_drop_params = llm_drop_params
 
         # Loop messages
         self.loop = loop

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -80,6 +80,7 @@ class OpenInterpreter:
         multi_line=False,
         contribute_conversation=False,
         llm_drop_params=False,
+        llm_modify_params=False,
     ):
         # State
         self.messages = [] if messages is None else messages
@@ -99,6 +100,7 @@ class OpenInterpreter:
         self.multi_line = multi_line
         self.contribute_conversation = contribute_conversation
         self.llm_drop_params = llm_drop_params
+        self.llm_modify_params = llm_modify_params
 
         # Loop messages
         self.loop = loop

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -261,6 +261,8 @@ Continuing...
             litellm.set_verbose = True
         if self.interpreter.llm_drop_params:
             litellm.drop_params = True
+        if self.interpreter.llm_modify_params:
+            litellm.modify_params = True
 
         if self.interpreter.debug:
             print("\n\n\nOPENAI COMPATIBLE MESSAGES\n\n\n")

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -259,6 +259,8 @@ Continuing...
             litellm.max_budget = self.max_budget
         if self.interpreter.verbose:
             litellm.set_verbose = True
+        if self.interpreter.llm_drop_params:
+            litellm.drop_params = True
 
         if self.interpreter.debug:
             print("\n\n\nOPENAI COMPATIBLE MESSAGES\n\n\n")

--- a/interpreter/terminal_interface/profiles/defaults/default.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/default.yaml
@@ -24,7 +24,8 @@ computer:
 # offline: False  # If True, will disable some online features like checking for updates
 # verbose: False  # If True, will print detailed logs
 # multi_line: False # If True, you can input multiple lines starting and ending with ```
-# llm_drop_params: False # If True, litellm.drop_params=True, Drop any unmapped params ```
+# llm_drop_params: False # If True, litellm.drop_params=True, Drop any unmapped params
+# llm_modify_params: False # If True, litellm.drop_params=True, Modify params or messages
 
 # Documentation
 # All options: https://docs.openinterpreter.com/settings

--- a/interpreter/terminal_interface/profiles/defaults/default.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/default.yaml
@@ -24,6 +24,7 @@ computer:
 # offline: False  # If True, will disable some online features like checking for updates
 # verbose: False  # If True, will print detailed logs
 # multi_line: False # If True, you can input multiple lines starting and ending with ```
+# llm_drop_params: False # If True, litellm.drop_params=True, Drop any unmapped params ```
 
 # Documentation
 # All options: https://docs.openinterpreter.com/settings

--- a/interpreter/terminal_interface/profiles/defaults/fast.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/fast.yaml
@@ -20,6 +20,7 @@ custom_instructions: "The user has set you to FAST mode. **No talk, just code.**
 # offline: False  # If True, will disable some online features like checking for updates
 # verbose: False  # If True, will print detailed logs
 # multi_line: False # If True, you can input multiple lines starting and ending with ```
+# llm_drop_params: False # If True, litellm.drop_params=True, Drop any unmapped params ```
 
 # All options: https://docs.openinterpreter.com/settings
 

--- a/interpreter/terminal_interface/profiles/defaults/fast.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/fast.yaml
@@ -20,7 +20,8 @@ custom_instructions: "The user has set you to FAST mode. **No talk, just code.**
 # offline: False  # If True, will disable some online features like checking for updates
 # verbose: False  # If True, will print detailed logs
 # multi_line: False # If True, you can input multiple lines starting and ending with ```
-# llm_drop_params: False # If True, litellm.drop_params=True, Drop any unmapped params ```
+# llm_drop_params: False # If True, litellm.drop_params=True, Drop any unmapped params
+# llm_modify_params: False # If True, litellm.drop_params=True, Modify params or messages
 
 # All options: https://docs.openinterpreter.com/settings
 

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -195,6 +195,13 @@ def start_terminal_interface(interpreter):
             "attribute": {"object": interpreter, "attr_name": "multi_line"},
         },
         {
+            "name": "llm_drop_params",
+            "nickname": "ldp",
+            "help_text": "set litellm.drop_params=True, Drop any unmapped params",
+            "type": bool,
+            "attribute": {"object": interpreter, "attr_name": "llm_drop_params"},
+        },
+        {
             "name": "local",
             "nickname": "l",
             "help_text": "setup a local model (shortcut for `interpreter --profile local`)",

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -195,13 +195,6 @@ def start_terminal_interface(interpreter):
             "attribute": {"object": interpreter, "attr_name": "multi_line"},
         },
         {
-            "name": "llm_drop_params",
-            "nickname": "ldp",
-            "help_text": "set litellm.drop_params=True, Drop any unmapped params",
-            "type": bool,
-            "attribute": {"object": interpreter, "attr_name": "llm_drop_params"},
-        },
-        {
             "name": "local",
             "nickname": "l",
             "help_text": "setup a local model (shortcut for `interpreter --profile local`)",
@@ -271,6 +264,20 @@ def start_terminal_interface(interpreter):
                 "object": interpreter,
                 "attr_name": "contribute_conversation",
             },
+        },
+        {
+            "name": "llm_drop_params",
+            "nickname": "ldp",
+            "help_text": "set litellm.drop_params=True, Drop any unmapped params",
+            "type": bool,
+            "attribute": {"object": interpreter, "attr_name": "llm_drop_params"},
+        },
+        {
+            "name": "llm_modify_params",
+            "nickname": "lmp",
+            "help_text": "set litellm.modify_params=True, Modify params or messages",
+            "type": bool,
+            "attribute": {"object": interpreter, "attr_name": "llm_modify_params"},
         },
     ]
 


### PR DESCRIPTION
litellm.drop_params=True can avoid this error(https://github.com/OpenInterpreter/open-interpreter/issues/1240).
Error in chat: AnthropicException - anthropic does not support parameters
I think drop_params is good altanative for debugging or workaround of future errors.

### Describe the changes you have made:
This option allow litellm.drop_params=True.

### Reference any relevant issues (e.g. "Fixes #000"):
Related with https://github.com/OpenInterpreter/open-interpreter/issues/1240.

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

I found "Use Anthropic function calling" in ROADMAP.md.
Is #1240 just not implemaneted?

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux

### Test(works fine)

```
interpreter --model claude-3-haiku-20240307 -y --llm_drop_params
```

### Note1

This error is probably resolved by this PR.

```
Error in chat: AnthropicException - {"type":"error","error":{"type":"invalid_request_error","message":"messages: roles must alternate between \"user\" and \"assistant\", but found multiple \"user\" roles in a row"}}
```

### Note2

"litellm.modify_params" helps activate [here code](https://github.com/BerriAI/litellm/blob/b7c6f0500b35d6e6afd0d09d6b644365da8445b4/litellm/llms/prompt_templates/factory.py#L848) in litellm.
The first message is empty or non user, dummy message append in anthropic model.
It is not important, but helps for me.