### PR TITLE
Fix: Correct max_output location in YAML profile templates

### DIFF
--- a/interpreter/terminal_interface/profiles/defaults/default.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/default.yaml
@@ -9,7 +9,6 @@ llm:
   # api_key: ...  # Your API key, if the API requires it
   # api_base: ...  # The URL where an OpenAI-compatible server is running to handle LLM API requests
   # api_version: ...  # The version of the API (this is primarily for Azure)
-  # max_output: 2500  # The maximum characters of code output visible to the LLM
 
 # Computer Settings
 computer:
@@ -23,6 +22,7 @@ computer:
 # safe_mode: "off"  # The safety mode for the LLM — one of "off", "ask", "auto"
 # offline: False  # If True, will disable some online features like checking for updates
 # verbose: False  # If True, will print detailed logs
+# max_output: 2500  # The maximum characters of code output visible to the LLM
 
 # To use a separate model for the `wtf` command:
 # wtf:

--- a/interpreter/terminal_interface/profiles/defaults/fast.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/fast.yaml
@@ -8,18 +8,20 @@ llm:
   # api_key: ...  # Your API key, if the API requires it
   # api_base: ...  # The URL where an OpenAI-compatible server is running to handle LLM API requests
   # api_version: ...  # The version of the API (this is primarily for Azure)
-  # max_output: 2500  # The maximum characters of code output visible to the LLM
 
 # Computer Settings
 computer:
   import_computer_api: True # Gives OI a helpful Computer API designed for code interpreting language models
 
 custom_instructions: "The user has set you to FAST mode. **No talk, just code.** Be as brief as possible. No comments, no unnecessary messages. Assume as much as possible, rarely ask the user for clarification. Once the task has been completed, say 'The task is done.'" # This will be appended to the system message
+
+# General Configuration
 # auto_run: False  # If True, code will run without asking for confirmation
 # safe_mode: "off"  # The safety mode for the LLM — one of "off", "ask", "auto"
 # offline: False  # If True, will disable some online features like checking for updates
 # verbose: False  # If True, will print detailed logs
 # multi_line: False # If True, you can input multiple lines starting and ending with ```
+# max_output: 2500  # The maximum characters of code output visible to the LLM
 
 # All options: https://docs.openinterpreter.com/settings
 

--- a/interpreter/terminal_interface/profiles/defaults/snowpark.yml
+++ b/interpreter/terminal_interface/profiles/defaults/snowpark.yml
@@ -9,7 +9,6 @@ llm:
   # api_key: ...  # Your API key, if the API requires it
   # api_base: ...  # The URL where an OpenAI-compatible server is running to handle LLM API requests
   # api_version: ...  # The version of the API (this is primarily for Azure)
-  # max_output: 2500  # The maximum characters of code output visible to the LLM
 
 # Computer Settings
 computer:
@@ -34,7 +33,7 @@ If this doesnt work, you may need to run the following commands to install snowp
 !pip install "snowflake-connector-python[pandas]"
 ```
 
-Then, you can create a dictionary with the necessary connection parameters and create a session. You will access these values from the 
+Then, you can create a dictionary with the necessary connection parameters and create a session. You will access these values from the
 environment variables:
 ```python
 # Retrieve environment variables
@@ -43,7 +42,7 @@ snowflake_user = os.getenv("SNOWFLAKE_USER")
 snowflake_password = os.getenv("SNOWFLAKE_PASSWORD")
 snowflake_role = os.getenv("SNOWFLAKE_ROLE")
 snowflake_warehouse = os.getenv("SNOWFLAKE_WAREHOUSE")
-snowflake_database = os.getenv("SNOWFLAKE_DATABASE") 
+snowflake_database = os.getenv("SNOWFLAKE_DATABASE")
 snowflake_schema = os.getenv("SNOWFLAKE_SCHEMA")
 
 # Create connection parameters dictionary
@@ -52,15 +51,15 @@ connection_parameters = {
     "user": snowflake_user,
     "password": snowflake_password,
     "role": snowflake_role,
-    "warehouse": snowflake_warehouse, 
-    "database": snowflake_database, 
+    "warehouse": snowflake_warehouse,
+    "database": snowflake_database,
     "schema": snowflake_schema,
 }
 
 # Create a session
 session = Session.builder.configs(connection_parameters).create()
 ```
-You should assume that the environment variables have already been set. 
+You should assume that the environment variables have already been set.
 You can run a query against the snowflake data by using the session.sql() method. Then, you can turn the snowpark dataframe
 that is created into a pandas dataframe for use in other processes. Here is an example of how you can run a query:
 ```python
@@ -82,6 +81,7 @@ You can now use this dataframe to do whatever you need to do with the data.
 # offline: False  # If True, will disable some online features like checking for updates
 # verbose: False  # If True, will print detailed logs
 # multi_line: False # If True, you can input multiple lines starting and ending with ```
+# max_output: 2500  # The maximum characters of code output visible to the LLM
 
 # Documentation
 # All options: https://docs.openinterpreter.com/settings

--- a/interpreter/terminal_interface/profiles/profiles.py
+++ b/interpreter/terminal_interface/profiles/profiles.py
@@ -511,10 +511,13 @@ You are capable of **any** task.""",
 # Be sure to remove the "#" before the following settings to use them.
 
 # custom_instructions: ""  # This will be appended to the system message
+
+# General Configuration
 # auto_run: False  # If True, code will run without asking for confirmation
 # safe_mode: "off"  # The safety mode (see https://docs.openinterpreter.com/usage/safe-mode)
 # offline: False  # If True, will disable some online features like checking for updates
 # verbose: False  # If True, will print detailed logs
+# max_output: 2800  # The maximum characters of code output visible to the LLM
 
 # computer
     # languages: ["javascript", "shell"]  # Restrict to certain languages
@@ -523,7 +526,6 @@ You are capable of **any** task.""",
     # api_key: ...  # Your API key, if the API requires it
     # api_base: ...  # The URL where an OpenAI-compatible server is running
     # api_version: ...  # The version of the API (this is primarily for Azure)
-    # max_output: 2800  # The maximum characters of code output visible to the LLM
 
 # All options: https://docs.openinterpreter.com/settings
 


### PR DESCRIPTION
The YAML profile templates incorrectly show max_output under llm (llm.max_output), but max_output belongs on Interpreter, not on the Llm class.

History:
- [20b8230a8](https://github.com/openinterpreter/open-interpreter/commit/20b8230a8a08398d3600dc165896da2f915d4b5a#diff-84e60b3b4939012c48b4d4a4fe07cf56fe76abe8edddc92063565097c75957cbL10-R7): max_output was added as top-level in config.yaml
- [2400eabd8](https://github.com/openinterpreter/open-interpreter/commit/2400eabd84b8e983bd8bbaede7d9fd426e6148f6#diff-84e60b3b4939012c48b4d4a4fe07cf56fe76abe8edddc92063565097c75957cbR10-R17): Template changed to llm.max_output and parsing code removed (bug introduced)
- [861341c63](https://github.com/openinterpreter/open-interpreter/commit/861341c6378ddc557e0028340a68b4daa18585e5#diff-56512ffb06d2c8a0b4a0a816b6aa33facfb6589c40a65818573521f6da74af7cR9-R11): Changed to nested YAML format but still under llm: (still wrong)

Evidence:
- max_output was originally top-level in 20b8230a8
- Llm class has no max_output attribute (unlike context_window, max_tokens)
- Code uses interpreter.max_output (core.py:420)
- Migration mapping doesn't include max_output (unlike other LLM settings)

The templates have been wrong since 2400eabd8, causing profiles with llm.max_output to be silently ignored. Users saw the default (2800) instead of their configured value.

Changes:
- Move max_output from llm: section to top-level in all YAML templates (default.yaml, fast.yaml, snowpark.yml)
- Fix template comment in profiles.py used for new profile generation

This restores the original design where max_output is a top-level Interpreter setting, matching the code structure.

### Describe the changes you have made:

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
