### PR TITLE
Include x-coding-assistant=open-interpreter header in litellm calls

### DIFF
--- a/interpreter/core/llm/__init__.py
+++ b/interpreter/core/llm/__init__.py
@@ -1,0 +1,14 @@
+from importlib import metadata
+
+_VERSION = "dev"
+
+
+def __get_version():
+    try:
+        version = metadata.version("open-interpreter")
+    except metadata.PackageNotFoundError:
+        version = _VERSION
+    return version
+
+
+__version__ = __get_version()

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -4,6 +4,7 @@ os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
 import sys
 
 import litellm
+from . import __version__
 
 litellm.suppress_debug_info = True
 litellm.REPEATED_STREAMING_CHUNK_LIMIT = 99999999
@@ -437,6 +438,7 @@ def fixed_litellm_completions(**params):
     first_error = None
 
     params["num_retries"] = 0
+    params["headers"] = {"x-coding-assistant": f"open-interpreter/{__version__}"}
 
     for attempt in range(attempts):
         try:


### PR DESCRIPTION
### Describe the changes you have made:

Proxies that inspect traffic between the development environment and an
LLM might be interested in whether it's OI or another tool calling in
order to be able to inspect and/or modify the payload.

The most common way of solving this would be to add a `user-agent` header.
However, litellm which OI uses calls into OpenAI libraries directly
when making the request and it seems like the only way to set a custom
`http_client`. This seemed like something that might have unforeseen
consequences (timeouts? retries?). For other LLMs, litellm seems to use
its own httpx wrapper which might presumably be easier to customize, but
I have not tried.

To make things easier, let's just add an OI specific header. I put the
string OI followed by the version there, but the value - and indeed the key
- of the header are not that interesting, what I would like to do is to just
be able to to tell OI calls.


### Reference any relevant issues (e.g. "Fixes #000"):
N/A

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
