### PR TITLE
Add autonomous agent framework (Kairos) + OpenInterpreter integration (Phase 1 & 2)

### DIFF
--- a/kairos_agent/__init__.py
+++ b/kairos_agent/__init__.py
@@ -1,0 +1,64 @@
+"""Kairos Agent — autonomous agent framework (standalone, host-agnostic).
+
+The package is organized as a small set of cooperating modules:
+
+    common/        — interfaces, DTOs, logging, filesystem helpers
+    memory/        — persistent storage of events, profile, plans
+    coordinator/   — priority queue + locks that route work between modules
+    kairos/        — the persistent tick loop, state, and triggers
+    autodream/     — periodic memory consolidation (LLM-backed)
+    ultraplan/     — goal → structured plan decomposition
+    normalizer/    — style + privacy helpers (stub at MVP)
+    adapters/      — host integrations (open-interpreter, ...) — Phase 2
+
+Public surface is intentionally narrow: instantiate KairosConfig, then build
+MemoryManager, Coordinator, KairosCore from it. See README / plan for usage.
+"""
+from .autodream import AutoDream, Summarizer
+from .common import (
+    Clock,
+    DummyLLMClient,
+    EventBus,
+    LLMClient,
+    SystemClock,
+    TaskRequest,
+    TriggerEvent,
+    configure_logging,
+    get_logger,
+)
+from .config import KairosConfig
+from .coordinator import Coordinator
+from .kairos import InactivityTrigger, KairosCore, TimeTrigger, Trigger
+from .memory import MemoryManager
+from .normalizer import format_code, redact_pii
+from .ultraplan import Plan, Task, UltraPlan
+
+__all__ = [
+    # config + interfaces
+    "KairosConfig",
+    "LLMClient",
+    "DummyLLMClient",
+    "Clock",
+    "SystemClock",
+    "EventBus",
+    "TaskRequest",
+    "TriggerEvent",
+    "configure_logging",
+    "get_logger",
+    # core building blocks
+    "MemoryManager",
+    "Coordinator",
+    "KairosCore",
+    "Trigger",
+    "TimeTrigger",
+    "InactivityTrigger",
+    # services
+    "AutoDream",
+    "Summarizer",
+    "UltraPlan",
+    "Plan",
+    "Task",
+    # utilities
+    "redact_pii",
+    "format_code",
+]

--- a/kairos_agent/adapters/__init__.py
+++ b/kairos_agent/adapters/__init__.py
@@ -1,1 +1,4 @@
-"""Host integrations live here. Empty at MVP — see plan Phase 2."""
+"""Host integrations.
+
+Phase 2 adapter for open-interpreter. More adapters (LangChain, etc.) later.
+"""

--- a/kairos_agent/adapters/__init__.py
+++ b/kairos_agent/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Host integrations live here. Empty at MVP — see plan Phase 2."""

--- a/kairos_agent/adapters/open_interpreter.py
+++ b/kairos_agent/adapters/open_interpreter.py
@@ -1,0 +1,232 @@
+"""Adapter that bridges open-interpreter ↔ kairos_agent.
+
+Zero modifications to interpreter/core/core.py — everything is wired via
+composition and monkey-patching of the interpreter instance at runtime.
+
+Usage
+-----
+    from interpreter import interpreter
+    from kairos_agent.adapters.open_interpreter import attach_to_interpreter
+
+    kairos = attach_to_interpreter(interpreter, tick_interval=10.0)
+    interpreter.chat("Hello!")
+    # ... Kairos observes, consolidates, plans in background ...
+    kairos.stop()
+"""
+from __future__ import annotations
+
+import functools
+import logging
+from datetime import timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from ..autodream import AutoDream
+from ..common.interfaces import LLMClient
+from ..common.logger import get_logger
+from ..config import KairosConfig
+from ..coordinator import Coordinator
+from ..kairos import InactivityTrigger, KairosCore
+from ..memory import MemoryManager
+from ..ultraplan import UltraPlan
+
+if TYPE_CHECKING:
+    from interpreter.core.core import OpenInterpreter
+
+_log = get_logger("adapter.oi")
+
+
+# ---------------------------------------------------------------------------
+# 1. LLMClient adapter
+# ---------------------------------------------------------------------------
+
+class OpenInterpreterLLMClient(LLMClient):
+    """Adapts ``interpreter.llm.run()`` to the ``LLMClient.complete()`` ABC.
+
+    ``interpreter.llm.run(messages)`` is a **generator** that yields LMC chunks
+    (``{"type": "message", "content": "..."}``).  We iterate the generator,
+    concatenate all message-type chunks, and return a single string.
+    """
+
+    def __init__(self, interpreter: "OpenInterpreter"):
+        self._interpreter = interpreter
+
+    def complete(self, prompt: str, **kwargs: Any) -> str:
+        system_text = kwargs.pop("system", "You are a helpful assistant.")
+
+        # Build LMC-format messages expected by interpreter.llm.run().
+        messages = [
+            {"role": "system", "type": "message", "content": system_text},
+            {"role": "user", "type": "message", "content": prompt},
+        ]
+
+        parts: list[str] = []
+        try:
+            for chunk in self._interpreter.llm.run(messages):
+                if chunk.get("type") == "message":
+                    content = chunk.get("content", "")
+                    if content:
+                        parts.append(content)
+        except Exception as exc:
+            _log.exception("adapter.llm_error", extra={"err": str(exc)})
+            raise
+
+        return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# 2. Chat wrapper for automatic event recording
+# ---------------------------------------------------------------------------
+
+def _wrap_chat(original_chat, kairos: KairosCore, memory: MemoryManager):
+    """Return a wrapper around ``interpreter.chat()`` that records events.
+
+    Before the call we signal user activity (re-arms InactivityTrigger).
+    After a successful call we persist the new messages as memory events so
+    AutoDream can consolidate them later.
+    """
+
+    @functools.wraps(original_chat)
+    def wrapped(message=None, display=True, stream=False, blocking=True):
+        # Record user activity (text) for the inactivity trigger.
+        if message is not None:
+            text = message if isinstance(message, str) else str(message)[:200]
+            kairos.record_user_activity({"text": text})
+
+        # Delegate to the real chat().
+        result = original_chat(message=message, display=display,
+                               stream=stream, blocking=blocking)
+
+        # After the chat round-trip, persist new assistant messages.
+        if blocking and not stream:
+            try:
+                interpreter = original_chat.__self__  # type: ignore[attr-defined]
+                new_msgs = interpreter.messages[interpreter.last_messages_count:]
+                for msg in new_msgs:
+                    memory.save_event(
+                        kind=f"{msg.get('role', 'unknown')}_{msg.get('type', 'unknown')}",
+                        payload={
+                            "content": str(msg.get("content", ""))[:500],
+                            "format": msg.get("format"),
+                        },
+                    )
+            except Exception:
+                _log.exception("adapter.event_save_error")
+
+        return result
+
+    return wrapped
+
+
+# ---------------------------------------------------------------------------
+# 3. Helper: one-call wiring
+# ---------------------------------------------------------------------------
+
+def attach_to_interpreter(
+    interpreter: "OpenInterpreter",
+    *,
+    storage_path: str | Path | None = None,
+    tick_interval: float = 30.0,
+    inactivity_seconds: float = 300.0,
+    log_level: int = logging.INFO,
+    log_to_console: bool = False,
+) -> KairosCore:
+    """Wire Kairos into an existing ``OpenInterpreter`` instance.
+
+    Creates the full module graph (config, memory, coordinator, autodream,
+    ultraplan, kairos) and starts the background tick loop. The interpreter's
+    ``chat()`` method is transparently wrapped so every conversation is
+    recorded as memory events — no manual calls required.
+
+    Parameters
+    ----------
+    interpreter
+        A live ``OpenInterpreter`` instance (``from interpreter import interpreter``).
+    storage_path
+        Where to store kairos.db, profile.json, and logs. Defaults to
+        ``~/.kairos_agent``.
+    tick_interval
+        Seconds between Kairos ticks.
+    inactivity_seconds
+        Seconds of silence before AutoDream is triggered.
+    log_level / log_to_console
+        Forwarded to ``configure_logging``.
+
+    Returns
+    -------
+    KairosCore
+        The started agent. Call ``.stop()`` when done.
+    """
+    # Resolve storage path — prefer the host's storage dir if available.
+    if storage_path is None:
+        try:
+            from interpreter.terminal_interface.utils.local_storage_path import (
+                get_storage_path,
+            )
+            storage_path = get_storage_path("kairos")
+        except ImportError:
+            storage_path = None  # falls back to ~/.kairos_agent
+
+    # --- Config ---
+    llm = OpenInterpreterLLMClient(interpreter)
+    config = KairosConfig(
+        storage_path=storage_path,
+        tick_interval=tick_interval,
+        log_level=log_level,
+        log_to_console=log_to_console,
+        llm_client=llm,
+    )
+
+    # --- Memory ---
+    memory = MemoryManager(config)
+
+    # --- Coordinator + handlers ---
+    coordinator = Coordinator()
+    autodream = AutoDream(config, memory)
+    ultraplan = UltraPlan(llm, memory)
+    coordinator.register("autodream.run", autodream.run)
+    coordinator.register("ultraplan.generate",
+                         lambda task: ultraplan.generate(task.payload.get("goal", "")))
+
+    # --- KairosCore + triggers ---
+    kairos = KairosCore(config, coordinator, memory)
+    kairos.register_trigger(
+        InactivityTrigger(
+            silence=timedelta(seconds=inactivity_seconds),
+            handler_name="autodream.run",
+            priority=3,
+        ),
+    )
+
+    # --- Wrap chat ---
+    interpreter.chat = _wrap_chat(interpreter.chat, kairos, memory)
+
+    # --- Attach and start ---
+    interpreter.kairos = kairos  # type: ignore[attr-defined]
+    interpreter.kairos_memory = memory  # type: ignore[attr-defined]
+    kairos.start()
+    _log.info("adapter.attached", extra={
+        "model": getattr(interpreter.llm, "model", "unknown"),
+        "tick_interval": tick_interval,
+        "inactivity_seconds": inactivity_seconds,
+    })
+
+    return kairos
+
+
+def detach_from_interpreter(interpreter: "OpenInterpreter") -> None:
+    """Stop Kairos and restore the original ``chat()`` method."""
+    kairos = getattr(interpreter, "kairos", None)
+    if kairos is not None:
+        kairos.stop()
+
+    # Restore original chat if it was wrapped.
+    if hasattr(interpreter.chat, "__wrapped__"):
+        interpreter.chat = interpreter.chat.__wrapped__
+
+    # Clean up the attributes we added.
+    for attr in ("kairos", "kairos_memory"):
+        if hasattr(interpreter, attr):
+            delattr(interpreter, attr)
+
+    _log.info("adapter.detached")

--- a/kairos_agent/autodream/__init__.py
+++ b/kairos_agent/autodream/__init__.py
@@ -1,0 +1,5 @@
+"""Periodic memory consolidation."""
+from .consolidator import AutoDream
+from .summarizer import Summarizer
+
+__all__ = ["AutoDream", "Summarizer"]

--- a/kairos_agent/autodream/consolidator.py
+++ b/kairos_agent/autodream/consolidator.py
@@ -1,0 +1,55 @@
+"""AutoDream — periodic memory consolidation.
+
+Triggered by Kairos (typically after a period of user inactivity), AutoDream
+reads unconsolidated events from MemoryManager, asks a Summarizer to compress
+them, writes the result onto the user profile, and marks the source events
+consolidated so they aren't summarized again.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from ..common.dto import TaskRequest
+from ..common.logger import get_logger
+from ..config import KairosConfig
+from ..memory.manager import MemoryManager
+from .summarizer import Summarizer
+
+
+_log = get_logger("autodream")
+
+
+class AutoDream:
+    def __init__(self, config: KairosConfig, memory: MemoryManager,
+                 summarizer: Summarizer | None = None):
+        self._config = config
+        self._memory = memory
+        self._summarizer = summarizer or Summarizer(config.llm_client)
+
+    def run(self, task: TaskRequest | None = None) -> dict[str, Any]:
+        """Pipeline entry point. Returns a small report dict for logging/tests."""
+        events = self._memory.load_events(consolidated=False, limit=500)
+        _log.info("autodream.start", extra={"event_count": len(events)})
+        if not events:
+            return {"events_consolidated": 0, "summary": ""}
+
+        summary = self._summarizer.summarize(events)
+        profile = self._memory.load_profile()
+        # Keep a rolling list of summaries so the agent has a memory of memories.
+        history = profile.data.setdefault("summary_history", [])
+        history.append({
+            "ts": self._config.clock.now().isoformat(),
+            "event_count": len(events),
+            "summary": summary,
+        })
+        profile.data["last_summary"] = summary
+        profile.data["last_consolidation"] = self._config.clock.now().isoformat()
+        self._memory.save_profile(profile)
+
+        ids = [e.id for e in events if e.id is not None]
+        self._memory.mark_events_consolidated(ids)
+        _log.info("autodream.done", extra={
+            "events_consolidated": len(ids),
+            "summary_chars": len(summary),
+        })
+        return {"events_consolidated": len(ids), "summary": summary}

--- a/kairos_agent/autodream/summarizer.py
+++ b/kairos_agent/autodream/summarizer.py
@@ -1,0 +1,56 @@
+"""Summarizer used by AutoDream.
+
+Wraps an LLMClient with a deterministic fallback so the consolidation pipeline
+remains usable in tests and offline runs.
+"""
+from __future__ import annotations
+
+import json
+
+from ..common.interfaces import LLMClient
+from ..memory.schemas import EventRecord
+
+
+_PROMPT_TEMPLATE = (
+    "You are an autonomous agent's memory consolidator. Read the following "
+    "recent events and produce a concise (max 6 sentences) summary that "
+    "captures the user's intent, decisions made, and anything worth remembering "
+    "for future sessions. Respond with plain text only.\n\n"
+    "Events (JSON):\n{events}\n\nSummary:"
+)
+
+
+class Summarizer:
+    def __init__(self, llm: LLMClient | None):
+        self._llm = llm
+
+    def summarize(self, events: list[EventRecord]) -> str:
+        if not events:
+            return ""
+        if self._llm is None:
+            return self._fallback(events)
+        prompt = _PROMPT_TEMPLATE.format(events=self._render_events(events))
+        try:
+            return self._llm.complete(prompt).strip()
+        except Exception:  # noqa: BLE001 — never let consolidation crash
+            return self._fallback(events)
+
+    @staticmethod
+    def _render_events(events: list[EventRecord]) -> str:
+        rendered = [
+            {
+                "ts": e.ts.isoformat(),
+                "kind": e.kind,
+                "payload": e.payload,
+            }
+            for e in events
+        ]
+        return json.dumps(rendered, ensure_ascii=False, indent=2)
+
+    @staticmethod
+    def _fallback(events: list[EventRecord]) -> str:
+        kinds: dict[str, int] = {}
+        for e in events:
+            kinds[e.kind] = kinds.get(e.kind, 0) + 1
+        breakdown = ", ".join(f"{k}={v}" for k, v in sorted(kinds.items()))
+        return f"[fallback summary] {len(events)} events: {breakdown}"

--- a/kairos_agent/common/__init__.py
+++ b/kairos_agent/common/__init__.py
@@ -1,0 +1,20 @@
+"""Shared infrastructure: interfaces, DTOs, logging, paths."""
+from .dto import TaskRequest, TriggerEvent
+from .dummy_llm import DummyLLMClient
+from .interfaces import Clock, EventBus, LLMClient, SystemClock
+from .logger import configure_logging, get_logger
+from .paths import DEFAULT_STORAGE_DIR, ensure_storage_dir
+
+__all__ = [
+    "TaskRequest",
+    "TriggerEvent",
+    "DummyLLMClient",
+    "Clock",
+    "EventBus",
+    "LLMClient",
+    "SystemClock",
+    "configure_logging",
+    "get_logger",
+    "DEFAULT_STORAGE_DIR",
+    "ensure_storage_dir",
+]

--- a/kairos_agent/common/dto.py
+++ b/kairos_agent/common/dto.py
@@ -1,0 +1,41 @@
+"""Internal DTOs passed between Kairos modules.
+
+These are deliberately *not* the persistence schemas (which live in
+memory/schemas.py). Keeping them separate lets the persistence layer evolve
+without breaking the in-memory message bus.
+"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class TriggerEvent:
+    """Emitted by a Trigger when it decides Kairos should act."""
+    name: str
+    fired_at: datetime
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TaskRequest:
+    """A unit of work the Coordinator will dispatch to a registered handler.
+
+    `handler_name` matches a key in Coordinator's registry, e.g.
+    "autodream.run" or "ultraplan.generate". `payload` carries handler args.
+    """
+    handler_name: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    priority: int = 5  # 1 = urgent, 10 = optional
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    source: str = "kairos"  # who enqueued it (for logs)
+
+    def __lt__(self, other: "TaskRequest") -> bool:
+        # Required so PriorityQueue can break priority ties without crashing.
+        if not isinstance(other, TaskRequest):
+            return NotImplemented
+        return self.created_at < other.created_at

--- a/kairos_agent/common/dummy_llm.py
+++ b/kairos_agent/common/dummy_llm.py
@@ -1,0 +1,31 @@
+"""Deterministic LLMClient implementation for tests and offline smoke runs.
+
+Returns predictable strings without making any network calls. Two modes:
+- Default: echoes a tagged version of the prompt, useful for assertions.
+- Scripted: returns canned responses from a queue in order, falling back to
+  echo when the queue is exhausted.
+"""
+from __future__ import annotations
+
+from collections import deque
+from typing import Iterable
+
+from .interfaces import LLMClient
+
+
+class DummyLLMClient(LLMClient):
+    def __init__(self, scripted_responses: Iterable[str] | None = None):
+        self._queue: deque[str] = deque(scripted_responses or [])
+        self.call_count = 0
+        self.last_prompt: str | None = None
+
+    def complete(self, prompt: str, **kwargs) -> str:
+        self.call_count += 1
+        self.last_prompt = prompt
+        if self._queue:
+            return self._queue.popleft()
+        # Echo mode: short, deterministic, parseable.
+        return f"[dummy-llm] {prompt[:120]}"
+
+    def push_response(self, response: str) -> None:
+        self._queue.append(response)

--- a/kairos_agent/common/interfaces.py
+++ b/kairos_agent/common/interfaces.py
@@ -1,0 +1,59 @@
+"""Abstract interfaces that decouple kairos_agent from any host application.
+
+Every external dependency Kairos has on the outside world (LLM provider, wall
+clock, event source) goes through one of these ABCs. This is what makes the
+package standalone-testable: the host wires real implementations in, and tests
+inject deterministic fakes.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Callable
+
+
+class LLMClient(ABC):
+    """Minimal LLM contract Kairos depends on.
+
+    Implementations adapt this to whatever provider the host uses
+    (open-interpreter's Llm, raw OpenAI/Anthropic SDK, a local model, etc.).
+    """
+
+    @abstractmethod
+    def complete(self, prompt: str, **kwargs) -> str:
+        """Return a single completion string for the given prompt.
+
+        kwargs are passed through to the underlying provider (model, temperature,
+        max_tokens, ...). Implementations should silently ignore unknown kwargs.
+        """
+
+
+class Clock(ABC):
+    """Wall-clock abstraction. Mockable in tests via FakeClock."""
+
+    @abstractmethod
+    def now(self) -> datetime:
+        ...
+
+
+class SystemClock(Clock):
+    """Default real-time clock."""
+
+    def now(self) -> datetime:
+        return datetime.utcnow()
+
+
+class EventBus(ABC):
+    """Optional pub/sub for external triggers (e.g. host signals end of session).
+
+    Kairos works without an EventBus — triggers fall back to time-based polling.
+    Hosts that want push-based triggers implement this and pass it to KairosCore.
+    """
+
+    @abstractmethod
+    def publish(self, topic: str, payload: dict) -> None:
+        ...
+
+    @abstractmethod
+    def subscribe(self, topic: str, handler: Callable[[dict], None]) -> None:
+        ...

--- a/kairos_agent/common/logger.py
+++ b/kairos_agent/common/logger.py
@@ -1,0 +1,124 @@
+"""Structured JSON-line logging for kairos_agent.
+
+One file handler shared by all submodules under <storage_path>/logs/kairos.log,
+plus an optional console handler. Each record is one JSON object per line so
+logs can be tailed and parsed by simple tooling.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+_CONFIGURED = False
+_LOG_FILE: Path | None = None
+
+# Reserved attribute names used internally by LogRecord. Anything in the user's
+# `extra=` mapping that collides with one of these would otherwise raise
+# KeyError inside logging.makeRecord. We rename collisions on the way in so
+# call sites don't have to know the list.
+_RESERVED_RECORD_FIELDS = frozenset({
+    "name", "msg", "args", "levelname", "levelno", "pathname", "filename",
+    "module", "exc_info", "exc_text", "stack_info", "lineno", "funcName",
+    "created", "msecs", "relativeCreated", "thread", "threadName",
+    "processName", "process", "message", "asctime",
+})
+
+
+def _sanitize_extra(extra: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not extra:
+        return extra
+    safe: dict[str, Any] = {}
+    for key, value in extra.items():
+        if key in _RESERVED_RECORD_FIELDS:
+            safe[f"{key}_"] = value
+        else:
+            safe[key] = value
+    return safe
+
+
+class _JsonLineFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "ts": self.formatTime(record, "%Y-%m-%dT%H:%M:%S"),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        # Include any structured extras attached via logger.info(..., extra={...}).
+        for key, value in record.__dict__.items():
+            if key in ("args", "msg", "levelname", "levelno", "pathname", "filename",
+                       "module", "exc_info", "exc_text", "stack_info", "lineno",
+                       "funcName", "created", "msecs", "relativeCreated", "thread",
+                       "threadName", "processName", "process", "name", "message",
+                       "asctime"):
+                continue
+            try:
+                json.dumps(value)
+                payload[key] = value
+            except TypeError:
+                payload[key] = repr(value)
+        if record.exc_info:
+            payload["exc"] = self.formatException(record.exc_info)
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def configure_logging(storage_dir: Path, level: int = logging.INFO,
+                      console: bool = False) -> Path:
+    """Set up the kairos_agent logger hierarchy. Idempotent.
+
+    Returns the path to the log file so callers can surface it to the user.
+    """
+    global _CONFIGURED, _LOG_FILE
+    log_file = storage_dir / "logs" / "kairos.log"
+    if _CONFIGURED and _LOG_FILE == log_file:
+        return log_file
+
+    root = logging.getLogger("kairos_agent")
+    root.setLevel(level)
+    # Clear any prior handlers if reconfiguring (e.g. tests with new tmp dir).
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+
+    formatter = _JsonLineFormatter()
+
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    root.addHandler(file_handler)
+
+    if console:
+        console_handler = logging.StreamHandler(sys.stderr)
+        console_handler.setFormatter(formatter)
+        root.addHandler(console_handler)
+
+    root.propagate = False
+    _CONFIGURED = True
+    _LOG_FILE = log_file
+    return log_file
+
+
+class _SafeLogger(logging.Logger):
+    """Logger that sanitizes `extra=` keys to avoid LogRecord field collisions."""
+
+    def _log(self, level, msg, args, exc_info=None, extra=None,  # type: ignore[override]
+             stack_info=False, stacklevel=1):
+        super()._log(level, msg, args, exc_info=exc_info,
+                     extra=_sanitize_extra(extra), stack_info=stack_info,
+                     stacklevel=stacklevel)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a child logger of the kairos_agent root.
+
+    Pass the submodule name without the prefix, e.g. get_logger("memory").
+    Calling before configure_logging() still works — records will buffer until
+    a handler is attached.
+    """
+    full_name = f"kairos_agent.{name}"
+    logger = logging.getLogger(full_name)
+    # Force the safe subclass on every kairos_agent.* logger so any caller
+    # benefits from extras sanitization.
+    logger.__class__ = _SafeLogger
+    return logger

--- a/kairos_agent/common/paths.py
+++ b/kairos_agent/common/paths.py
@@ -1,0 +1,20 @@
+"""Filesystem helpers for Kairos storage."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+DEFAULT_STORAGE_DIR = Path.home() / ".kairos_agent"
+
+
+def ensure_storage_dir(path: str | os.PathLike | None = None) -> Path:
+    """Resolve a storage directory, create it if needed, return the Path.
+
+    If `path` is None, falls back to ~/.kairos_agent. The `logs/` subdirectory
+    is also created so the logger can write immediately.
+    """
+    target = Path(path) if path is not None else DEFAULT_STORAGE_DIR
+    target = target.expanduser().resolve()
+    (target / "logs").mkdir(parents=True, exist_ok=True)
+    return target

--- a/kairos_agent/config.py
+++ b/kairos_agent/config.py
@@ -1,0 +1,23 @@
+"""Top-level configuration object passed to every Kairos subsystem."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .common.interfaces import Clock, EventBus, LLMClient, SystemClock
+from .common.paths import DEFAULT_STORAGE_DIR
+
+
+@dataclass
+class KairosConfig:
+    storage_path: Path | str = DEFAULT_STORAGE_DIR
+    tick_interval: float = 30.0  # seconds between Kairos tick loop iterations
+    log_level: int = logging.INFO
+    log_to_console: bool = False
+    llm_client: LLMClient | None = None  # required by AutoDream + UltraPlan
+    clock: Clock = field(default_factory=SystemClock)
+    event_bus: EventBus | None = None
+
+    def __post_init__(self) -> None:
+        self.storage_path = Path(self.storage_path).expanduser()

--- a/kairos_agent/coordinator/__init__.py
+++ b/kairos_agent/coordinator/__init__.py
@@ -1,0 +1,5 @@
+"""Internal task router and lock registry."""
+from .coordinator import Coordinator, Handler
+from .locks import LockRegistry
+
+__all__ = ["Coordinator", "Handler", "LockRegistry"]

--- a/kairos_agent/coordinator/coordinator.py
+++ b/kairos_agent/coordinator/coordinator.py
@@ -1,0 +1,123 @@
+"""Internal task router.
+
+The Coordinator is the single writer to the persistent modules. Kairos and
+external code never call AutoDream/UltraPlan directly — they enqueue a
+TaskRequest with a `handler_name` and the Coordinator dispatches it on its
+worker thread, holding a per-module lock to prevent conflicts.
+"""
+from __future__ import annotations
+
+import queue
+import threading
+from typing import Callable
+
+from ..common.dto import TaskRequest
+from ..common.logger import get_logger
+from .locks import LockRegistry
+
+
+_log = get_logger("coordinator")
+
+#: A handler is any callable that takes a TaskRequest. Return value is logged
+#: but otherwise ignored — handlers are expected to mutate state via MemoryManager.
+Handler = Callable[[TaskRequest], object]
+
+
+class Coordinator:
+    def __init__(self) -> None:
+        self._queue: queue.PriorityQueue[tuple[int, TaskRequest]] = queue.PriorityQueue()
+        self._registry: dict[str, Handler] = {}
+        self._locks = LockRegistry()
+        self._stop_event = threading.Event()
+        self._worker: threading.Thread | None = None
+
+    # ----- registration -----------------------------------------------------
+
+    def register(self, handler_name: str, handler: Handler) -> None:
+        if handler_name in self._registry:
+            raise ValueError(f"handler already registered: {handler_name}")
+        self._registry[handler_name] = handler
+        _log.info("coordinator.handler_registered", extra={"handler": handler_name})
+
+    # ----- enqueue / dispatch ----------------------------------------------
+
+    def enqueue(self, task: TaskRequest) -> None:
+        _log.info("coordinator.enqueue", extra={
+            "id": task.id,
+            "handler": task.handler_name,
+            "priority": task.priority,
+            "source": task.source,
+        })
+        self._queue.put((task.priority, task))
+
+    def _dispatch(self, task: TaskRequest) -> None:
+        handler = self._registry.get(task.handler_name)
+        if handler is None:
+            _log.warning("coordinator.no_handler", extra={
+                "id": task.id, "handler": task.handler_name,
+            })
+            return
+        # Lock by module prefix: "autodream.run" -> "autodream".
+        module_name = task.handler_name.split(".", 1)[0]
+        with self._locks.acquire(module_name) as acquired:
+            if not acquired:
+                _log.warning("coordinator.lock_unavailable", extra={
+                    "id": task.id, "module": module_name,
+                })
+                return
+            try:
+                handler(task)
+                _log.info("coordinator.task_done", extra={
+                    "id": task.id, "handler": task.handler_name,
+                })
+            except Exception as exc:  # noqa: BLE001 — log and continue
+                _log.exception("coordinator.task_error", extra={
+                    "id": task.id, "handler": task.handler_name, "err": str(exc),
+                })
+
+    # ----- worker thread ---------------------------------------------------
+
+    def start(self) -> None:
+        if self._worker is not None and self._worker.is_alive():
+            return
+        self._stop_event.clear()
+        self._worker = threading.Thread(
+            target=self._run, name="kairos-coordinator", daemon=True,
+        )
+        self._worker.start()
+        _log.info("coordinator.started")
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._stop_event.set()
+        # Wake the worker so it can observe the stop flag.
+        # We push a sentinel with the highest possible priority.
+        self._queue.put((-1, _SENTINEL))
+        if self._worker is not None:
+            self._worker.join(timeout=timeout)
+        _log.info("coordinator.stopped")
+
+    def run_pending(self) -> int:
+        """Drain the queue synchronously (used by tests). Returns task count."""
+        count = 0
+        while not self._queue.empty():
+            _, task = self._queue.get()
+            if task is _SENTINEL:
+                continue
+            self._dispatch(task)
+            count += 1
+        return count
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                _, task = self._queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            if task is _SENTINEL:
+                continue
+            self._dispatch(task)
+
+
+# Sentinel sortable by PriorityQueue. Using a TaskRequest with a fixed id keeps
+# tuple comparison happy.
+_SENTINEL = TaskRequest(handler_name="__sentinel__", priority=-1)

--- a/kairos_agent/coordinator/locks.py
+++ b/kairos_agent/coordinator/locks.py
@@ -1,0 +1,38 @@
+"""Named locks to prevent module-level conflicts.
+
+Used by Coordinator to ensure that two TaskRequests targeting the same module
+(e.g. autodream.run while another autodream.run is in flight) serialize.
+"""
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from typing import Iterator
+
+
+class LockRegistry:
+    def __init__(self) -> None:
+        self._locks: dict[str, threading.Lock] = {}
+        self._meta_lock = threading.Lock()
+
+    def _get(self, name: str) -> threading.Lock:
+        with self._meta_lock:
+            lock = self._locks.get(name)
+            if lock is None:
+                lock = threading.Lock()
+                self._locks[name] = lock
+            return lock
+
+    @contextmanager
+    def acquire(self, name: str, timeout: float | None = None) -> Iterator[bool]:
+        """Acquire the named lock for the duration of the with-block.
+
+        Yields True if the lock was acquired, False on timeout. Always releases.
+        """
+        lock = self._get(name)
+        acquired = lock.acquire(timeout=timeout) if timeout is not None else lock.acquire()
+        try:
+            yield acquired
+        finally:
+            if acquired:
+                lock.release()

--- a/kairos_agent/kairos/__init__.py
+++ b/kairos_agent/kairos/__init__.py
@@ -1,0 +1,14 @@
+"""Persistent agent loop."""
+from .core import KairosCore
+from .scheduler import Scheduler
+from .state import KairosState
+from .triggers import InactivityTrigger, TimeTrigger, Trigger
+
+__all__ = [
+    "KairosCore",
+    "Scheduler",
+    "KairosState",
+    "Trigger",
+    "TimeTrigger",
+    "InactivityTrigger",
+]

--- a/kairos_agent/kairos/core.py
+++ b/kairos_agent/kairos/core.py
@@ -1,0 +1,110 @@
+"""KairosCore — the persistent agent loop.
+
+Owns the Scheduler, the KairosState, and the list of Triggers. On every tick
+it (1) refreshes state from MemoryManager, (2) asks each Trigger if it wants
+to fire, and (3) enqueues any produced TaskRequests on the Coordinator. Kairos
+itself is intentionally dumb: all the actual work happens in handlers
+registered on the Coordinator.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from ..common.dto import TaskRequest
+from ..common.logger import configure_logging, get_logger
+from ..common.paths import ensure_storage_dir
+from ..config import KairosConfig
+from ..coordinator.coordinator import Coordinator
+from ..memory.manager import MemoryManager
+from .scheduler import Scheduler
+from .state import KairosState
+from .triggers import Trigger
+
+
+_log = get_logger("kairos")
+
+
+class KairosCore:
+    def __init__(
+        self,
+        config: KairosConfig,
+        coordinator: Coordinator,
+        memory: MemoryManager,
+    ) -> None:
+        self._config = config
+        self._coordinator = coordinator
+        self._memory = memory
+        self._triggers: list[Trigger] = []
+        self._state = KairosState(started_at=config.clock.now())
+        self._scheduler = Scheduler(
+            interval=config.tick_interval,
+            on_tick=self.tick,
+            name="kairos-tick",
+        )
+
+    # ----- public API -------------------------------------------------------
+
+    @property
+    def state(self) -> KairosState:
+        return self._state
+
+    def register_trigger(self, trigger: Trigger) -> None:
+        self._triggers.append(trigger)
+        _log.info("kairos.trigger_registered",
+                  extra={"type": type(trigger).__name__})
+
+    def record_user_activity(self, payload: dict[str, Any] | None = None) -> None:
+        """Tell Kairos the user just did something.
+
+        Persists an event to memory and updates state so InactivityTrigger
+        re-arms. Hosts call this from their input loop (e.g. open-interpreter
+        adapter calls it from `_streaming_chat`).
+        """
+        now = self._config.clock.now()
+        self._state.mark_user_activity(now)
+        self._memory.save_event(
+            kind="user_activity",
+            payload=payload or {},
+        )
+
+    def start(self) -> None:
+        ensure_storage_dir(self._config.storage_path)
+        configure_logging(self._config.storage_path,
+                          level=self._config.log_level,
+                          console=self._config.log_to_console)
+        # Refresh state from memory before starting the loop so triggers see
+        # any prior profile.
+        try:
+            self._state.profile = self._memory.load_profile().data
+        except Exception:  # noqa: BLE001 — fresh install path
+            self._state.profile = {}
+        self._coordinator.start()
+        self._scheduler.start()
+        _log.info("kairos.started", extra={
+            "tick_interval": self._config.tick_interval,
+            "trigger_count": len(self._triggers),
+        })
+
+    def stop(self) -> None:
+        self._scheduler.stop()
+        self._coordinator.stop()
+        _log.info("kairos.stopped", extra={"ticks": self._state.tick_count})
+
+    def tick(self) -> None:
+        """One iteration of the loop. Public so tests can drive it directly."""
+        now = self._config.clock.now()
+        self._state.mark_tick(now)
+        _log.info("kairos.tick", extra={"n": self._state.tick_count})
+        produced: list[TaskRequest] = []
+        for trigger in self._triggers:
+            try:
+                task = trigger.evaluate(self._state)
+            except Exception as exc:  # noqa: BLE001
+                _log.exception("kairos.trigger_error", extra={
+                    "trigger": type(trigger).__name__, "err": str(exc),
+                })
+                continue
+            if task is not None:
+                produced.append(task)
+        for task in produced:
+            self._coordinator.enqueue(task)

--- a/kairos_agent/kairos/scheduler.py
+++ b/kairos_agent/kairos/scheduler.py
@@ -1,0 +1,50 @@
+"""Background tick driver.
+
+Tiny on purpose: it's a daemon thread that calls a callback every `interval`
+seconds until told to stop. Kairos owns the callback and the state mutation;
+the scheduler is just the timing mechanism, isolated so it can be swapped for
+asyncio or APScheduler later without touching KairosCore.
+"""
+from __future__ import annotations
+
+import threading
+from typing import Callable
+
+
+class Scheduler:
+    def __init__(self, interval: float, on_tick: Callable[[], None],
+                 name: str = "kairos-scheduler"):
+        self._interval = interval
+        self._on_tick = on_tick
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._name = name
+
+    @property
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def start(self) -> None:
+        if self.is_running:
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, name=self._name, daemon=True)
+        self._thread.start()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+
+    def _run(self) -> None:
+        # First tick fires immediately so callers don't wait a full interval
+        # to see Kairos do anything on startup.
+        while not self._stop.is_set():
+            try:
+                self._on_tick()
+            except Exception:  # noqa: BLE001 — never let the loop die
+                # Logged inside the callback; we just don't propagate.
+                pass
+            # Use Event.wait so stop() can interrupt the sleep immediately.
+            if self._stop.wait(self._interval):
+                break

--- a/kairos_agent/kairos/state.py
+++ b/kairos_agent/kairos/state.py
@@ -1,0 +1,28 @@
+"""In-memory snapshot of what Kairos currently believes about itself.
+
+Distinct from MemoryManager (which is durable) — this is the working set the
+tick loop uses to decide what to do next, refreshed on demand from memory.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass
+class KairosState:
+    started_at: datetime
+    last_tick_at: datetime | None = None
+    last_user_activity_at: datetime | None = None
+    profile: dict[str, Any] = field(default_factory=dict)
+    active_plan_id: int | None = None
+    tick_count: int = 0
+    context: dict[str, Any] = field(default_factory=dict)
+
+    def mark_user_activity(self, when: datetime) -> None:
+        self.last_user_activity_at = when
+
+    def mark_tick(self, when: datetime) -> None:
+        self.last_tick_at = when
+        self.tick_count += 1

--- a/kairos_agent/kairos/triggers.py
+++ b/kairos_agent/kairos/triggers.py
@@ -1,0 +1,87 @@
+"""Trigger primitives evaluated each tick.
+
+A Trigger looks at KairosState and returns either None (do nothing) or a
+TaskRequest to enqueue. Triggers are stateless aside from the small bookkeeping
+they need to detect "fired since last tick".
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import timedelta
+
+from ..common.dto import TaskRequest
+from .state import KairosState
+
+
+class Trigger(ABC):
+    """Pure decision unit. Inspects state, optionally produces a TaskRequest."""
+
+    @abstractmethod
+    def evaluate(self, state: KairosState) -> TaskRequest | None:
+        ...
+
+
+class TimeTrigger(Trigger):
+    """Fires once every `interval`, regardless of activity."""
+
+    def __init__(self, interval: timedelta, handler_name: str,
+                 priority: int = 5, payload: dict | None = None):
+        self._interval = interval
+        self._handler = handler_name
+        self._priority = priority
+        self._payload = payload or {}
+        self._last_fired_at = None  # type: ignore[var-annotated]
+
+    def evaluate(self, state: KairosState) -> TaskRequest | None:
+        now = state.last_tick_at
+        if now is None:
+            return None
+        if self._last_fired_at is None or (now - self._last_fired_at) >= self._interval:
+            self._last_fired_at = now
+            return TaskRequest(
+                handler_name=self._handler,
+                priority=self._priority,
+                payload=dict(self._payload),
+                source="kairos.time_trigger",
+            )
+        return None
+
+
+class InactivityTrigger(Trigger):
+    """Fires after `silence` seconds without observed user activity.
+
+    Re-arms only after another user activity is observed, so it doesn't
+    re-fire on every tick once the threshold is past.
+    """
+
+    def __init__(self, silence: timedelta, handler_name: str,
+                 priority: int = 5, payload: dict | None = None):
+        self._silence = silence
+        self._handler = handler_name
+        self._priority = priority
+        self._payload = payload or {}
+        self._fired_for_window: bool = False
+        self._last_seen_activity = None  # type: ignore[var-annotated]
+
+    def evaluate(self, state: KairosState) -> TaskRequest | None:
+        now = state.last_tick_at
+        if now is None:
+            return None
+        if state.last_user_activity_at != self._last_seen_activity:
+            # New activity since we last looked → reset the latch.
+            self._last_seen_activity = state.last_user_activity_at
+            self._fired_for_window = False
+        if self._fired_for_window:
+            return None
+        # If we have no activity baseline, use Kairos start time so the trigger
+        # can still fire after long idle uptime.
+        baseline = state.last_user_activity_at or state.started_at
+        if (now - baseline) >= self._silence:
+            self._fired_for_window = True
+            return TaskRequest(
+                handler_name=self._handler,
+                priority=self._priority,
+                payload=dict(self._payload),
+                source="kairos.inactivity_trigger",
+            )
+        return None

--- a/kairos_agent/memory/__init__.py
+++ b/kairos_agent/memory/__init__.py
@@ -1,0 +1,12 @@
+"""Persistent memory for Kairos: events, profile, plans."""
+from .manager import MemoryManager, task_record
+from .schemas import EventRecord, PlanRecord, ProfileRecord, TaskRecord
+
+__all__ = [
+    "MemoryManager",
+    "task_record",
+    "EventRecord",
+    "PlanRecord",
+    "ProfileRecord",
+    "TaskRecord",
+]

--- a/kairos_agent/memory/manager.py
+++ b/kairos_agent/memory/manager.py
@@ -1,0 +1,133 @@
+"""Public memory API used by the rest of Kairos.
+
+MemoryManager is the *only* class outside the memory package that the rest of
+Kairos imports. It hides the SQLite/JSON split behind plain method calls.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Iterable
+
+from ..common.logger import get_logger
+from ..config import KairosConfig
+from .schemas import EventRecord, PlanRecord, ProfileRecord, TaskRecord
+from .store import JSONProfileStore, SQLiteStore
+
+
+_log = get_logger("memory")
+
+
+class MemoryManager:
+    def __init__(self, config: KairosConfig):
+        self._config = config
+        storage = config.storage_path
+        # storage_path is guaranteed to exist by KairosCore.start(); but if a
+        # caller instantiates MemoryManager directly we make sure it does.
+        storage.mkdir(parents=True, exist_ok=True)
+        self._sqlite = SQLiteStore(storage / "kairos.db")
+        self._profile = JSONProfileStore(storage / "profile.json")
+        _log.info("memory.ready", extra={"db": str(storage / "kairos.db")})
+
+    def close(self) -> None:
+        self._sqlite.close()
+
+    # ----- events -----------------------------------------------------------
+
+    def save_event(
+        self,
+        kind: str,
+        payload: dict[str, Any],
+        session_id: str | None = None,
+    ) -> int:
+        event = EventRecord(
+            id=None,
+            ts=self._config.clock.now(),
+            kind=kind,
+            payload=payload,
+            session_id=session_id,
+        )
+        new_id = self._sqlite.insert_event(event)
+        _log.info("memory.event_saved", extra={"id": new_id, "kind": kind})
+        return new_id
+
+    def load_events(
+        self,
+        since: datetime | None = None,
+        consolidated: bool | None = None,
+        limit: int = 100,
+    ) -> list[EventRecord]:
+        return self._sqlite.select_events(since=since, consolidated=consolidated,
+                                          limit=limit)
+
+    def mark_events_consolidated(self, ids: Iterable[int]) -> int:
+        n = self._sqlite.mark_events_consolidated(ids)
+        _log.info("memory.events_consolidated", extra={"count": n})
+        return n
+
+    # ----- profile ----------------------------------------------------------
+
+    def load_profile(self) -> ProfileRecord:
+        return self._profile.load()
+
+    def save_profile(self, profile: ProfileRecord) -> None:
+        self._profile.save(profile)
+        _log.info("memory.profile_saved", extra={"user_id": profile.user_id})
+
+    def update_profile(self, **patch: Any) -> ProfileRecord:
+        """Convenience: load, merge top-level keys into `data`, save."""
+        profile = self.load_profile()
+        profile.data.update(patch)
+        self.save_profile(profile)
+        return profile
+
+    # ----- plans ------------------------------------------------------------
+
+    def save_plan(self, plan: PlanRecord) -> int:
+        new_id = self._sqlite.insert_plan(plan)
+        plan.id = new_id
+        _log.info("memory.plan_saved", extra={"id": new_id, "goal": plan.goal[:60]})
+        return new_id
+
+    def get_plan(self, plan_id: int) -> PlanRecord | None:
+        return self._sqlite.get_plan(plan_id)
+
+    def update_plan_task(
+        self,
+        plan_id: int,
+        task_id: str,
+        patch: dict[str, Any],
+    ) -> PlanRecord:
+        plan = self._sqlite.get_plan(plan_id)
+        if plan is None:
+            raise KeyError(f"plan {plan_id} not found")
+        for task in plan.tasks:
+            if task.id == task_id:
+                for key, value in patch.items():
+                    if not hasattr(task, key):
+                        raise AttributeError(f"unknown task field: {key}")
+                    setattr(task, key, value)
+                break
+        else:
+            raise KeyError(f"task {task_id} not found in plan {plan_id}")
+        self._sqlite.update_plan_tasks(plan_id, plan.tasks)
+        return plan
+
+    def set_plan_status(self, plan_id: int, status: str) -> None:
+        self._sqlite.update_plan_status(plan_id, status)
+
+
+def task_record(
+    id: str,
+    description: str,
+    deps: list[str] | None = None,
+    priority: int = 5,
+    status: str = "pending",
+) -> TaskRecord:
+    """Small helper so callers don't need to import schemas just to build tasks."""
+    return TaskRecord(
+        id=id,
+        description=description,
+        deps=deps or [],
+        priority=priority,
+        status=status,
+    )

--- a/kairos_agent/memory/migrations.py
+++ b/kairos_agent/memory/migrations.py
@@ -1,0 +1,41 @@
+"""Idempotent SQLite schema setup.
+
+There is no migration framework at the MVP — every CREATE is `IF NOT EXISTS`,
+and new columns can be added later via a small `_ensure_column` helper.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+
+SCHEMA_STATEMENTS = (
+    """
+    CREATE TABLE IF NOT EXISTS events (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        ts            TEXT    NOT NULL,
+        kind          TEXT    NOT NULL,
+        payload       TEXT    NOT NULL,
+        session_id    TEXT,
+        consolidated  INTEGER NOT NULL DEFAULT 0
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts)",
+    "CREATE INDEX IF NOT EXISTS idx_events_consolidated ON events(consolidated)",
+    """
+    CREATE TABLE IF NOT EXISTS plans (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        goal        TEXT    NOT NULL,
+        tasks       TEXT    NOT NULL,
+        status      TEXT    NOT NULL DEFAULT 'active',
+        created_at  TEXT    NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_plans_status ON plans(status)",
+)
+
+
+def apply_schema(conn: sqlite3.Connection) -> None:
+    cur = conn.cursor()
+    for statement in SCHEMA_STATEMENTS:
+        cur.execute(statement)
+    conn.commit()

--- a/kairos_agent/memory/schemas.py
+++ b/kairos_agent/memory/schemas.py
@@ -1,0 +1,53 @@
+"""Persistence-layer dataclasses for memory.
+
+These are returned to callers of MemoryManager. They are *not* the wire format
+between Kairos modules — those live in kairos_agent/common/dto.py.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass
+class EventRecord:
+    """A single observation Kairos has stored: an interaction, a decision, etc."""
+    id: int | None              # None until the row has been inserted
+    ts: datetime
+    kind: str                   # free-form tag, e.g. "user_message", "tool_call"
+    payload: dict[str, Any]
+    session_id: str | None = None
+    consolidated: bool = False  # set to True once AutoDream has summarized it
+
+
+@dataclass
+class ProfileRecord:
+    """The agent's persistent picture of the user.
+
+    Stored as a single JSON file (one user per Kairos instance for the MVP);
+    `data` is fully user-defined so AutoDream and the host can extend it freely.
+    """
+    user_id: str = "default"
+    data: dict[str, Any] = field(default_factory=dict)
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class TaskRecord:
+    """One step inside a Plan. Mirror of ultraplan.schemas.Task for storage."""
+    id: str
+    description: str
+    deps: list[str] = field(default_factory=list)
+    priority: int = 5
+    status: str = "pending"  # pending | in_progress | done | blocked
+
+
+@dataclass
+class PlanRecord:
+    """A goal-decomposed plan persisted in SQLite."""
+    id: int | None
+    goal: str
+    tasks: list[TaskRecord]
+    status: str = "active"  # active | done | abandoned
+    created_at: datetime = field(default_factory=datetime.utcnow)

--- a/kairos_agent/memory/store.py
+++ b/kairos_agent/memory/store.py
@@ -1,0 +1,195 @@
+"""Storage backends: SQLite for events/plans, JSON file for the profile."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from .migrations import apply_schema
+from .schemas import EventRecord, PlanRecord, ProfileRecord, TaskRecord
+
+
+_ISO = "%Y-%m-%dT%H:%M:%S.%f"
+
+
+def _iso(ts: datetime) -> str:
+    return ts.strftime(_ISO)
+
+
+def _parse_iso(value: str) -> datetime:
+    return datetime.strptime(value, _ISO)
+
+
+class SQLiteStore:
+    """Thin wrapper over a SQLite connection.
+
+    The connection is opened with `check_same_thread=False` and protected by
+    a single re-entrant lock so it can safely be shared between Kairos's
+    background threads (Coordinator worker, tick loop) without per-thread
+    connection juggling. Volume is low — this trades a little contention for
+    a much simpler ownership model.
+    """
+
+    def __init__(self, db_path: Path):
+        self._db_path = db_path
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        apply_schema(self._conn)
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    # ----- events -----------------------------------------------------------
+
+    def insert_event(self, event: EventRecord) -> int:
+        with self._lock:
+            cur = self._conn.execute(
+                "INSERT INTO events (ts, kind, payload, session_id, consolidated) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    _iso(event.ts),
+                    event.kind,
+                    json.dumps(event.payload, ensure_ascii=False),
+                    event.session_id,
+                    1 if event.consolidated else 0,
+                ),
+            )
+            self._conn.commit()
+            return int(cur.lastrowid)
+
+    def select_events(
+        self,
+        since: datetime | None = None,
+        consolidated: bool | None = None,
+        limit: int = 100,
+    ) -> list[EventRecord]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if since is not None:
+            clauses.append("ts >= ?")
+            params.append(_iso(since))
+        if consolidated is not None:
+            clauses.append("consolidated = ?")
+            params.append(1 if consolidated else 0)
+        where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+        sql = f"SELECT * FROM events{where} ORDER BY ts ASC LIMIT ?"
+        params.append(limit)
+        with self._lock:
+            rows = self._conn.execute(sql, params).fetchall()
+        return [self._row_to_event(r) for r in rows]
+
+    def mark_events_consolidated(self, ids: Iterable[int]) -> int:
+        ids = list(ids)
+        if not ids:
+            return 0
+        placeholders = ",".join("?" * len(ids))
+        with self._lock:
+            cur = self._conn.execute(
+                f"UPDATE events SET consolidated = 1 WHERE id IN ({placeholders})",
+                ids,
+            )
+            self._conn.commit()
+            return cur.rowcount
+
+    @staticmethod
+    def _row_to_event(row: sqlite3.Row) -> EventRecord:
+        return EventRecord(
+            id=row["id"],
+            ts=_parse_iso(row["ts"]),
+            kind=row["kind"],
+            payload=json.loads(row["payload"]),
+            session_id=row["session_id"],
+            consolidated=bool(row["consolidated"]),
+        )
+
+    # ----- plans ------------------------------------------------------------
+
+    def insert_plan(self, plan: PlanRecord) -> int:
+        with self._lock:
+            cur = self._conn.execute(
+                "INSERT INTO plans (goal, tasks, status, created_at) VALUES (?, ?, ?, ?)",
+                (
+                    plan.goal,
+                    json.dumps([t.__dict__ for t in plan.tasks], ensure_ascii=False),
+                    plan.status,
+                    _iso(plan.created_at),
+                ),
+            )
+            self._conn.commit()
+            return int(cur.lastrowid)
+
+    def get_plan(self, plan_id: int) -> PlanRecord | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM plans WHERE id = ?", (plan_id,)
+            ).fetchone()
+        return self._row_to_plan(row) if row else None
+
+    def update_plan_tasks(self, plan_id: int, tasks: list[TaskRecord]) -> None:
+        with self._lock:
+            self._conn.execute(
+                "UPDATE plans SET tasks = ? WHERE id = ?",
+                (json.dumps([t.__dict__ for t in tasks], ensure_ascii=False), plan_id),
+            )
+            self._conn.commit()
+
+    def update_plan_status(self, plan_id: int, status: str) -> None:
+        with self._lock:
+            self._conn.execute(
+                "UPDATE plans SET status = ? WHERE id = ?", (status, plan_id)
+            )
+            self._conn.commit()
+
+    @staticmethod
+    def _row_to_plan(row: sqlite3.Row) -> PlanRecord:
+        raw_tasks = json.loads(row["tasks"])
+        tasks = [TaskRecord(**t) for t in raw_tasks]
+        return PlanRecord(
+            id=row["id"],
+            goal=row["goal"],
+            tasks=tasks,
+            status=row["status"],
+            created_at=_parse_iso(row["created_at"]),
+        )
+
+
+class JSONProfileStore:
+    """Single-file JSON store for the user profile.
+
+    Lock-protected because Kairos may consolidate from a worker thread while
+    the main thread reads the profile to enrich a prompt.
+    """
+
+    def __init__(self, profile_path: Path):
+        self._path = profile_path
+        self._lock = threading.RLock()
+
+    def load(self) -> ProfileRecord:
+        with self._lock:
+            if not self._path.exists():
+                return ProfileRecord()
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        return ProfileRecord(
+            user_id=raw.get("user_id", "default"),
+            data=raw.get("data", {}),
+            updated_at=_parse_iso(raw["updated_at"]) if "updated_at" in raw
+            else datetime.utcnow(),
+        )
+
+    def save(self, profile: ProfileRecord) -> None:
+        profile.updated_at = datetime.utcnow()
+        payload = {
+            "user_id": profile.user_id,
+            "data": profile.data,
+            "updated_at": _iso(profile.updated_at),
+        }
+        with self._lock:
+            tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+            tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2),
+                           encoding="utf-8")
+            tmp.replace(self._path)

--- a/kairos_agent/normalizer/__init__.py
+++ b/kairos_agent/normalizer/__init__.py
@@ -1,0 +1,4 @@
+"""Style + privacy helpers (MVP stub)."""
+from .normalizer import format_code, redact_pii
+
+__all__ = ["redact_pii", "format_code"]

--- a/kairos_agent/normalizer/normalizer.py
+++ b/kairos_agent/normalizer/normalizer.py
@@ -1,0 +1,35 @@
+"""Style + privacy helpers (MVP stub).
+
+Two pure functions: redact common PII patterns from a string, and format code
+(passthrough at MVP — `black` integration is a future iteration). These are
+not yet wired into the rest of Kairos; once everything else is stable they'll
+become an optional middleware layer in front of the LLMClient.
+"""
+from __future__ import annotations
+
+import re
+
+
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+_IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_ABS_PATH_RE = re.compile(r"(?:/[^\s/]+){2,}")
+_HOME_PATH_RE = re.compile(r"~/[^\s]+")
+
+
+def redact_pii(text: str) -> str:
+    """Replace common PII tokens with placeholders.
+
+    Conservative on purpose — only replaces patterns that are unambiguous.
+    """
+    if not text:
+        return text
+    out = _EMAIL_RE.sub("<email>", text)
+    out = _IPV4_RE.sub("<ip>", out)
+    out = _HOME_PATH_RE.sub("<path>", out)
+    out = _ABS_PATH_RE.sub("<path>", out)
+    return out
+
+
+def format_code(text: str, language: str = "python") -> str:
+    """Format a code snippet. MVP passthrough — keeps the seam for later."""
+    return text

--- a/kairos_agent/ultraplan/__init__.py
+++ b/kairos_agent/ultraplan/__init__.py
@@ -1,0 +1,5 @@
+"""Goal decomposition and plan management."""
+from .planner import UltraPlan
+from .schemas import Plan, Task
+
+__all__ = ["UltraPlan", "Plan", "Task"]

--- a/kairos_agent/ultraplan/planner.py
+++ b/kairos_agent/ultraplan/planner.py
@@ -1,0 +1,131 @@
+"""ULTRAPLAN — goal → structured plan.
+
+The LLM is prompted to emit JSON conforming to the Plan schema. A regex-based
+fallback parses simple bullet lists, so the deterministic DummyLLMClient still
+yields a usable plan in tests.
+"""
+from __future__ import annotations
+
+import json
+import re
+import uuid
+
+from ..common.interfaces import LLMClient
+from ..common.logger import get_logger
+from ..memory.manager import MemoryManager
+from ..memory.schemas import PlanRecord, TaskRecord
+from .schemas import Plan, Task
+
+
+_log = get_logger("ultraplan")
+
+
+_PROMPT_TEMPLATE = """You are a planning assistant. Decompose the user's goal
+into a small set of concrete, sequenced sub-tasks (3 to 8 items). Reply with a
+single JSON object — no prose around it — matching this exact schema:
+
+{{
+  "goal": "<verbatim goal>",
+  "tasks": [
+    {{
+      "id": "t1",
+      "description": "...",
+      "deps": [],
+      "priority": 5,
+      "status": "pending"
+    }}
+  ]
+}}
+
+Rules:
+- Task ids are short slugs (t1, t2, ...).
+- "deps" lists ids of tasks that must complete first; use [] when none.
+- "priority" is an integer from 1 (urgent) to 10 (optional).
+- "status" is always "pending".
+
+Goal: {goal}
+
+JSON:"""
+
+
+_BULLET_RE = re.compile(r"^\s*(?:[-*]|\d+[.)])\s+(.+?)\s*$")
+_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+class UltraPlan:
+    def __init__(self, llm: LLMClient, memory: MemoryManager | None = None):
+        self._llm = llm
+        self._memory = memory
+
+    def generate(self, goal: str, persist: bool = True) -> Plan:
+        prompt = _PROMPT_TEMPLATE.format(goal=goal)
+        try:
+            raw = self._llm.complete(prompt)
+        except Exception as exc:  # noqa: BLE001
+            _log.exception("ultraplan.llm_error", extra={"err": str(exc)})
+            raw = ""
+
+        plan = self._parse(raw, goal)
+        if persist and self._memory is not None:
+            record = PlanRecord(
+                id=None,
+                goal=plan.goal,
+                tasks=[
+                    TaskRecord(
+                        id=t.id,
+                        description=t.description,
+                        deps=list(t.deps),
+                        priority=t.priority,
+                        status=t.status,
+                    )
+                    for t in plan.tasks
+                ],
+                status=plan.status,
+                created_at=plan.created_at,
+            )
+            new_id = self._memory.save_plan(record)
+            plan.id = new_id
+        _log.info("ultraplan.generated", extra={
+            "goal": goal[:80], "task_count": len(plan.tasks),
+        })
+        return plan
+
+    # ----- parsing helpers --------------------------------------------------
+
+    def _parse(self, raw: str, goal: str) -> Plan:
+        # 1. Try to find and parse a JSON object inside the response.
+        match = _JSON_OBJECT_RE.search(raw or "")
+        if match is not None:
+            try:
+                obj = json.loads(match.group(0))
+                if isinstance(obj, dict) and "tasks" in obj:
+                    obj.setdefault("goal", goal)
+                    return Plan.from_dict(obj)
+            except (json.JSONDecodeError, KeyError, ValueError):
+                pass
+
+        # 2. Fall back to bullet-list extraction so DummyLLMClient still works.
+        bullets = self._extract_bullets(raw or "")
+        if bullets:
+            tasks = [
+                Task(id=f"t{i + 1}", description=text)
+                for i, text in enumerate(bullets)
+            ]
+            return Plan(goal=goal, tasks=tasks)
+
+        # 3. Last resort: a single task that just restates the goal so the
+        # plan is never empty (downstream code can rely on len(tasks) >= 1).
+        fallback_id = f"t1-{uuid.uuid4().hex[:6]}"
+        return Plan(
+            goal=goal,
+            tasks=[Task(id=fallback_id, description=goal, priority=5)],
+        )
+
+    @staticmethod
+    def _extract_bullets(text: str) -> list[str]:
+        out: list[str] = []
+        for line in text.splitlines():
+            m = _BULLET_RE.match(line)
+            if m:
+                out.append(m.group(1).strip())
+        return out

--- a/kairos_agent/ultraplan/schemas.py
+++ b/kairos_agent/ultraplan/schemas.py
@@ -1,0 +1,71 @@
+"""Plan / Task dataclasses (in-memory representation).
+
+Round-trip JSON via to_dict / from_dict — used both for LLM I/O and for
+persistence (the memory store keeps tasks as a JSON column).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass
+class Task:
+    id: str
+    description: str
+    deps: list[str] = field(default_factory=list)
+    priority: int = 5  # 1 = urgent, 10 = optional
+    status: str = "pending"  # pending | in_progress | done | blocked
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "description": self.description,
+            "deps": list(self.deps),
+            "priority": self.priority,
+            "status": self.status,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "Task":
+        return cls(
+            id=str(raw["id"]),
+            description=str(raw["description"]),
+            deps=list(raw.get("deps", [])),
+            priority=int(raw.get("priority", 5)),
+            status=str(raw.get("status", "pending")),
+        )
+
+
+@dataclass
+class Plan:
+    goal: str
+    tasks: list[Task]
+    id: int | None = None
+    status: str = "active"
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "goal": self.goal,
+            "status": self.status,
+            "created_at": self.created_at.isoformat(),
+            "tasks": [t.to_dict() for t in self.tasks],
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "Plan":
+        created_at_raw = raw.get("created_at")
+        if created_at_raw:
+            created_at = datetime.fromisoformat(created_at_raw)
+        else:
+            created_at = datetime.utcnow()
+        return cls(
+            id=raw.get("id"),
+            goal=str(raw["goal"]),
+            status=str(raw.get("status", "active")),
+            created_at=created_at,
+            tasks=[Task.from_dict(t) for t in raw.get("tasks", [])],
+        )

--- a/tests/kairos_agent/conftest.py
+++ b/tests/kairos_agent/conftest.py
@@ -1,0 +1,92 @@
+"""Shared fixtures for kairos_agent tests.
+
+Everything here is host-agnostic: tmp storage path, fake clock, dummy LLM.
+No imports from `interpreter.*` — Kairos is standalone.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from kairos_agent import (
+    Coordinator,
+    DummyLLMClient,
+    KairosConfig,
+    MemoryManager,
+    configure_logging,
+)
+from kairos_agent.common.interfaces import Clock
+from kairos_agent.common.paths import ensure_storage_dir
+
+
+def pytest_configure(config: pytest.Config) -> None:  # noqa: D401
+    config.addinivalue_line(
+        "markers",
+        "llm: tests that hit a real LLM provider (skipped by default)",
+    )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    if config.getoption("-m") and "llm" in config.getoption("-m"):
+        return  # user explicitly asked for them
+    skip_marker = pytest.mark.skip(reason="needs -m llm")
+    for item in items:
+        if "llm" in item.keywords:
+            item.add_marker(skip_marker)
+
+
+class FakeClock(Clock):
+    """Hand-cranked clock so tests don't depend on wall time."""
+
+    def __init__(self, start: datetime | None = None):
+        self._now = start or datetime(2030, 1, 1, 0, 0, 0)
+
+    def now(self) -> datetime:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now = self._now + timedelta(seconds=seconds)
+
+
+@pytest.fixture
+def fake_clock() -> FakeClock:
+    return FakeClock()
+
+
+@pytest.fixture
+def storage_path(tmp_path: Path) -> Path:
+    return ensure_storage_dir(tmp_path / "kairos")
+
+
+@pytest.fixture
+def dummy_llm() -> DummyLLMClient:
+    return DummyLLMClient()
+
+
+@pytest.fixture
+def config(storage_path: Path, fake_clock: FakeClock,
+           dummy_llm: DummyLLMClient) -> KairosConfig:
+    cfg = KairosConfig(
+        storage_path=storage_path,
+        tick_interval=0.05,
+        clock=fake_clock,
+        llm_client=dummy_llm,
+    )
+    configure_logging(cfg.storage_path)
+    return cfg
+
+
+@pytest.fixture
+def memory(config: KairosConfig):
+    mem = MemoryManager(config)
+    yield mem
+    mem.close()
+
+
+@pytest.fixture
+def coordinator() -> Coordinator:
+    coord = Coordinator()
+    yield coord
+    coord.stop()

--- a/tests/kairos_agent/test_adapter_open_interpreter.py
+++ b/tests/kairos_agent/test_adapter_open_interpreter.py
@@ -1,0 +1,190 @@
+"""Tests for the open-interpreter adapter.
+
+We *don't* import from `interpreter` here (it pulls in litellm, torch, etc.).
+Instead we build a minimal mock that looks enough like OpenInterpreter for the
+adapter to wire itself up.  This keeps the tests lightweight and CI-friendly.
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from kairos_agent.adapters.open_interpreter import (
+    OpenInterpreterLLMClient,
+    attach_to_interpreter,
+    detach_from_interpreter,
+)
+from kairos_agent.common import configure_logging, ensure_storage_dir
+
+
+# ---------------------------------------------------------------------------
+# Helpers / mocks
+# ---------------------------------------------------------------------------
+
+def _make_fake_interpreter(tmp_path: Path):
+    """Build a minimal stand-in for OpenInterpreter.
+
+    Just enough surface area for the adapter to latch on:
+    - .llm with .run(messages) and .model
+    - .chat(message, display, stream, blocking)
+    - .messages, .last_messages_count
+    """
+    # Fake llm that yields two message chunks
+    def fake_llm_run(messages):
+        yield {"type": "message", "content": "Hello "}
+        yield {"type": "message", "content": "world"}
+
+    fake_llm = SimpleNamespace(
+        run=fake_llm_run,
+        model="fake-model",
+    )
+
+    # Fake chat — just appends messages to .messages
+    interp = MagicMock()
+    interp.llm = fake_llm
+    interp.messages = []
+    interp.last_messages_count = 0
+
+    original_chat_calls: list[dict] = []
+
+    def fake_chat(message=None, display=True, stream=False, blocking=True):
+        original_chat_calls.append({"message": message})
+        if message is not None:
+            interp.messages.append(
+                {"role": "user", "type": "message", "content": message}
+            )
+        interp.messages.append(
+            {"role": "assistant", "type": "message", "content": "fake reply"}
+        )
+        interp.last_messages_count = len(interp.messages) - 1
+        return interp.messages[interp.last_messages_count:]
+
+    # Bind fake_chat properly so __self__ is available to the wrapper.
+    interp.chat = fake_chat
+    interp.chat.__self__ = interp  # the wrapper reads this
+    interp._original_chat_calls = original_chat_calls
+
+    return interp
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestOpenInterpreterLLMClient:
+    def test_complete_concatenates_message_chunks(self, tmp_path: Path) -> None:
+        interp = _make_fake_interpreter(tmp_path)
+        llm = OpenInterpreterLLMClient(interp)
+        result = llm.complete("Say hi")
+        assert result == "Hello world"
+
+    def test_complete_ignores_code_chunks(self, tmp_path: Path) -> None:
+        def run_with_code(messages):
+            yield {"type": "message", "content": "Sure: "}
+            yield {"type": "code", "format": "python", "content": "print(1)"}
+            yield {"type": "message", "content": "done"}
+
+        interp = _make_fake_interpreter(tmp_path)
+        interp.llm.run = run_with_code
+        llm = OpenInterpreterLLMClient(interp)
+        assert llm.complete("run code") == "Sure: done"
+
+
+class TestAttachDetach:
+    def test_attach_starts_kairos_and_wraps_chat(self, tmp_path: Path) -> None:
+        storage = ensure_storage_dir(tmp_path / "kairos")
+        configure_logging(storage)
+        interp = _make_fake_interpreter(tmp_path)
+
+        kairos = attach_to_interpreter(
+            interp,
+            storage_path=storage,
+            tick_interval=0.05,
+            inactivity_seconds=999,
+        )
+
+        # Kairos is running
+        assert hasattr(interp, "kairos")
+        assert interp.kairos is kairos
+
+        # Chat wrapper is in place — original chat still gets called
+        interp.chat(message="test message")
+        assert len(interp._original_chat_calls) == 1
+
+        # Events were recorded in memory
+        events = interp.kairos_memory.load_events()
+        # At least the user_activity event from record_user_activity
+        assert len(events) >= 1
+
+        kairos.stop()
+
+    def test_detach_restores_interpreter(self, tmp_path: Path) -> None:
+        storage = ensure_storage_dir(tmp_path / "kairos")
+        configure_logging(storage)
+        interp = _make_fake_interpreter(tmp_path)
+
+        kairos = attach_to_interpreter(
+            interp,
+            storage_path=storage,
+            tick_interval=0.05,
+        )
+        kairos.stop()  # stop background threads first
+
+        detach_from_interpreter(interp)
+        assert not hasattr(interp, "kairos")
+        assert not hasattr(interp, "kairos_memory")
+
+    def test_chat_records_assistant_messages_as_events(self, tmp_path: Path) -> None:
+        storage = ensure_storage_dir(tmp_path / "kairos")
+        configure_logging(storage)
+        interp = _make_fake_interpreter(tmp_path)
+
+        kairos = attach_to_interpreter(
+            interp,
+            storage_path=storage,
+            tick_interval=60,  # won't tick during this test
+        )
+
+        interp.chat(message="hello")
+        interp.chat(message="world")
+
+        events = interp.kairos_memory.load_events()
+        kinds = [e.kind for e in events]
+        # Should have user_activity events + assistant_message events
+        assert any("user_activity" in k for k in kinds)
+        assert any("assistant" in k for k in kinds)
+
+        kairos.stop()
+
+    def test_ultraplan_handler_is_registered(self, tmp_path: Path) -> None:
+        storage = ensure_storage_dir(tmp_path / "kairos")
+        configure_logging(storage)
+        interp = _make_fake_interpreter(tmp_path)
+
+        kairos = attach_to_interpreter(
+            interp,
+            storage_path=storage,
+            tick_interval=60,
+        )
+
+        from kairos_agent.common import TaskRequest
+
+        # UltraPlan handler should be registered and callable via Coordinator.
+        coord = kairos._coordinator
+        task = TaskRequest(handler_name="ultraplan.generate",
+                           payload={"goal": "test goal"})
+        coord.enqueue(task)
+        coord.run_pending()
+
+        # Plan should have been persisted
+        plans_events = interp.kairos_memory.load_events()
+        # Just verify no crash; the plan is in the DB
+        plan = interp.kairos_memory.get_plan(1)
+        assert plan is not None
+        assert plan.goal == "test goal"
+
+        kairos.stop()

--- a/tests/kairos_agent/test_autodream_pipeline.py
+++ b/tests/kairos_agent/test_autodream_pipeline.py
@@ -1,0 +1,41 @@
+"""AutoDream pipeline: consolidation with mocked LLM."""
+from __future__ import annotations
+
+from kairos_agent import AutoDream, DummyLLMClient, KairosConfig, MemoryManager
+from kairos_agent.autodream import Summarizer
+
+
+def test_consolidation_pipeline(config: KairosConfig, memory: MemoryManager) -> None:
+    llm = DummyLLMClient(["FAKE_SUMMARY"])
+    config.llm_client = llm
+    for i in range(5):
+        memory.save_event("msg", {"i": i})
+    ad = AutoDream(config, memory)
+    report = ad.run()
+    assert report["events_consolidated"] == 5
+    assert report["summary"] == "FAKE_SUMMARY"
+    profile = memory.load_profile()
+    assert profile.data["last_summary"] == "FAKE_SUMMARY"
+    assert len(profile.data.get("summary_history", [])) == 1
+    assert memory.load_events(consolidated=False) == []
+
+
+def test_consolidation_with_no_events(config: KairosConfig,
+                                      memory: MemoryManager) -> None:
+    ad = AutoDream(config, memory)
+    report = ad.run()
+    assert report["events_consolidated"] == 0
+    assert report["summary"] == ""
+
+
+def test_fallback_summarizer_without_llm(config: KairosConfig,
+                                          memory: MemoryManager) -> None:
+    config.llm_client = None
+    for i in range(3):
+        memory.save_event("tool_call", {"tool": "shell"})
+    summarizer = Summarizer(llm=None)
+    ad = AutoDream(config, memory, summarizer=summarizer)
+    report = ad.run()
+    assert report["events_consolidated"] == 3
+    assert "[fallback summary]" in report["summary"]
+    assert "tool_call=3" in report["summary"]

--- a/tests/kairos_agent/test_coordinator_priority.py
+++ b/tests/kairos_agent/test_coordinator_priority.py
@@ -1,0 +1,55 @@
+"""Coordinator: priority ordering + lock serialization."""
+from __future__ import annotations
+
+import threading
+import time
+
+from kairos_agent import Coordinator, TaskRequest
+
+
+def test_priority_order(coordinator: Coordinator) -> None:
+    calls: list[str] = []
+    coordinator.register("test.do", lambda task: calls.append(task.id))
+    coordinator.enqueue(TaskRequest(handler_name="test.do", priority=10, id="c"))
+    coordinator.enqueue(TaskRequest(handler_name="test.do", priority=1, id="a"))
+    coordinator.enqueue(TaskRequest(handler_name="test.do", priority=5, id="b"))
+    coordinator.run_pending()
+    assert calls == ["a", "b", "c"]
+
+
+def test_worker_thread_dispatches(coordinator: Coordinator) -> None:
+    calls: list[str] = []
+    coordinator.register("test.do", lambda task: calls.append(task.id))
+    coordinator.start()
+    coordinator.enqueue(TaskRequest(handler_name="test.do", id="w1"))
+    coordinator.enqueue(TaskRequest(handler_name="test.do", id="w2"))
+    time.sleep(0.3)
+    coordinator.stop()
+    assert "w1" in calls
+    assert "w2" in calls
+
+
+def test_unknown_handler_does_not_crash(coordinator: Coordinator) -> None:
+    coordinator.enqueue(TaskRequest(handler_name="nonexistent", id="x"))
+    coordinator.run_pending()  # should log a warning, not raise
+
+
+def test_lock_serialization(coordinator: Coordinator) -> None:
+    """Two tasks targeting the same module should not run concurrently."""
+    running = threading.Event()
+    overlap_detected = []
+
+    def slow_handler(task: TaskRequest) -> None:
+        if running.is_set():
+            overlap_detected.append(True)
+        running.set()
+        time.sleep(0.15)
+        running.clear()
+
+    coordinator.register("mod.action", slow_handler)
+    coordinator.start()
+    coordinator.enqueue(TaskRequest(handler_name="mod.action", priority=1, id="s1"))
+    coordinator.enqueue(TaskRequest(handler_name="mod.action", priority=1, id="s2"))
+    time.sleep(0.5)
+    coordinator.stop()
+    assert not overlap_detected, "handlers ran concurrently — lock failed"

--- a/tests/kairos_agent/test_kairos_tick.py
+++ b/tests/kairos_agent/test_kairos_tick.py
@@ -1,0 +1,86 @@
+"""KairosCore tick loop + triggers."""
+from __future__ import annotations
+
+import threading
+import time
+from datetime import timedelta
+
+from kairos_agent import (
+    Coordinator,
+    InactivityTrigger,
+    KairosConfig,
+    KairosCore,
+    MemoryManager,
+    TaskRequest,
+    TimeTrigger,
+)
+from tests.kairos_agent.conftest import FakeClock
+
+
+def test_tick_fires_time_trigger(config: KairosConfig, memory: MemoryManager,
+                                 coordinator: Coordinator,
+                                 fake_clock: FakeClock) -> None:
+    calls: list[str] = []
+    coordinator.register("test.handler", lambda t: calls.append(t.id))
+    kairos = KairosCore(config, coordinator, memory)
+    kairos.register_trigger(
+        TimeTrigger(timedelta(seconds=0), "test.handler"),
+    )
+    kairos.start()
+    time.sleep(0.3)
+    kairos.stop()
+    assert kairos.state.tick_count >= 2
+    assert len(calls) >= 2
+
+
+def test_no_threads_left_after_stop(config: KairosConfig, memory: MemoryManager,
+                                    coordinator: Coordinator) -> None:
+    kairos = KairosCore(config, coordinator, memory)
+    kairos.start()
+    time.sleep(0.15)
+    kairos.stop()
+    # Give daemon threads a moment to wind down.
+    time.sleep(0.1)
+    alive = [t for t in threading.enumerate() if "kairos" in t.name.lower()]
+    assert alive == [], f"leftover threads: {alive}"
+
+
+def test_inactivity_trigger_fires_after_silence(
+    config: KairosConfig, memory: MemoryManager,
+    coordinator: Coordinator, fake_clock: FakeClock,
+) -> None:
+    calls: list[str] = []
+    coordinator.register("dream", lambda t: calls.append(t.id))
+    kairos = KairosCore(config, coordinator, memory)
+    kairos.register_trigger(
+        InactivityTrigger(timedelta(seconds=2), "dream"),
+    )
+    # Manually drive ticks with the fake clock so we don't wait wall time.
+    kairos.tick()  # t=0, no inactivity yet
+    coordinator.run_pending()
+    assert len(calls) == 0
+
+    fake_clock.advance(3)
+    kairos.tick()  # t=3, 3s silence → fire
+    coordinator.run_pending()
+    assert len(calls) == 1
+
+    fake_clock.advance(1)
+    kairos.tick()  # t=4, already fired for this window
+    coordinator.run_pending()
+    assert len(calls) == 1, "should not re-fire until new activity"
+
+    # Simulate activity then silence again
+    kairos.record_user_activity()
+    fake_clock.advance(3)
+    kairos.tick()
+    coordinator.run_pending()
+    assert len(calls) == 2, "should fire again after new silence"
+
+
+def test_tick_direct_call_does_not_crash_without_start(
+    config: KairosConfig, memory: MemoryManager, coordinator: Coordinator,
+) -> None:
+    kairos = KairosCore(config, coordinator, memory)
+    kairos.tick()  # should work even though start() wasn't called
+    assert kairos.state.tick_count == 1

--- a/tests/kairos_agent/test_llm_integration.py
+++ b/tests/kairos_agent/test_llm_integration.py
@@ -1,0 +1,15 @@
+"""Real LLM integration tests — skipped by default.
+
+Run explicitly with:  pytest tests/kairos_agent/ -m llm -v
+Requires OPENAI_API_KEY (or another provider env var) to be set.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.llm
+
+
+def test_placeholder() -> None:
+    """Placeholder so the module is importable. Replace with real LLM tests."""
+    pytest.skip("real LLM tests not yet wired — add provider adapter first")

--- a/tests/kairos_agent/test_memory_manager.py
+++ b/tests/kairos_agent/test_memory_manager.py
@@ -1,0 +1,73 @@
+"""Memory persistence: events round-trip, profile, plans."""
+from __future__ import annotations
+
+from kairos_agent.memory import MemoryManager, PlanRecord, task_record
+
+
+def test_save_and_load_events(memory: MemoryManager) -> None:
+    ids = [
+        memory.save_event("user_message", {"text": "hi"}),
+        memory.save_event("tool_call", {"tool": "shell"}),
+        memory.save_event("decision", {"why": "curiosity"}),
+    ]
+    assert len(ids) == 3 and all(isinstance(i, int) for i in ids)
+
+    events = memory.load_events()
+    assert len(events) == 3
+    kinds = {e.kind for e in events}
+    assert kinds == {"user_message", "tool_call", "decision"}
+
+
+def test_mark_consolidated_filters_correctly(memory: MemoryManager) -> None:
+    memory.save_event("a", {})
+    memory.save_event("b", {})
+    memory.save_event("c", {})
+
+    pending = memory.load_events(consolidated=False)
+    assert len(pending) == 3
+
+    memory.mark_events_consolidated([e.id for e in pending])
+    assert memory.load_events(consolidated=False) == []
+    assert len(memory.load_events(consolidated=True)) == 3
+
+
+def test_profile_round_trip(memory: MemoryManager) -> None:
+    profile = memory.update_profile(name="Rima", goal="ship kairos")
+    assert profile.data["name"] == "Rima"
+
+    reloaded = memory.load_profile()
+    assert reloaded.data["name"] == "Rima"
+    assert reloaded.data["goal"] == "ship kairos"
+
+
+def test_plan_round_trip_with_dependencies(memory: MemoryManager) -> None:
+    plan = PlanRecord(
+        id=None,
+        goal="write blog post",
+        tasks=[
+            task_record("t1", "outline", priority=2),
+            task_record("t2", "draft", deps=["t1"]),
+            task_record("t3", "review", deps=["t2"], priority=3),
+        ],
+    )
+    plan_id = memory.save_plan(plan)
+    assert plan_id == plan.id
+
+    loaded = memory.get_plan(plan_id)
+    assert loaded is not None
+    assert loaded.goal == "write blog post"
+    assert [t.id for t in loaded.tasks] == ["t1", "t2", "t3"]
+    assert loaded.tasks[1].deps == ["t1"]
+    assert loaded.tasks[0].priority == 2
+
+
+def test_update_plan_task_status(memory: MemoryManager) -> None:
+    plan_id = memory.save_plan(PlanRecord(
+        id=None,
+        goal="x",
+        tasks=[task_record("t1", "first"), task_record("t2", "second", deps=["t1"])],
+    ))
+    memory.update_plan_task(plan_id, "t1", {"status": "done"})
+    loaded = memory.get_plan(plan_id)
+    assert loaded.tasks[0].status == "done"
+    assert loaded.tasks[1].status == "pending"

--- a/tests/kairos_agent/test_normalizer.py
+++ b/tests/kairos_agent/test_normalizer.py
@@ -1,0 +1,34 @@
+"""Normalizer: PII redaction + format_code passthrough."""
+from __future__ import annotations
+
+from kairos_agent import format_code, redact_pii
+
+
+def test_redact_email() -> None:
+    assert "<email>" in redact_pii("contact me at alice@example.com please")
+
+
+def test_redact_ip() -> None:
+    assert "<ip>" in redact_pii("server is at 192.168.1.42 ok")
+
+
+def test_redact_absolute_path() -> None:
+    assert "<path>" in redact_pii("file at /home/user/secret/data.json")
+
+
+def test_redact_home_path() -> None:
+    assert "<path>" in redact_pii("config in ~/my_app/config.yaml")
+
+
+def test_redact_preserves_safe_text() -> None:
+    safe = "This is perfectly fine text with no PII."
+    assert redact_pii(safe) == safe
+
+
+def test_redact_empty() -> None:
+    assert redact_pii("") == ""
+
+
+def test_format_code_passthrough() -> None:
+    code = "def foo():\n    return 42\n"
+    assert format_code(code) == code

--- a/tests/kairos_agent/test_ultraplan_schema.py
+++ b/tests/kairos_agent/test_ultraplan_schema.py
@@ -1,0 +1,66 @@
+"""ULTRAPLAN: schema round-trip + LLM-backed plan generation."""
+from __future__ import annotations
+
+import json
+
+from kairos_agent import DummyLLMClient, KairosConfig, MemoryManager
+from kairos_agent.ultraplan import Plan, Task, UltraPlan
+
+
+def test_plan_json_round_trip() -> None:
+    plan = Plan(
+        goal="launch product",
+        tasks=[
+            Task(id="t1", description="design", deps=[], priority=2),
+            Task(id="t2", description="build", deps=["t1"], priority=5),
+            Task(id="t3", description="ship", deps=["t1", "t2"], priority=1),
+        ],
+    )
+    raw = plan.to_dict()
+    restored = Plan.from_dict(raw)
+    assert restored.goal == plan.goal
+    assert len(restored.tasks) == 3
+    assert restored.tasks[2].deps == ["t1", "t2"]
+    assert restored.tasks[0].priority == 2
+
+
+def test_generate_parses_json_response(memory: MemoryManager) -> None:
+    response = json.dumps({
+        "goal": "write blog",
+        "tasks": [
+            {"id": "t1", "description": "outline", "deps": [], "priority": 3, "status": "pending"},
+            {"id": "t2", "description": "draft", "deps": ["t1"], "priority": 5, "status": "pending"},
+        ],
+    })
+    llm = DummyLLMClient([response])
+    up = UltraPlan(llm, memory)
+    plan = up.generate("write blog")
+    assert plan.id is not None  # persisted
+    assert len(plan.tasks) == 2
+    assert plan.tasks[1].deps == ["t1"]
+
+
+def test_generate_parses_bullet_list(memory: MemoryManager) -> None:
+    llm = DummyLLMClient([
+        "Here's a plan:\n- Research the topic\n- Write first draft\n- Proofread\n"
+    ])
+    up = UltraPlan(llm, memory)
+    plan = up.generate("write essay")
+    assert len(plan.tasks) == 3
+    assert plan.tasks[0].description == "Research the topic"
+
+
+def test_generate_fallback_on_empty_response() -> None:
+    llm = DummyLLMClient([""])
+    up = UltraPlan(llm, memory=None)
+    plan = up.generate("do something", persist=False)
+    assert len(plan.tasks) >= 1
+    assert plan.tasks[0].description == "do something"
+
+
+def test_generate_with_dummy_echo() -> None:
+    """Default DummyLLMClient (echo mode) still yields a valid plan."""
+    llm = DummyLLMClient()
+    up = UltraPlan(llm, memory=None)
+    plan = up.generate("launch rocket", persist=False)
+    assert len(plan.tasks) >= 1


### PR DESCRIPTION
This PR introduces a complete autonomous agent framework named kairos_agent, implemented as a standalone package and integrated cleanly with open-interpreter through an adapter layer.
Phase 1 — Standalone package (kairos_agent/)
- Modular architecture with 7 components: common, memory, coordinator, kairos, autodream, ultraplan, normalizer.
- Persistent memory system (SQLite for events/plans + JSON for user profile).
- Background autonomous loop (KairosCore) with triggers and internal state.
- AutoDream pipeline for memory consolidation.
- UltraPlan module for goal decomposition and structured planning.
- Coordinator with priority queue and lock registry.
- Normalizer for PII redaction and code formatting.
- Full test suite (34 passed, 1 skipped for LLM integration).
Phase 2 — Integration with open-interpreter
- Adapter: kairos_agent/adapters/open_interpreter.py.
- OpenInterpreterLLMClient bridging interpreter.llm.run() to LLMClient.complete().
- _wrap_chat() to automatically record events.
- attach_to_interpreter() to initialize and start Kairos in one call.
- detach_from_interpreter() to stop Kairos and restore original behavior.
- Zero modifications to interpreter/core/core.py (clean composition + dependency injection).

Reference any relevant issues:
N/A (initial integration)

Pre-Submission Checklist:
- [x] Architecture validated
- [x] Tests passing
- [x] No changes to interpreter core
- [x] Adapter isolated in kairos_agent/adapters/

OS Tests:
- [x] Tested on Linux
- [ ] Tested on Windows
- [ ] Tested on MacOS
