### PR TITLE
docs: added Downloads badge from pepy.tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <p align="center">
     <a href="https://discord.gg/Hvz9Axh84z">
         <img alt="Discord" src="https://img.shields.io/discord/1146610656779440188?logo=discord&style=flat&logoColor=white"/></a>
+    <img src="https://static.pepy.tech/badge/open-interpreter" alt="PyPI Downloads">
     <a href="docs/README_JA.md"><img src="https://img.shields.io/badge/ドキュメント-日本語-white.svg" alt="JA doc"/></a>
     <a href="docs/README_ZH.md"><img src="https://img.shields.io/badge/文档-中文版-white.svg" alt="ZH doc"/></a>
     <a href="docs/README_ES.md"> <img src="https://img.shields.io/badge/Español-white.svg" alt="ES doc"/></a>


### PR DESCRIPTION
Added Downloads badge in Readme <img src="https://static.pepy.tech/badge/open-interpreter" alt="PyPI Downloads">

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [x] Tested on MacOS
- [x] Tested on Linux
