### PR TITLE
Improved litellm exception handler

### DIFF
--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -461,8 +461,8 @@ def fixed_litellm_completions(**params):
             if isinstance(e, litellm.exceptions.RateLimitError):
                 # On the second attempt, raise the error
                 if attempt == 1:
-                    # RateLimitError can be caused if you have no credit left
-                    print("You still exceeded the rate limit. Try again later and check if you have credit left.")
+                    # RateLimitError can be caused if you have no tokens left
+                    print("You still exceeded the rate limit. Try again later. If you use an API, ensure you have tokens left.")
                     raise first_error
                 # Wait and try again
                 print("You exceeded the rate limit. Trying again in 15 seconds...")

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -458,6 +458,16 @@ def fixed_litellm_completions(**params):
                 )
                 # So, let's try one more time with a dummy API key:
                 params["api_key"] = "x"
+            if isinstance(e, litellm.exceptions.RateLimitError):
+                # On the second attempt, raise the error
+                if attempt == 1:
+                    # RateLimitError can be caused if you have no credit left
+                    print("You still exceeded the rate limit. Try again later and check if you have credit left.")
+                    raise first_error
+                # Wait and try again
+                print("You exceeded the rate limit. Trying again in 15 seconds...")
+                time.sleep(15)
+                continue
             if attempt == 1:
                 # Try turning up the temperature?
                 params["temperature"] = params.get("temperature", 0.0) + 0.1


### PR DESCRIPTION
### Describe the changes you have made:
I improved the litellm exception handler in `llm.py` by adding a 15 sec backoff, if litellm returns `litellm.exceptions.RateLimitError`. If the rate limit exceeds a second time, interpreter displays a message that you should try again later and check your balance if you use an API. `RateLimitError` can be caused by depleted tokens.

### Reference any relevant issues (e.g. "Fixes #000"):
None

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs) -> Think there are no changes to make at all
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux