### PR TITLE
docs: add Tuning Engines custom endpoint example

### DIFF
--- a/docs/language-models/local-models/custom-endpoint.mdx
+++ b/docs/language-models/local-models/custom-endpoint.mdx
@@ -6,13 +6,36 @@ Simply set `api_base` to any OpenAI compatible server:
 
 <CodeGroup>
 ```bash Terminal
-interpreter --api_base <custom_endpoint>
+interpreter --api_base <custom_endpoint> --api_key <api_key> --model openai/<model>
 ```
 
 ```python Python
 from interpreter import interpreter
 
 interpreter.llm.api_base = "<custom_endpoint>"
+interpreter.llm.api_key = "<api_key>"
+interpreter.llm.model = "openai/<model>"
+interpreter.chat()
+```
+
+</CodeGroup>
+
+For example, to use a Tuning Engines workspace as the OpenAI-compatible endpoint:
+
+<CodeGroup>
+```bash Terminal
+interpreter \
+  --api_base "https://api.tuningengines.com/v1" \
+  --api_key "sk-te-..." \
+  --model "openai/<your-model-alias>"
+```
+
+```python Python
+from interpreter import interpreter
+
+interpreter.llm.api_base = "https://api.tuningengines.com/v1"
+interpreter.llm.api_key = "sk-te-..."
+interpreter.llm.model = "openai/<your-model-alias>"
 interpreter.chat()
 ```
 


### PR DESCRIPTION
### Describe the changes you have made:

Adds a docs-only example for using a Tuning Engines workspace through Open Interpreter's existing OpenAI-compatible custom endpoint support.

### Reference any relevant issues (e.g. "Fixes #000"):

N/A

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux

Docs-only change; runtime tests were not run.
