### PR TITLE
Fix typo in print statement for immediate execution

### DIFF
--- a/interpreter/core/computer/skills/skills.py
+++ b/interpreter/core/computer/skills/skills.py
@@ -237,7 +237,7 @@ def {normalized_name}(step=0):
         else:
             computer.mouse.click(steps[step]["element"], icon_dimensions=steps[step]["icon_dimensions"]) # Instructed click
         if step + 1 < len(steps):
-            print("After completing the above, I need you to run {normalized_name}(step=" + str(step + 1) + ") immediatly.")
+            print("After completing the above, I need you to run {normalized_name}(step=" + str(step + 1) + ") immediately.")
         else:
             print("After executing the code, you have completed all the steps, the task/skill has been run!")
     else:


### PR DESCRIPTION
### Describe the changes you have made:
Fixed a typo in a user-facing print statement within interpreter/core/computer/skills/skills.py.
Specifically, corrected "immediatly" to "immediately" to improve clarity and professionalism of the output message.

### Reference any relevant issues (e.g. "Fixes #000"):
N/A (minor typo fix)
### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [X] I have read `docs/CONTRIBUTING.md`
- [X] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [X] Tested on Windows
- [X] Tested on MacOS
- [X] Tested on Linux
