### PR TITLE
fix: detect sudo password prompt and exit cleanly instead of hanging

### DIFF
--- a/interpreter/core/computer/terminal/languages/subprocess_language.py
+++ b/interpreter/core/computer/terminal/languages/subprocess_language.py
@@ -148,6 +148,20 @@ class SubprocessLanguage(BaseLanguage):
                 if line is None:
                     continue  # `line = None` is the postprocessor's signal to discard completely
 
+                if "[sudo] password for" in line:
+                    self.output_queue.put(
+                        {
+                            "type": "console",
+                            "format": "output",
+                            "content": (
+                                "[sudo] password prompt detected — OI cannot provide a password "
+                                "through a pipe. Please run this command manually in your terminal.\n"
+                            ),
+                        }
+                    )
+                    self.done.set()
+                    return
+
                 if self.detect_active_line(line):
                     active_line = self.detect_active_line(line)
                     self.output_queue.put(


### PR DESCRIPTION
Fixes #1694

## Problem
When the LLM generates a `sudo` command (e.g., `sudo journalctl -xe`), the subprocess uses `subprocess.PIPE` which has no terminal for interactive password input. The `[sudo] password for <user>:` prompt appears on stderr but the process then blocks indefinitely waiting for input that can never arrive through the pipe. OI hangs for ~120 seconds with no output before timing out.

## Solution
Added a check in `handle_stream_output()` in `subprocess_language.py` for the `[sudo] password for` pattern in the output stream. When detected, OI immediately:
1. Emits a clear message informing the user that sudo requires elevated privileges and should be run manually
2. Sets the `done` event so the `run()` loop exits without waiting for the execution timeout

The subprocess remains blocked but gets cleaned up on the next execution or when OI exits, consistent with how other error cases are handled.

## Testing
- Trigger a sudo command with OI in a non-passwordless sudo environment
- Before: OI hangs for ~120 seconds then times out with a generic error
- After: OI immediately returns with a clear message: `[sudo] password prompt detected — OI cannot provide a password through a pipe. Please run this command manually in your terminal.`

Existing `True`/`False` auto_run behavior and non-sudo commands are completely unaffected.