### PR TITLE
fix: support Python 3.13 and 3.14 by updating tiktoken constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ easyocr = { version = "^1.7.1", optional = true }
 janus = { version = "^1.0.0", optional = true }
 
 # Required dependencies
-python = ">=3.9,<3.13"
+python = ">=3.9,<4"
 setuptools = "*"
 astor = "^0.8.1"
 git-python = "^1.0.3"
@@ -54,7 +54,7 @@ ipykernel = "^6.26.0"
 jupyter-client = "^8.6.0"
 matplotlib = "^3.8.2"
 toml = "^0.10.2"
-tiktoken = "^0.7.0"
+tiktoken = ">=0.8.0"
 platformdirs = "^4.2.0"
 pydantic = "^2.6.4"
 google-generativeai = "^0.7.1"


### PR DESCRIPTION
## Problem

Two issues block installation on Python 3.13 and 3.14:

**1. Python version gate:** `python = ">=3.9,<3.13"` hard-blocks installation before pip even resolves dependencies.

**2. tiktoken wheel availability:** `tiktoken = "^0.7.0"` (Poetry caret = `>=0.7.0, <0.8.0`) has no pre-built `cp313`/`cp314` wheels. pip falls back to building from source, which requires a Rust/Cargo toolchain and fails:

```
error: the configured Python interpreter version (3.13) is newer than
       PyO3's maximum supported version (3.12)
ERROR: Failed building wheel for tiktoken
```

The `<3.13` Python gate was added in 3718bed72 as a workaround for this build failure rather than fixing the dependency. This PR fixes the root cause.

## Solution

```diff
-python = ">=3.9,<3.13"
+python = ">=3.9,<4"
-tiktoken = "^0.7.0"
+tiktoken = ">=0.8.0"
```

**Why `>=0.8.0` and not `^0.8.0` or `>=0.7.0`?**

- `^0.8.0` in Poetry caret notation means `>=0.8.0, <0.9.0`, which would block tiktoken 0.9.0–0.12.0 — all already released, with no breaking API changes (see #1744)
- `>=0.7.0` is technically correct (pip resolves to the latest by default) but is dishonest: 0.7.x still can't be built on Python 3.13 if somehow selected (see #1739)
- `>=0.8.0` (no upper bound) explicitly states the minimum version that ships `cp313` wheels, and allows all future releases

tiktoken 0.8.0 (Oct 2024) added `cp313` wheels; 0.12.0 (Oct 2025) added `cp314` wheels. The APIs used here (`encoding_for_model()`, `encode()`) are unchanged across all versions 0.4.0–0.12.0. `tokentrim` already declares `tiktoken >=0.4.0` with no upper bound for the same reason.

**Why restore `<4`?** The original constraint was `<4` before the workaround commit. All key dependencies declare `<4.0` or no upper bound — none require tighter. Tight Python upper bounds cause exactly this class of install-blocking bug and require a maintenance PR with every new Python release for no benefit.

Co-authored-by: Cursor <cursoragent@cursor.com>

### Reference any relevant issues (e.g. "Fixes #000"):

- Fixes #1539
- Fixes #1640
- Fixes #1743
- Supersedes #1739 (uses `>=0.7.0`; also correct but lower bound is misleading)
- Supersedes #1744 (uses `^0.8.0` which blocks 0.9.0–0.12.0 due to Poetry caret semantics)
- Related: #1667 (add Python 3.14 to CI; needs this fix to work)

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux