### PR TITLE
Update lmc-messages.mdx

### DIFF
--- a/docs/protocols/lmc-messages.mdx
+++ b/docs/protocols/lmc-messages.mdx
@@ -65,3 +65,4 @@ code|python|Python code that should be executed.|`assistant`|
 code|r|R code that should be executed.|`assistant`|
 code|applescript|AppleScript code that should be executed.|`assistant`|
 code|shell|Shell code that should be executed.|`assistant`|
+audio|wav|wav formatted audio used by the websocket protocol.|`user`|


### PR DESCRIPTION
adding information about sending audio LMC Messages. The raw audio is in wav format.

(The 01 exposes a speech-to-speech websocket at localhost:10001.

If you stream raw audio bytes to / in Streaming LMC format, you will receive its response in the same format.)

### Describe the changes you have made:

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux
