### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,32 @@ interpreter.llm.model = "gpt-3.5-turbo"
 
 [Find the appropriate "model" string for your language model here.](https://docs.litellm.ai/docs/providers/)
 
+### Using MiniMax
+
+To use [MiniMax](https://platform.minimax.io/) models, set your API key and use the built-in profile:
+
+```shell
+export MINIMAX_API_KEY=your_api_key
+interpreter --profile minimax.py
+```
+
+Or configure it in Python:
+
+```python
+from interpreter import interpreter
+
+interpreter.llm.model = "openai/MiniMax-M2.5"
+interpreter.llm.api_key = "your_api_key"
+interpreter.llm.api_base = "https://api.minimax.io/v1"
+interpreter.llm.context_window = 204800
+interpreter.llm.max_tokens = 4096
+interpreter.llm.temperature = 1.0
+
+interpreter.chat()
+```
+
+Available models: `MiniMax-M2.5` (default) and `MiniMax-M2.5-highspeed` (faster).
+
 ### Running Open Interpreter locally
 
 #### Terminal

--- a/README.md
+++ b/README.md
@@ -207,17 +207,17 @@ Or configure it in Python:
 ```python
 from interpreter import interpreter
 
-interpreter.llm.model = "openai/MiniMax-M2.7"
+interpreter.llm.model = "openai/MiniMax-M3"
 interpreter.llm.api_key = "your_api_key"
 interpreter.llm.api_base = "https://api.minimax.io/v1"
-interpreter.llm.context_window = 204800
+interpreter.llm.context_window = 512000
 interpreter.llm.max_tokens = 4096
 interpreter.llm.temperature = 1.0
 
 interpreter.chat()
 ```
 
-Available models: `MiniMax-M2.7` (default), `MiniMax-M2.7-highspeed` (faster), `MiniMax-M2.5`, and `MiniMax-M2.5-highspeed`.
+Available models: `MiniMax-M3` (default), `MiniMax-M2.7`, and `MiniMax-M2.7-highspeed` (faster).
 
 ### Running Open Interpreter locally
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Or configure it in Python:
 ```python
 from interpreter import interpreter
 
-interpreter.llm.model = "openai/MiniMax-M2.5"
+interpreter.llm.model = "openai/MiniMax-M2.7"
 interpreter.llm.api_key = "your_api_key"
 interpreter.llm.api_base = "https://api.minimax.io/v1"
 interpreter.llm.context_window = 204800
@@ -217,7 +217,7 @@ interpreter.llm.temperature = 1.0
 interpreter.chat()
 ```
 
-Available models: `MiniMax-M2.5` (default) and `MiniMax-M2.5-highspeed` (faster).
+Available models: `MiniMax-M2.7` (default), `MiniMax-M2.7-highspeed` (faster), `MiniMax-M2.5`, and `MiniMax-M2.5-highspeed`.
 
 ### Running Open Interpreter locally
 

--- a/interpreter/terminal_interface/profiles/defaults/minimax.py
+++ b/interpreter/terminal_interface/profiles/defaults/minimax.py
@@ -3,12 +3,11 @@ This is an Open Interpreter profile to use MiniMax.
 
 Please set the MINIMAX_API_KEY environment variable.
 
-MiniMax provides powerful language models with a 204,800 token context window.
+MiniMax provides powerful language models with up to a 512,000 token context window.
 Available models:
-  - MiniMax-M2.7 (default): Latest flagship model with enhanced reasoning and coding.
+  - MiniMax-M3 (default): Latest flagship model with 512K context, up to 128K output, and image input support.
+  - MiniMax-M2.7: Previous generation flagship model with enhanced reasoning and coding.
   - MiniMax-M2.7-highspeed: High-speed version of M2.7 for low-latency scenarios.
-  - MiniMax-M2.5: Peak Performance. Ultimate Value.
-  - MiniMax-M2.5-highspeed: Same performance, faster and more agile.
 
 See https://platform.minimax.io/docs/api-reference/text-openai-api for more information.
 """
@@ -17,13 +16,13 @@ from interpreter import interpreter
 import os
 
 # LLM settings
-interpreter.llm.model = "openai/MiniMax-M2.7"
+interpreter.llm.model = "openai/MiniMax-M3"
 interpreter.llm.api_key = os.environ.get("MINIMAX_API_KEY")
 interpreter.llm.api_base = "https://api.minimax.io/v1"
 interpreter.llm.supports_functions = True
-interpreter.llm.supports_vision = False
+interpreter.llm.supports_vision = True
 interpreter.llm.max_tokens = 4096
-interpreter.llm.context_window = 204800
+interpreter.llm.context_window = 512000
 interpreter.llm.temperature = 1.0
 
 # Computer settings

--- a/interpreter/terminal_interface/profiles/defaults/minimax.py
+++ b/interpreter/terminal_interface/profiles/defaults/minimax.py
@@ -5,7 +5,9 @@ Please set the MINIMAX_API_KEY environment variable.
 
 MiniMax provides powerful language models with a 204,800 token context window.
 Available models:
-  - MiniMax-M2.5 (default): Peak Performance. Ultimate Value.
+  - MiniMax-M2.7 (default): Latest flagship model with enhanced reasoning and coding.
+  - MiniMax-M2.7-highspeed: High-speed version of M2.7 for low-latency scenarios.
+  - MiniMax-M2.5: Peak Performance. Ultimate Value.
   - MiniMax-M2.5-highspeed: Same performance, faster and more agile.
 
 See https://platform.minimax.io/docs/api-reference/text-openai-api for more information.
@@ -15,7 +17,7 @@ from interpreter import interpreter
 import os
 
 # LLM settings
-interpreter.llm.model = "openai/MiniMax-M2.5"
+interpreter.llm.model = "openai/MiniMax-M2.7"
 interpreter.llm.api_key = os.environ.get("MINIMAX_API_KEY")
 interpreter.llm.api_base = "https://api.minimax.io/v1"
 interpreter.llm.supports_functions = True

--- a/interpreter/terminal_interface/profiles/defaults/minimax.py
+++ b/interpreter/terminal_interface/profiles/defaults/minimax.py
@@ -1,0 +1,32 @@
+"""
+This is an Open Interpreter profile to use MiniMax.
+
+Please set the MINIMAX_API_KEY environment variable.
+
+MiniMax provides powerful language models with a 204,800 token context window.
+Available models:
+  - MiniMax-M2.5 (default): Peak Performance. Ultimate Value.
+  - MiniMax-M2.5-highspeed: Same performance, faster and more agile.
+
+See https://platform.minimax.io/docs/api-reference/text-openai-api for more information.
+"""
+
+from interpreter import interpreter
+import os
+
+# LLM settings
+interpreter.llm.model = "openai/MiniMax-M2.5"
+interpreter.llm.api_key = os.environ.get("MINIMAX_API_KEY")
+interpreter.llm.api_base = "https://api.minimax.io/v1"
+interpreter.llm.supports_functions = True
+interpreter.llm.supports_vision = False
+interpreter.llm.max_tokens = 4096
+interpreter.llm.context_window = 204800
+interpreter.llm.temperature = 1.0
+
+# Computer settings
+interpreter.computer.import_computer_api = True
+
+# Misc settings
+interpreter.offline = False
+interpreter.auto_run = False


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use M3 as the default model.

## Changes
- Set `MiniMax-M3` as the default model in the MiniMax profile
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives (older M2.5 variants removed)
- Update context window to 512K and enable vision support
- Update README documentation to reflect new default model

## Why
MiniMax-M3 is the latest flagship model, with a 512K context window, up to 128K output, and image input support.

## Testing
- Profile loads successfully with M3 set as default
- MINIMAX_API_KEY environment variable is honored