### PR TITLE
Use response inside try block in computer.ai fast_llm

### DIFF
--- a/interpreter/core/computer/ai/ai.py
+++ b/interpreter/core/computer/ai/ai.py
@@ -84,10 +84,10 @@ def fast_llm(llm, system_message, user_message):
         llm.interpreter.system_message = system_message
         llm.interpreter.messages = []
         response = llm.interpreter.chat(user_message)
+        return response[-1].get("content")
     finally:
         llm.interpreter.messages = old_messages
         llm.interpreter.system_message = old_system_message
-        return response[-1].get("content")
 
 
 def query_map_chunks(chunks, llm, query):


### PR DESCRIPTION
### Describe the changes you have made:

The response object will not be available if an exception is thrown when executing `llm.interpreter.chat`, so we should only access the response inside the try block. 

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [ ] I have read `docs/ROADMAP.md`
