### PR TITLE
fix: replace 55 bare except clauses with except Exception

### DIFF
--- a/interpreter/core/archived_server_2.py
+++ b/interpreter/core/archived_server_2.py
@@ -90,7 +90,7 @@ class AsyncInterpreter:
         else:
             try:
                 chunk = json.loads(chunk)
-            except:
+            except Exception:
                 pass
 
             if "start" in chunk:

--- a/interpreter/core/async_core.py
+++ b/interpreter/core/async_core.py
@@ -33,7 +33,7 @@ try:
     )
     from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
     from starlette.status import HTTP_403_FORBIDDEN
-except:
+except Exception:
     # Server dependencies are not required by the main package.
     pass
 
@@ -1030,6 +1030,6 @@ class Server:
         #                 str(e)
         #                 + """\n\nPlease ensure you have run `pip install "open-interpreter[server]"` to install server dependencies."""
         #             )
-        #     except:
+        #     except Exception:
         #         print("An unexpected error occurred:", traceback.format_exc())
         #         print("Server restarting.")

--- a/interpreter/core/computer/computer.py
+++ b/interpreter/core/computer/computer.py
@@ -226,7 +226,7 @@ Do not import the computer module, or any of its sub-modules. They are already i
             try:
                 json.dumps(obj)
                 return True
-            except:
+            except Exception:
                 return False
 
         return {k: v for k, v in self.__dict__.items() if json_serializable(v)}

--- a/interpreter/core/computer/display/display.py
+++ b/interpreter/core/computer/display/display.py
@@ -22,7 +22,7 @@ from ..utils.recipient_utils import format_to_recipient
 # Lazy import of optional packages
 try:
     cv2 = lazy_import("cv2")
-except:
+except Exception:
     cv2 = None  # Fixes colab error
 
 pyautogui = lazy_import("pyautogui")
@@ -31,7 +31,7 @@ pyautogui = lazy_import("pyautogui")
 try:
     # Attempt to get the screen size
     pyautogui.size()
-except:
+except Exception:
     pyautogui = None
 
 np = lazy_import("numpy")
@@ -238,7 +238,7 @@ class Display:
                 )
 
                 return result
-            except:
+            except Exception:
                 if self.computer.debug:
                     # We want to know these bugs lmao
                     raise
@@ -294,7 +294,7 @@ class Display:
                 )
                 response = response.json()
                 return response
-            except:
+            except Exception:
                 print("Attempting to find the text locally.")
 
         # We'll only get here if 1) self.computer.offline = True, or the API failed
@@ -326,14 +326,14 @@ class Display:
                 )
                 response = response.json()
                 return response
-            except:
+            except Exception:
                 print("Attempting to get the text locally.")
 
         # We'll only get here if 1) self.computer.offline = True, or the API failed
 
         try:
             return pytesseract_get_text(screenshot)
-        except:
+        except Exception:
             raise Exception(
                 "Failed to find text locally.\n\nTo find text in order to use the mouse, please make sure you've installed `pytesseract` along with the Tesseract executable (see this Stack Overflow answer for help installing Tesseract: https://stackoverflow.com/questions/50951955/pytesseract-tesseractnotfound-error-tesseract-is-not-installed-or-its-not-i)."
             )

--- a/interpreter/core/computer/keyboard/keyboard.py
+++ b/interpreter/core/computer/keyboard/keyboard.py
@@ -25,7 +25,7 @@ class Keyboard:
         else:
             try:
                 clipboard_history = self.computer.clipboard.view()
-            except:
+            except Exception:
                 pass
 
             ends_in_enter = False
@@ -51,7 +51,7 @@ class Keyboard:
 
             try:
                 self.computer.clipboard.copy(clipboard_history)
-            except:
+            except Exception:
                 pass
 
         time.sleep(delay / 2)

--- a/interpreter/core/computer/mail/mail.py
+++ b/interpreter/core/computer/mail/mail.py
@@ -144,7 +144,7 @@ class Mail:
             return round(
                 max(0.2, estimated_time_seconds + 1), 1
             )  # Add 1 second buffer, ensure a minimum delay of 1.2 seconds, rounded to one decimal place
-        except:
+        except Exception:
             # Return a default delay of 5 seconds if an error occurs
             return 5
 

--- a/interpreter/core/computer/mouse/mouse.py
+++ b/interpreter/core/computer/mouse/mouse.py
@@ -10,7 +10,7 @@ from ..utils.recipient_utils import format_to_recipient
 # Lazy import of optional packages
 try:
     cv2 = lazy_import("cv2")
-except:
+except Exception:
     cv2 = None  # Fixes colab error
 np = lazy_import("numpy")
 pyautogui = lazy_import("pyautogui")

--- a/interpreter/core/computer/os/os.py
+++ b/interpreter/core/computer/os/os.py
@@ -71,7 +71,7 @@ class Os:
                     import plyer
 
                     plyer.notification.notify(title=title, message=text)
-                except:
+                except Exception:
                     # Optional package
                     pass
         except Exception as e:

--- a/interpreter/core/computer/sms/sms.py
+++ b/interpreter/core/computer/sms/sms.py
@@ -22,7 +22,7 @@ class SMS:
             else:
                 home_directory = os.path.expanduser("~")
             return f"{home_directory}/Library/Messages/chat.db"
-        except:
+        except Exception:
             home_directory = os.path.expanduser("~")
             return f"{home_directory}/Library/Messages/chat.db"
 
@@ -83,7 +83,7 @@ LEFT JOIN handle ON message.handle_id = handle.ROWID
                         # Try to parse as plist
                         plist_data = plistlib.loads(text_data)
                         text = plist_data.get("NS.string", "")
-                    except:
+                    except Exception:
                         # If plist parsing fails, use the raw string
                         text = text_data
                     if text:  # Only add messages with content

--- a/interpreter/core/computer/terminal/languages/jupyter_language.py
+++ b/interpreter/core/computer/terminal/languages/jupyter_language.py
@@ -99,7 +99,7 @@ import matplotlib.pyplot as plt
 
         # try:
         #     functions = string_to_python(code)
-        # except:
+        # except Exception:
         #     # Non blocking
         #     functions = {}
 
@@ -117,7 +117,7 @@ import matplotlib.pyplot as plt
         try:
             try:
                 preprocessed_code = self.preprocess_code(code)
-            except:
+            except Exception:
                 # Any errors produced here are our fault.
                 # Also, for python, you don't need them! It's just for active_line and stuff. Just looks pretty.
                 preprocessed_code = code
@@ -126,7 +126,7 @@ import matplotlib.pyplot as plt
             yield from self._capture_output(message_queue)
         except GeneratorExit:
             raise  # gotta pass this up!
-        except:
+        except Exception:
             content = traceback.format_exc()
             yield {"type": "console", "format": "output", "content": content}
 
@@ -310,7 +310,7 @@ import matplotlib.pyplot as plt
             # Split the last active line by "##" and grab the first element
             try:
                 active_line = int(last_active_line.split("##")[0])
-            except:
+            except Exception:
                 active_line = 0
             # Remove all ##active_line{number}##\n
             line = re.sub(r"##active_line\d+##\n", "", line)
@@ -403,7 +403,7 @@ def add_active_line_prints(code):
     processed_code = "\n".join(code_lines)
     try:
         tree = ast.parse(processed_code)
-    except:
+    except Exception:
         # If you can't parse the processed version, try the unprocessed version before giving up
         tree = ast.parse(code)
     transformer = AddLinePrints()

--- a/interpreter/core/computer/terminal/languages/subprocess_language.py
+++ b/interpreter/core/computer/terminal/languages/subprocess_language.py
@@ -79,7 +79,7 @@ class SubprocessLanguage(BaseLanguage):
             code = self.preprocess_code(code)
             if not self.process:
                 self.start_process()
-        except:
+        except Exception:
             yield {
                 "type": "console",
                 "format": "output",
@@ -97,7 +97,7 @@ class SubprocessLanguage(BaseLanguage):
                 self.process.stdin.write(code + "\n")
                 self.process.stdin.flush()
                 break
-            except:
+            except Exception:
                 if retry_count != 0:
                     # For UX, I like to hide this if it happens once. Obviously feels better to not see errors
                     # Most of the time it doesn't matter, but we should figure out why it happens frequently with:

--- a/interpreter/core/computer/utils/computer_vision.py
+++ b/interpreter/core/computer/utils/computer_vision.py
@@ -6,7 +6,7 @@ from ...utils.lazy_import import lazy_import
 np = lazy_import("numpy")
 try:
     cv2 = lazy_import("cv2")
-except:
+except Exception:
     cv2 = None  # Fixes colab error
 PIL = lazy_import("PIL")
 pytesseract = lazy_import("pytesseract")

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -133,7 +133,7 @@ class Llm:
                     self.supports_functions = True
                 else:
                     self.supports_functions = False
-            except:
+            except Exception:
                 self.supports_functions = False
 
         # Detect vision support
@@ -143,7 +143,7 @@ class Llm:
                     self.supports_vision = True
                 else:
                     self.supports_vision = False
-            except:
+            except Exception:
                 self.supports_vision = False
 
         # Trim image messages if they're there
@@ -237,7 +237,7 @@ class Llm:
                     messages = tt.trim(
                         messages, system_message=system_message, model=model
                     )
-                except:
+                except Exception:
                     if len(messages) == 1:
                         if self.interpreter.in_terminal_interface:
                             self.interpreter.display_message(
@@ -264,7 +264,7 @@ Continuing...
                     messages = tt.trim(
                         messages, system_message=system_message, max_tokens=8000
                     )
-        except:
+        except Exception:
             # If we're trimming messages, this won't work.
             # If we're trimming from a model we don't know, this won't work.
             # Better not to fail until `messages` is too big, just for frustrations sake, I suppose.
@@ -412,7 +412,7 @@ Continuing...
                     self.max_tokens = min(
                         int(self.context_window * 0.2), model_info["max_output_tokens"]
                     )
-            except:
+            except Exception:
                 pass
 
 

--- a/interpreter/core/llm/run_text_llm.py
+++ b/interpreter/core/llm/run_text_llm.py
@@ -7,7 +7,7 @@ def run_text_llm(llm, params):
             params["messages"][0][
                 "content"
             ] += "\n" + llm.execution_instructions
-        except:
+        except Exception:
             print('params["messages"][0]', params["messages"][0])
             raise
 

--- a/interpreter/core/llm/utils/parse_partial_json.py
+++ b/interpreter/core/llm/utils/parse_partial_json.py
@@ -6,7 +6,7 @@ def parse_partial_json(s):
     # Attempt to parse the string as-is.
     try:
         return json.loads(s)
-    except:
+    except Exception:
         pass
 
     # Initialize variables.
@@ -55,6 +55,6 @@ def parse_partial_json(s):
     # Attempt to parse the modified string as JSON.
     try:
         return json.loads(new_s)
-    except:
+    except Exception:
         # If we still can't parse the string as JSON, return None to indicate failure.
         return None

--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -190,7 +190,7 @@ def respond(interpreter):
                         interpreter.messages[-1][
                             "format"
                         ] = language  # So the LLM can see it.
-                    except:
+                    except Exception:
                         pass
 
                 # print(code)
@@ -203,7 +203,7 @@ def respond(interpreter):
                         interpreter.messages[-1][
                             "content"
                         ] = code  # So the LLM can see it.
-                    except:
+                    except Exception:
                         pass
 
                 if code.replace("\n", "").replace(" ", "").startswith('{"language":'):
@@ -218,7 +218,7 @@ def respond(interpreter):
                             interpreter.messages[-1][
                                 "format"
                             ] = language  # So the LLM can see it.
-                    except:
+                    except Exception:
                         pass
 
                 if code.replace("\n", "").replace(" ", "").startswith("{language:"):
@@ -236,7 +236,7 @@ def respond(interpreter):
                             interpreter.messages[-1][
                                 "format"
                             ] = language  # So the LLM can see it.
-                    except:
+                    except Exception:
                         pass
 
                 if (
@@ -398,7 +398,7 @@ def respond(interpreter):
 
             except KeyboardInterrupt:
                 break  # It's fine.
-            except:
+            except Exception:
                 yield {
                     "role": "computer",
                     "type": "console",

--- a/interpreter/core/utils/system_debug_info.py
+++ b/interpreter/core/utils/system_debug_info.py
@@ -122,7 +122,7 @@ def interpreter_info(interpreter):
         """ + "\n\n".join(
             [str(m) for m in messages_to_display]
         )
-    except:
+    except Exception:
         return "Error, couldn't get interpreter info"
 
 

--- a/interpreter/core/utils/telemetry.py
+++ b/interpreter/core/utils/telemetry.py
@@ -36,7 +36,7 @@ def get_or_create_uuid():
             with open(uuid_file_path, "w") as file:
                 file.write(new_uuid)
             return new_uuid
-    except:
+    except Exception:
         # Non blocking
         return "idk"
 
@@ -58,5 +58,5 @@ def send_telemetry(event_name, properties=None):
             "distinct_id": user_id,
         }
         requests.post(url, headers=headers, data=json.dumps(data))
-    except:
+    except Exception:
         pass

--- a/interpreter/terminal_interface/contributing_conversations.py
+++ b/interpreter/terminal_interface/contributing_conversations.py
@@ -188,6 +188,6 @@ def contribute_conversations(
 
     try:
         requests.post(url, json=payload)
-    except:
+    except Exception:
         # Non blocking
         pass

--- a/interpreter/terminal_interface/profiles/defaults/os.py
+++ b/interpreter/terminal_interface/profiles/defaults/os.py
@@ -140,7 +140,7 @@ try:
                 + "\n(If you need to be in another active application to help the user, you need to switch to it.)"
             )
 
-except:
+except Exception:
     # Non blocking
     pass
     

--- a/interpreter/terminal_interface/profiles/profiles.py
+++ b/interpreter/terminal_interface/profiles/profiles.py
@@ -53,7 +53,7 @@ def profile(interpreter, filename_or_url):
     if profile == None:
         try:
             profile = get_profile(filename_or_url, profile_path)
-        except:
+        except Exception:
             if filename_or_url in ["default", "default.yaml"]:
                 # Literally this just happens to default.yaml
                 reset_profile(filename_or_url)
@@ -175,7 +175,7 @@ def apply_profile(interpreter, profile, profile_path):
                     elif profile["llm"]["model"] == "gpt-4-turbo-preview":
                         text = text.replace("gpt-4-turbo-preview", "gpt-4o")
                         profile["llm"]["model"] = "gpt-4o"
-                except:
+                except Exception:
                     raise
                     pass  # fine
 

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -524,7 +524,7 @@ Use """ to write multi-line messages.
                 interpreter.display_message(
                     "> **A new version of Open Interpreter is available.**\n>Please run: `pip install --upgrade open-interpreter`\n\n---"
                 )
-    except:
+    except Exception:
         # Doesn't matter
         pass
 

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -39,7 +39,7 @@ random.shuffle(examples)
 try:
     for example in examples:
         readline.add_history(example)
-except:
+except Exception:
     # If they don't have readline, that's fine
     pass
 
@@ -106,7 +106,7 @@ def terminal_interface(interpreter, message):
             try:
                 # This lets users hit the up arrow key for past messages
                 readline.add_history(message)
-            except:
+            except Exception:
                 # If the user doesn't have readline (may be the case on windows), that's fine
                 pass
 
@@ -535,7 +535,7 @@ def terminal_interface(interpreter, message):
                 continue
             else:
                 break
-        except:
+        except Exception:
             if interpreter.debug:
                 system_info(interpreter)
             raise

--- a/interpreter/terminal_interface/utils/count_tokens.py
+++ b/interpreter/terminal_interface/utils/count_tokens.py
@@ -1,7 +1,7 @@
 try:
     import tiktoken
     from litellm import cost_per_token
-except:
+except Exception:
     # Non-essential feature
     pass
 
@@ -25,7 +25,7 @@ def count_tokens(text="", model="gpt-4"):
             encoder = tiktoken.encoding_for_model("gpt-4")
 
         return len(encoder.encode(text))
-    except:
+    except Exception:
         # Non-essential feature
         return 0
 
@@ -39,7 +39,7 @@ def token_cost(tokens=0, model="gpt-4"):
         (prompt_cost, _) = cost_per_token(model=model, prompt_tokens=tokens)
 
         return round(prompt_cost, 6)
-    except:
+    except Exception:
         # Non-essential feature
         return 0
 
@@ -66,6 +66,6 @@ def count_messages_tokens(messages=[], model=None):
         prompt_cost = token_cost(tokens_used, model=model)
 
         return (tokens_used, prompt_cost)
-    except:
+    except Exception:
         # Non-essential feature
         return (0, 0)

--- a/interpreter/terminal_interface/utils/in_jupyter_notebook.py
+++ b/interpreter/terminal_interface/utils/in_jupyter_notebook.py
@@ -4,5 +4,5 @@ def in_jupyter_notebook():
 
         if "IPKernelApp" in get_ipython().config:
             return True
-    except:
+    except Exception:
         return False

--- a/scripts/wtf.py
+++ b/scripts/wtf.py
@@ -375,7 +375,7 @@ def main():
                 model = wtf_model
             else:
                 model = profile.get("llm", {}).get("model", "gpt-4o-mini")
-    except:
+    except Exception:
         model = "gpt-4o-mini"
 
     # If they're using a local model (improve this heuristic) use the LOCAL_SYSTEM_MESSAGE


### PR DESCRIPTION
## What
Replace 55 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.