### PR TITLE
Update default model versions for Claude, Groq, and GPT-4 profiles

### DIFF
--- a/interpreter/computer_use/loop.py
+++ b/interpreter/computer_use/loop.py
@@ -84,9 +84,9 @@ class APIProvider(StrEnum):
 
 
 PROVIDER_TO_DEFAULT_MODEL_NAME: dict[APIProvider, str] = {
-    APIProvider.ANTHROPIC: "claude-3-5-sonnet-20241022",
-    APIProvider.BEDROCK: "anthropic.claude-3-5-sonnet-20241022-v2:0",
-    APIProvider.VERTEX: "claude-3-5-sonnet-v2@20241022",
+    APIProvider.ANTHROPIC: "claude-sonnet-4-6",
+    APIProvider.BEDROCK: "anthropic.claude-sonnet-4-6",
+    APIProvider.VERTEX: "claude-sonnet-4-6",
 }
 
 

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -114,8 +114,8 @@ class Llm:
             "claude-3.5-sonnet",
             "claude-3-5-sonnet",
         ]:
-            model = "claude-3-5-sonnet-20240620"
-            self.model = "claude-3-5-sonnet-20240620"
+            model = "claude-sonnet-4-6"
+            self.model = "claude-sonnet-4-6"
         # Setup our model endpoint
         if model == "i":
             model = "openai/i"

--- a/interpreter/terminal_interface/profiles/defaults/aws-docs.py
+++ b/interpreter/terminal_interface/profiles/defaults/aws-docs.py
@@ -5,7 +5,7 @@ This is an Open Interpreter profile. It is specialized for searching AWS documen
 # Configure Open Interpreter
 from interpreter import interpreter
 
-interpreter.llm.model = "claude-3-5-sonnet-20240620"
+interpreter.llm.model = "claude-sonnet-4-6"
 interpreter.computer.import_computer_api = True
 interpreter.llm.supports_functions = True
 interpreter.llm.supports_vision = True

--- a/interpreter/terminal_interface/profiles/defaults/bedrock-anthropic.py
+++ b/interpreter/terminal_interface/profiles/defaults/bedrock-anthropic.py
@@ -16,7 +16,7 @@ More information can be found here: https://docs.litellm.ai/docs/providers/bedro
 
 from interpreter import interpreter
 
-interpreter.llm.model = "bedrock/anthropic.claude-3-sonnet-20240229-v1:0"
+interpreter.llm.model = "bedrock/anthropic.claude-sonnet-4-6"
 
 interpreter.computer.import_computer_api = True
 

--- a/interpreter/terminal_interface/profiles/defaults/groq.py
+++ b/interpreter/terminal_interface/profiles/defaults/groq.py
@@ -6,7 +6,7 @@ Make sure to set GROQ_API_KEY environment variable to your API key.
 
 from interpreter import interpreter
 
-interpreter.llm.model = "groq/llama-3.1-70b-versatile"
+interpreter.llm.model = "groq/llama-3.3-70b-versatile"
 
 interpreter.computer.import_computer_api = True
 

--- a/interpreter/terminal_interface/profiles/defaults/obsidian.py
+++ b/interpreter/terminal_interface/profiles/defaults/obsidian.py
@@ -9,7 +9,7 @@ import os
 obsidian_directory = os.environ.get("OBSIDIAN_VAULT_PATH")
 
 # You can update to the model you want to use
-interpreter.llm.model = "groq/llama-3.1-70b-versatile"
+interpreter.llm.model = "groq/llama-3.3-70b-versatile"
 
 interpreter.computer.import_computer_api = False
 

--- a/interpreter/terminal_interface/profiles/defaults/screenpipe.py
+++ b/interpreter/terminal_interface/profiles/defaults/screenpipe.py
@@ -7,7 +7,7 @@ It leverages Llama 3.1 70b served by Groq and requires the environment variable 
 from interpreter import interpreter
 from datetime import datetime, timezone
 
-interpreter.llm.model = "groq/llama-3.1-70b-versatile"
+interpreter.llm.model = "groq/llama-3.3-70b-versatile"
 interpreter.computer.import_computer_api = False
 interpreter.llm.supports_functions = False
 interpreter.llm.supports_vision = False

--- a/interpreter/terminal_interface/profiles/defaults/template_profile.py
+++ b/interpreter/terminal_interface/profiles/defaults/template_profile.py
@@ -17,7 +17,7 @@ from datetime import date
 today = date.today()
 
 # LLM Settings
-interpreter.llm.model = "groq/llama-3.1-70b-versatile"
+interpreter.llm.model = "groq/llama-3.3-70b-versatile"
 interpreter.llm.context_window = 110000
 interpreter.llm.max_tokens = 4096
 interpreter.llm.api_base = "https://api.example.com"

--- a/interpreter/terminal_interface/profiles/defaults/the01.py
+++ b/interpreter/terminal_interface/profiles/defaults/the01.py
@@ -8,7 +8,7 @@ from interpreter import interpreter
 interpreter.tts = "openai"
 
 # Connect your 01 to a language model
-interpreter.llm.model = "claude-3.5"
+interpreter.llm.model = "claude-sonnet-4-6"
 # interpreter.llm.model = "gpt-4o-mini"
 interpreter.llm.context_window = 100000
 interpreter.llm.max_tokens = 4096

--- a/interpreter/terminal_interface/profiles/profiles.py
+++ b/interpreter/terminal_interface/profiles/profiles.py
@@ -170,11 +170,11 @@ def apply_profile(interpreter, profile, profile_path):
 
                 try:
                     if profile["llm"]["model"] == "gpt-4":
-                        text = text.replace("gpt-4", "gpt-4o")
-                        profile["llm"]["model"] = "gpt-4o"
+                        text = text.replace("gpt-4", "gpt-4.1")
+                        profile["llm"]["model"] = "gpt-4.1"
                     elif profile["llm"]["model"] == "gpt-4-turbo-preview":
-                        text = text.replace("gpt-4-turbo-preview", "gpt-4o")
-                        profile["llm"]["model"] = "gpt-4o"
+                        text = text.replace("gpt-4-turbo-preview", "gpt-4.1")
+                        profile["llm"]["model"] = "gpt-4.1"
                 except:
                     raise
                     pass  # fine

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -552,7 +552,7 @@ Use """ to write multi-line messages.
         "claude-3.5-sonnet",
         "claude-3-5-sonnet",
     ]:
-        interpreter.llm.model = "claude-3-5-sonnet-20240620"
+        interpreter.llm.model = "claude-sonnet-4-6"
 
     if not args.server:
         # This SHOULD RUN WHEN THE SERVER STARTS. But it can't rn because


### PR DESCRIPTION
## Fix deprecated model IDs causing 404 errors

### Problem

OS mode is broken out of the box. `claude-3-5-sonnet-20241022` has been removed from the Anthropic API:

```
Error code: 404 - {'type': 'error', 'error': {'type': 'not_found_error', 'message': 'model: claude-3-5-sonnet-20241022'}}
```

Multiple users have reported this in the community Discord. The model ID is hardcoded in `computer_use/loop.py` and cannot be overridden with `--model`.

### Changes

| File | Provider | Old | New | Source |
|------|----------|-----|-----|--------|
| `computer_use/loop.py` | Anthropic API | `claude-3-5-sonnet-20241022` | `claude-sonnet-4-6` | [Anthropic models docs](https://docs.anthropic.com/en/docs/about-claude/models/all-models) |
| `computer_use/loop.py` | AWS Bedrock | `anthropic.claude-3-5-sonnet-20241022-v2:0` | `anthropic.claude-sonnet-4-6` | [AWS Bedrock model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-6.html) |
| `computer_use/loop.py` | Google Vertex AI | `claude-3-5-sonnet-v2@20241022` | `claude-sonnet-4-6` | Same Anthropic model family; Vertex ID matches [Anthropic’s cross-platform table](https://docs.anthropic.com/en/docs/about-claude/models/all-models) |
| `llm.py` + `start_terminal_interface.py` | (alias expansion) | `claude-3-5-sonnet-20240620` | `claude-sonnet-4-6` | Same model family; old snapshot is no longer the right default |
| `profiles/defaults/aws-docs.py` | — | `claude-3-5-sonnet-20240620` | `claude-sonnet-4-6` | Same |
| `profiles/defaults/bedrock-anthropic.py` | Bedrock (LiteLLM) | `bedrock/anthropic.claude-3-sonnet-20240229-v1:0` | `bedrock/anthropic.claude-sonnet-4-6` | Claude 3 Sonnet (Feb 2024) is outdated vs current Bedrock offering |
| `profiles/defaults/the01.py` | — | `claude-3.5` | `claude-sonnet-4-6` | Avoids relying on shorthand that previously resolved to an old snapshot |
| `groq.py`, `obsidian.py`, `screenpipe.py`, `template_profile.py` | Groq | `groq/llama-3.1-70b-versatile` | `groq/llama-3.3-70b-versatile` | [Groq: Llama 3.3 70B](https://console.groq.com/docs/model/llama-3.3-70b-versatile) |
| `profiles/profiles.py` | (saved profile migration) | `gpt-4` / `gpt-4-turbo-preview` → `gpt-4o` | → `gpt-4.1` | [OpenAI deprecations](https://platform.openai.com/docs/deprecations/) lists `gpt-4.1` as substitute for `gpt-4-turbo` / legacy `gpt-4` snapshots |

### Not changed

- `self.model = "gpt-4o"` (default in `llm.py`) — still callable on the API today; changing the global default is a separate change.
- `fast.yaml`: `gpt-4o-mini` — still current for that profile.

Co-authored-by: Cursor <cursoragent@cursor.com>

### Reference any relevant issues (e.g. "Fixes #000"):

No linked GitHub issue — reproduction is the Discord-reported 404 on `claude-3-5-sonnet-20241022` in OS mode. If you open an issue with that stack trace, you can add `Fixes #NNN` in a follow-up commit.

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
