### PR TITLE
fix(%info): pass curl as argv list, add timeout, and surface real errors

### DIFF
--- a/interpreter/core/utils/system_debug_info.py
+++ b/interpreter/core/utils/system_debug_info.py
@@ -82,7 +82,17 @@ def interpreter_info(interpreter):
     try:
         if interpreter.offline and interpreter.llm.api_base:
             try:
-                curl = subprocess.check_output(f"curl {interpreter.llm.api_base}")
+                # Pass argv as a list (no shell=True) and a timeout so a dead /
+                # slow api_base doesn't hang `%info`. Previously this was
+                # `subprocess.check_output(f"curl {api_base}")` which raised
+                # FileNotFoundError because the whole string was treated as
+                # the executable path. See issues #1218 / #1083.
+                curl = subprocess.check_output(
+                    ["curl", "--silent", "--show-error", "--max-time", "5",
+                     interpreter.llm.api_base],
+                    stderr=subprocess.STDOUT,
+                    timeout=10,
+                )
             except Exception as e:
                 curl = str(e)
         else:

--- a/tests/core/utils/test_system_debug_info.py
+++ b/tests/core/utils/test_system_debug_info.py
@@ -1,0 +1,153 @@
+"""
+Regression tests for `interpreter.core.utils.system_debug_info.interpreter_info`.
+
+Bug (issue #1218 / surfaced in #1083): when `interpreter.offline` is True and
+`interpreter.llm.api_base` is set, the diagnostic helper invokes
+
+    subprocess.check_output(f"curl {interpreter.llm.api_base}")
+
+with a single string but no `shell=True`. `subprocess` then treats the entire
+string as the path to an executable and raises `FileNotFoundError`. The
+exception is caught and stringified, so `%info` shows e.g.
+`Curl output: [Errno 2] No such file or directory: 'curl http://...'`
+instead of the actual server response.
+
+These tests load the module by file path (so the heavy `interpreter` package
+__init__ is not evaluated) and stub `subprocess.check_output` to capture how
+curl is invoked.
+"""
+
+import importlib.util
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+MODULE_PATH = os.path.join(
+    REPO_ROOT, "interpreter", "core", "utils", "system_debug_info.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("sdi_under_test", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def sdi():
+    return _load_module()
+
+
+def _fake_interpreter(api_base="http://localhost:1234/v1"):
+    llm = SimpleNamespace(
+        api_base=api_base,
+        supports_vision=False,
+        model="test-model",
+        supports_functions=False,
+        context_window=2048,
+        max_tokens=512,
+    )
+    computer = SimpleNamespace(import_computer_api=False)
+    return SimpleNamespace(
+        offline=True,
+        llm=llm,
+        computer=computer,
+        auto_run=False,
+        messages=[],
+        system_message="sys",
+    )
+
+
+def test_interpreter_info_invokes_curl_with_argv_list(sdi):
+    """
+    The curl subprocess call MUST split args (or use shell=True) so the
+    binary 'curl' can actually be found and executed.
+    """
+    captured = {}
+
+    def fake_check_output(cmd, *args, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return b"PONG"
+
+    interp = _fake_interpreter()
+    with patch.object(sdi.subprocess, "check_output", side_effect=fake_check_output):
+        out = sdi.interpreter_info(interp)
+
+    cmd = captured.get("cmd")
+    # Either a list of args, or a string with shell=True. Both invoke curl correctly.
+    if isinstance(cmd, str):
+        assert captured["kwargs"].get("shell") is True, (
+            "string command must use shell=True so curl is resolved"
+        )
+        assert cmd.split()[0] == "curl"
+    else:
+        assert isinstance(cmd, (list, tuple)), f"unexpected cmd type: {type(cmd)}"
+        assert cmd[0] == "curl"
+        assert "http://localhost:1234/v1" in cmd
+
+    # Real output should appear in the rendered info string, not an exception text.
+    assert "PONG" in out
+    assert "No such file or directory" not in out
+
+
+def test_interpreter_info_does_not_hang_on_unresponsive_server(sdi):
+    """
+    A timeout should be passed so that an unresponsive api_base does not hang
+    the `%info` magic command (root cause behind #1218 'no output').
+    """
+    captured = {}
+
+    def fake_check_output(cmd, *args, **kwargs):
+        captured["kwargs"] = kwargs
+        return b"OK"
+
+    interp = _fake_interpreter()
+    with patch.object(sdi.subprocess, "check_output", side_effect=fake_check_output):
+        sdi.interpreter_info(interp)
+
+    assert "timeout" in captured["kwargs"], (
+        "curl call must pass a timeout to avoid hanging %info on a dead api_base"
+    )
+    assert captured["kwargs"]["timeout"] is not None
+    assert captured["kwargs"]["timeout"] > 0
+
+
+def test_interpreter_info_handles_curl_failure_gracefully(sdi):
+    """
+    If curl fails (network down, server off), interpreter_info still returns
+    a string and does not propagate the exception.
+    """
+    import subprocess as real_subprocess
+
+    def fake_check_output(cmd, *args, **kwargs):
+        raise real_subprocess.CalledProcessError(7, cmd, b"", b"connection refused")
+
+    interp = _fake_interpreter()
+    with patch.object(sdi.subprocess, "check_output", side_effect=fake_check_output):
+        out = sdi.interpreter_info(interp)
+
+    assert isinstance(out, str)
+    assert "Curl output" in out
+
+
+def test_interpreter_info_skips_curl_when_not_offline(sdi):
+    """
+    When the interpreter is online, curl must not be called at all.
+    """
+    interp = _fake_interpreter()
+    interp.offline = False
+
+    def fake_check_output(cmd, *args, **kwargs):  # pragma: no cover - must not run
+        raise AssertionError("curl must not be invoked when offline=False")
+
+    with patch.object(sdi.subprocess, "check_output", side_effect=fake_check_output):
+        out = sdi.interpreter_info(interp)
+
+    assert "Not local" in out


### PR DESCRIPTION
## Summary

Fixes #1218. `interpreter/core/utils/system_debug_info.py`:

```python
curl = subprocess.check_output(f"curl {interpreter.llm.api_base}")
```

Without `shell=True`, subprocess treats the entire f-string as the executable path → always raises `FileNotFoundError: 'curl http://...'`. Caught and stringified, so `%info` displays the FileNotFoundError text instead of the LLM-server response. There is also no timeout, so a naive `shell=True` patch would hang on a dead `api_base`.

## Fix

Pass argv as a list `["curl", "--silent", "--show-error", "--max-time", "5", api_base]` (curl is now resolved on PATH and actually runs), capture stderr, and add subprocess `timeout=10`.

## Test

`tests/core/utils/test_system_debug_info.py` (4 tests, loads module by file path so the heavy `interpreter/__init__.py` doesn't need its full dep tree):
1. curl is invoked as a real argv list, not as a single-token executable.
2. `timeout` kwarg is passed.
3. `CalledProcessError` is caught gracefully.
4. curl is not invoked when `offline=False`.

TDD: tests 1+2 RED on stock main → 4/4 GREEN after the patch. End-to-end smoke against `http://127.0.0.1:1` shows curl exits 7 ("failed to connect") in 0.01s instead of the previous spurious `FileNotFoundError`.

## Risk notes

Diagnostic path only (`%info` magic). Strictly more useful behaviour: real errors via `--show-error`, hard 10s upper bound, honest `FileNotFoundError: 'curl'` if curl is missing.

Refs #1218