### PR TITLE
Fix JSONDecodeError for Ollama and hide LiteLLM vision support warning

### DIFF
--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -26,14 +26,12 @@ from .utils.convert_to_openai_messages import convert_to_openai_messages
 # Create or get the logger
 logger = logging.getLogger("LiteLLM")
 
-
 class SuppressDebugFilter(logging.Filter):
     def filter(self, record):
         # Suppress only the specific message containing the keywords
-        if "cost map" in record.getMessage():
+        if "cost map" in record.getMessage() or "vision support" in record.getMessage():
             return False  # Suppress this log message
         return True  # Allow all other messages
-
 
 class Llm:
     """

--- a/interpreter/terminal_interface/local_setup.py
+++ b/interpreter/terminal_interface/local_setup.py
@@ -303,6 +303,7 @@ def local_setup(interpreter, provider=None, model=None):
 
             # Set the model to the selected model
             interpreter.llm.model = f"ollama/{model}"
+            interpreter.llm.supports_functions = False
 
             # Send a ping, which will actually load the model
 
@@ -373,6 +374,7 @@ def local_setup(interpreter, provider=None, model=None):
 
         interpreter.llm.model = jan_model_name
         interpreter.llm.api_key = "dummy"
+        interpreter.llm.supports_functions = False
         interpreter.display_message(f"\nUsing Jan model: `{jan_model_name}` \n")
         # time.sleep(1)
 


### PR DESCRIPTION
### Describe the changes you have made:
- Disabled function calling for ollama which fixes "json.decoder.JSONDecodeError: Unterminated string starting at: line 1 column 2 (char 1)"
- Hides a  LiteLLM warning that the model doesn't support vision

### Reference any relevant issues (e.g. "Fixes #000"):
- Fixes https://github.com/OpenInterpreter/open-interpreter/issues/1514
- Fixes https://github.com/OpenInterpreter/open-interpreter/issues/1512
- Fixes https://github.com/OpenInterpreter/open-interpreter/issues/1371

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
