### PR TITLE
Fix auto_run not supporting callable values

### DIFF
--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -347,7 +347,7 @@ class OpenInterpreter:
                         yield {**last_flag_base, "end": True}
                         last_flag_base = None
 
-                    if self.auto_run == False:
+                    if self.auto_run == False or callable(self.auto_run):
                         yield chunk
 
                     # We want to append this now, so even if content is never filled, we know that the execution didn't produce output.

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -185,7 +185,13 @@ def terminal_interface(interpreter, message):
 
                 # Execution notice
                 if chunk["type"] == "confirmation":
-                    if not interpreter.auto_run:
+                    _code_content = chunk["content"]["content"]
+                    _should_auto_run = (
+                        interpreter.auto_run(_code_content)
+                        if callable(interpreter.auto_run)
+                        else interpreter.auto_run
+                    )
+                    if not _should_auto_run:
                         # OI is about to execute code. The user wants to approve this
 
                         # End the active code block so you can run input() below it


### PR DESCRIPTION
### Describe the changes you have made:

When `auto_run` is set to a callable (as described in #1696), the interpreter fails to work correctly:

1. **`core.py`**: `self.auto_run == False` never matches a callable (which is truthy), so the confirmation chunk is never yielded to the terminal interface — the user never gets a chance to approve/reject.
2. **`terminal_interface.py`**: `not interpreter.auto_run` treats the callable as truthy, so the confirmation prompt is skipped entirely and all code runs without approval.

**Fix:**
- `core.py`: Yield the confirmation chunk when `auto_run` is `False` **or** `callable` — both cases need the terminal interface to handle the confirmation flow.
- `terminal_interface.py`: When `auto_run` is callable, call it with the code content to determine whether to auto-run. Otherwise fall back to the original boolean check.

### Reference any relevant issues (e.g. "Fixes #000"):

Fixes #1696

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on MacOS
- [ ] Tested on Windows
- [ ] Tested on Linux