### PR TITLE
GitHub Actions are failing with `Extra [server] is not specified.`

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: ["3.10", "3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install poetry
@@ -27,7 +27,7 @@ jobs:
         run: |
           # Ensure dependencies are installed without relying on a lock file.
           poetry update
-          poetry install -E server
+          poetry install --extras=server
       - name: Test with pytest
         run: |
           poetry run pytest -s -x -k test_


### PR DESCRIPTION
GitHub Actions failures: https://github.com/OpenInterpreter/open-interpreter/actions/workflows/python-package.yml
```
Writing lock file
Installing dependencies from lock file

Extra [server] is not specified.
Error: Process completed with exit code 1.
```
https://github.com/OpenInterpreter/open-interpreter/blob/36ec07125efec86594c91e990f68e0ab214e7edf/.github/workflows/python-package.yml#L30
% `poetry install --help`
```
[ ... ]
  -E, --extras=EXTRAS        Extra sets of dependencies to install. (multiple values allowed)
```
https://github.com/OpenInterpreter/open-interpreter/blob/36ec07125efec86594c91e990f68e0ab214e7edf/pyproject.toml#L75-L79

https://github.com/OpenInterpreter/open-interpreter/blob/36ec07125efec86594c91e990f68e0ab214e7edf/docs/CONTRIBUTING.md?plain=1#L30-L33

### Describe the changes you have made:

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [ ] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
