### PR TITLE
Security: Fix critical OS mode auto-run and remote profile RCE

### DIFF
--- a/interpreter/terminal_interface/profiles/defaults/os.py
+++ b/interpreter/terminal_interface/profiles/defaults/os.py
@@ -12,8 +12,8 @@ interpreter.computer.import_computer_api = True
 interpreter.llm.supports_functions = True
 interpreter.llm.context_window = 110000
 interpreter.llm.max_tokens = 4096
-interpreter.auto_run = True
-interpreter.loop = True
+interpreter.auto_run = False
+interpreter.loop = False
 interpreter.sync_computer = True
 
 interpreter.system_message = r"""
@@ -242,9 +242,7 @@ if not interpreter.auto_run:
 #     if chunk.get("format") != "active_line":
 #         print(chunk.get("content"))
 
-interpreter.auto_run = True
-
 interpreter.display_message(
-    "**Warning:** In this mode, Open Interpreter will not require approval before performing actions. Be ready to close your terminal."
+    "**Warning:** OS Control mode enables full system access. Actions require approval by default—set auto_run=True only if you understand the risks."
 )
 print("")  # < - Aesthetic choice

--- a/interpreter/terminal_interface/profiles/profiles.py
+++ b/interpreter/terminal_interface/profiles/profiles.py
@@ -61,7 +61,7 @@ def profile(interpreter, filename_or_url):
             else:
                 raise
 
-    return apply_profile(interpreter, profile, profile_path)
+    return apply_profile(interpreter, profile, profile_path, filename_or_url)
 
 
 def get_profile(filename_or_url, profile_path):
@@ -111,7 +111,9 @@ def get_profile(filename_or_url, profile_path):
     response = requests.get(filename_or_url)
     response.raise_for_status()
     if extension == ".py":
-        return {"start_script": response.text, "version": OI_VERSION}
+        raise Exception(
+            "Remote Python profiles are not allowed for security reasons."
+        )
     elif extension == ".json":
         return json.loads(response.text)
     elif extension == ".yaml":
@@ -142,8 +144,12 @@ class RemoveInterpreter(ast.NodeTransformer):
         return node  # return node otherwise to keep it in the AST
 
 
-def apply_profile(interpreter, profile, profile_path):
+def apply_profile(interpreter, profile, profile_path, source=None):
     if "start_script" in profile:
+        if source and (source.startswith("http://") or source.startswith("https://")):
+            raise Exception(
+                "Remote Python profiles are not allowed for security reasons."
+            )
         scope = {"interpreter": interpreter}
         exec(profile["start_script"], scope, scope)
 


### PR DESCRIPTION
## Summary

Fixes two critical security findings identified in audit 2026-04-28.

### 1. OS mode defaults to unattended execution with full system control
**File:** `interpreter/terminal_interface/profiles/defaults/os.py`

- Changed `auto_run` default from `True` to `False`
- Changed `loop` default from `True` to `False`
- Removed the second forced `auto_run = True` override at the end of the profile
- Updated the warning message to accurately reflect that approval is now required by default

### 2. Profile loading executes arbitrary code from remote URLs
**File:** `interpreter/terminal_interface/profiles/profiles.py`

- Disallowed downloading remote `.py` profiles via `requests.get()`; now raises a security exception
- Added a `source` parameter to `apply_profile()` to track the original profile source URL/path
- Added an `exec()` guard that rejects `start_script` execution for any profile sourced from an `http://` or `https://` URL

These are minimal, surgical changes that preserve local `.py` profile functionality while eliminating the remote arbitrary code execution vector.

## Test Results
- Syntax validation passed for both modified files (`py_compile`)
- No existing tests specifically cover profile loading or OS defaults; full pytest suite could not be executed locally due to Python 3.14 incompatibility with the project's `<3.13` requirement