### PR TITLE
docs(local-models): add Rapid-MLX (Apple Silicon) provider page

### DIFF
--- a/docs/language-models/local-models/rapid-mlx.mdx
+++ b/docs/language-models/local-models/rapid-mlx.mdx
@@ -1,0 +1,41 @@
+---
+title: Rapid-MLX
+---
+
+[Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) is an OpenAI-compatible
+inference server for Apple Silicon that runs MLX-quantized models natively,
+with streaming and tool calling.
+
+## Setup
+
+Install and start the server:
+
+```shell
+pip install rapid-mlx
+rapid-mlx serve mlx-community/Qwen3.5-4B-MLX-4bit
+```
+
+The server listens on `http://localhost:8000/v1`.
+
+## Terminal usage
+
+```shell
+interpreter --api_base "http://localhost:8000/v1" --api_key "fake_key" --model "openai/mlx-community/Qwen3.5-4B-MLX-4bit"
+```
+
+## Python usage
+
+```python
+from interpreter import interpreter
+
+interpreter.offline = True
+interpreter.llm.model = "openai/mlx-community/Qwen3.5-4B-MLX-4bit"
+interpreter.llm.api_key = "fake_key"
+interpreter.llm.api_base = "http://localhost:8000/v1"
+
+interpreter.chat()
+```
+
+Rapid-MLX includes 18 built-in tool-call parsers (hermes, llama3, qwen,
+glm47, minimax, gemma4, etc.), so function calling works with Open
+Interpreter's tool-driven workflow for the supported open-weight models.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -91,6 +91,7 @@
             "language-models/local-models/llamafile",
             "language-models/local-models/janai",
             "language-models/local-models/lm-studio",
+            "language-models/local-models/rapid-mlx",
             "language-models/local-models/custom-endpoint",
             "language-models/local-models/best-practices"
           ]


### PR DESCRIPTION
## Summary

Adds a new local-model docs page for [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX),
an OpenAI-compatible inference server for Apple Silicon built on Apple's
MLX framework, with streaming and native tool calling.

## Why

The current local-model pages cover Ollama, LM Studio, llamafile, and
Jan.ai, but none of them are MLX-native. Rapid-MLX fills this gap for
Apple Silicon users — it's pip-installable, exposes the standard
`http://localhost:8000/v1` chat completions API, and works with the
existing `--api_base` flag, so no Open Interpreter code changes are
needed.

## Files

- New: `docs/language-models/local-models/rapid-mlx.mdx` (modeled on
  `lm-studio.mdx`)
- Updated: `docs/mint.json` (registers the new page in the
  Local Providers nav group, between LM Studio and Custom Endpoint)

## Scope

Docs only. No code, no API changes.