### PR TITLE
fix: prevent AttributeError crash when Llamafile model download fails

### DIFF
--- a/interpreter/terminal_interface/local_setup.py
+++ b/interpreter/terminal_interface/local_setup.py
@@ -444,6 +444,12 @@ def local_setup(interpreter, provider=None, model=None):
                     print(e)
                     print("Model process terminated.")
 
+        if model_path is None:
+            print(
+                "\nNo model was downloaded. Cannot start Llamafile. Please try again or choose a different provider.\n"
+            )
+            return interpreter
+
         # Set flags for Llamafile to work with interpreter
         interpreter.llm.model = "openai/local"
         interpreter.llm.api_key = "dummy"


### PR DESCRIPTION
## Problem

When using `interpreter --local` and selecting the **Llamafile** provider, if `download_model()` fails (e.g. insufficient disk space, network error, or the user's machine can't fit any of the listed models), it returns `None`. The code then unconditionally executes:

```python
model_name = model_path.split("/")[-1]
```

This crashes with `AttributeError: 'NoneType' object has no attribute 'split'` instead of displaying a clear, actionable error.

The bug affects two code paths in `local_setup.py`:
1. **No models exist** — `model_path = download_model(...)` in the `if not models:` branch returns `None`
2. **Download new model** — user selects "↓ Download new model" in the `else` branch; `download_model()` returns `None`; the `if model_path:` guard correctly skips the process launch, but execution still falls through to the crashing line

## Solution

Add an early-return guard immediately before the Llamafile configuration block. When `model_path is None`, print a clear message and return the interpreter unchanged — instead of crashing.

```python
if model_path is None:
    print(
        "\nNo model was downloaded. Cannot start Llamafile. "
        "Please try again or choose a different provider.\n"
    )
    return interpreter
```

## Testing

- Normal Llamafile flow (existing model or successful download) is unchanged — the guard only activates when `model_path is None`.
- Simulated a failed download by having `download_model()` return `None`; previously crashed with `AttributeError`, now exits cleanly with a user-friendly message.