### PR TITLE
fix: show provider-specific rate limit message instead of hardcoded OpenAI text

### DIFF
--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -118,14 +118,31 @@ def respond(interpreter):
                     and ("exceeded" in str(e).lower() or
                          "insufficient_quota" in str(e).lower())
                 ):
-                    display_markdown_message(
-                        f""" > You ran out of current quota for OpenAI's API, please check your plan and billing details. You can either wait for the quota to reset or upgrade your plan.
+                    model = getattr(interpreter.llm, "model", "") or ""
+                    # Derive provider name from model prefix (e.g. "groq/llama3" → "Groq")
+                    if "/" in model:
+                        provider = model.split("/")[0].title()
+                        if provider.lower() == "openai":
+                            provider = "OpenAI"
+                    else:
+                        provider = "OpenAI"
 
-                        To check your current usage and billing details, visit the [OpenAI billing page](https://platform.openai.com/settings/organization/billing/overview).
+                    if provider == "OpenAI":
+                        display_markdown_message(
+                            f""" > You ran out of current quota for OpenAI's API, please check your plan and billing details. You can either wait for the quota to reset or upgrade your plan.
 
-                        You can also use `interpreter --max_budget [higher USD amount]` to set a budget for your sessions.
-                        """
-                    )
+                            To check your current usage and billing details, visit the [OpenAI billing page](https://platform.openai.com/settings/organization/billing/overview).
+
+                            You can also use `interpreter --max_budget [higher USD amount]` to set a budget for your sessions.
+                            """
+                        )
+                    else:
+                        display_markdown_message(
+                            f""" > You have exceeded your quota for {provider}'s API. Please check your plan and billing details with {provider}, or wait for the quota to reset.
+
+                            You can also use `interpreter --max_budget [higher USD amount]` to set a budget for your sessions.
+                            """
+                        )
 
                 elif (
                     interpreter.offline == False and "not have access" in str(e).lower()


### PR DESCRIPTION
Fixes #1706

## Problem
When users hit a rate limit or quota error while using non-OpenAI providers (e.g., Groq, Anthropic, Mistral), the error handler always displays a message that says *"You ran out of current quota for OpenAI's API"* and links to the OpenAI billing page. This is confusing and misleading for users who aren't using OpenAI at all.

## Solution
Detect the API provider from the model prefix (LiteLLM convention: `provider/model-name`) and display an appropriate message:

- **OpenAI models** (no prefix or `openai/` prefix): show the existing OpenAI-specific message with the OpenAI billing page link
- **Other providers** (e.g., `groq/llama3-8b-8192`): show a generic message naming the actual provider (e.g., "You have exceeded your quota for Groq's API") without incorrect OpenAI-specific links

The extraction uses `model.split("/")[0].title()` which correctly maps:
- `groq/llama3-8b-8192` → `Groq`
- `anthropic/claude-3` → `Anthropic`
- `mistral/mistral-7b` → `Mistral`
- `gpt-4`, `o1-mini` (no prefix) → `OpenAI`

## Testing
- Using Groq API and hitting rate limit now shows "You have exceeded your quota for Groq's API" instead of mentioning OpenAI
- Using OpenAI API still shows the original OpenAI-specific message with billing link
- Models without a provider prefix continue to default to the OpenAI message