### PR TITLE
Fix for consecutive user/tool blocks

### DIFF
--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -7,6 +7,7 @@ import litellm
 
 litellm.suppress_debug_info = True
 litellm.REPEATED_STREAMING_CHUNK_LIMIT = 99999999
+litellm.modify_params=True
 
 import json
 import logging


### PR DESCRIPTION
### Describe the changes you have made:

The fix is described here: https://docs.litellm.ai/docs/providers/bedrock#alternate-userassistant-messages 

### Reference any relevant issues (e.g. "Fixes #000"):

It is fix for this issue: https://github.com/OpenInterpreter/open-interpreter/issues/1518 

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
