### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: ["3.10", "3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install poetry


### PR DESCRIPTION
### Describe the changes you have made:
This PR updates outdated GitHub Action versions by upgrading `actions/checkout` from `v3` to `v6` and `actions/setup-python` from `v3` to `v6` in the relevant workflow files.

### Reference any relevant issues:
n/a

### Pre-Submission Checklist (optional but appreciated):
- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):
- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux

The changes will be tested in the CI pipeline of the pull request.