### PR TITLE
Fixed empty message error for computer use

### DIFF
--- a/interpreter/computer_use/loop.py
+++ b/interpreter/computer_use/loop.py
@@ -487,7 +487,7 @@ Move your mouse to any corner of the screen to exit.
 
             print_markdown("\nWe'll email you shortly. ✓\n---\n")
             continue
-        elif user_input=="":
+        elif user_input.strip()=="":
             continue
 
         messages.append(

--- a/interpreter/computer_use/loop.py
+++ b/interpreter/computer_use/loop.py
@@ -487,6 +487,8 @@ Move your mouse to any corner of the screen to exit.
 
             print_markdown("\nWe'll email you shortly. ✓\n---\n")
             continue
+        elif user_input=="":
+            continue
 
         messages.append(
             {"role": "user", "content": [{"type": "text", "text": user_input}]}


### PR DESCRIPTION
### Describe the changes you have made:
if the user presses enter without input it will continue and ask again instead of inserting an empty string into the prompt which throws an error

### Fixes https://github.com/OpenInterpreter/open-interpreter/issues/1517

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
