### PR TITLE
Enhancement : add per-response token usage display in terminal

### DIFF
--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -100,6 +100,9 @@ class OpenInterpreter:
         self.contribute_conversation = contribute_conversation
         self.plain_text_display = plain_text_display
         self.highlight_active_line = True  # additional setting to toggle active line highlighting. Defaults to True
+        self.track_usage = False
+        self.last_usage = None
+        self.last_usage_request = None
 
         # Loop messages
         self.loop = loop
@@ -310,6 +313,8 @@ class OpenInterpreter:
                 return True
             if chunk["type"] == "review":
                 return True
+            if chunk["type"] == "usage":
+                return True
             return False
 
         last_flag_base = None
@@ -432,6 +437,8 @@ class OpenInterpreter:
         self.computer._has_imported_computer_api = False  # Flag reset
         self.messages = []
         self.last_messages_count = 0
+        self.last_usage = None
+        self.last_usage_request = None
 
     def display_message(self, markdown):
         # This is just handy for start_script in profiles.
@@ -439,6 +446,38 @@ class OpenInterpreter:
             print(markdown)
         else:
             display_markdown_message(markdown)
+
+    def should_display_usage(self):
+        return self.in_terminal_interface and (self.verbose or self.track_usage)
+
+    def format_usage(self, usage=None):
+        usage = self.last_usage if usage is None else usage
+        if not usage:
+            return None
+
+        prompt_tokens = usage.get("prompt_tokens")
+        completion_tokens = usage.get("completion_tokens")
+        total_tokens = usage.get("total_tokens")
+        cost = usage.get("cost")
+        estimated = usage.get("estimated", False)
+
+        token_parts = []
+        if prompt_tokens is not None:
+            token_parts.append(f"{prompt_tokens} in")
+        if completion_tokens is not None:
+            token_parts.append(f"{completion_tokens} out")
+        if total_tokens is not None:
+            token_parts.append(f"{total_tokens} total")
+
+        if not token_parts and cost is None:
+            return None
+
+        label = "> Tokens (estimated): " if estimated else "> Tokens: "
+        message = label + ", ".join(token_parts) if token_parts else label.rstrip()
+        if cost is not None:
+            message += f" | Estimated cost: ${cost:.6f}"
+
+        return message
 
     def get_oi_dir(self):
         # Again, just handy for start_script in profiles.

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -286,7 +286,9 @@ Continuing...
             "model": model,
             "messages": messages,
             "stream": True,
+            "interpreter": self.interpreter,
         }
+        self.interpreter.last_usage_request = {"model": model, "messages": messages}
 
         # Optional inputs
         if self.api_key:
@@ -325,6 +327,54 @@ Continuing...
             yield from run_tool_calling_llm(self, params)
         else:
             yield from run_text_llm(self, params)
+
+    def estimate_usage(self, model, messages, completion):
+        prompt_tokens = None
+        completion_tokens = None
+        total_tokens = None
+        cost = None
+
+        try:
+            prompt_tokens = litellm.token_counter(model=model, messages=messages)
+        except:
+            pass
+
+        try:
+            completion_tokens = litellm.token_counter(
+                model=model, text=completion, count_response_tokens=True
+            )
+        except:
+            pass
+
+        if prompt_tokens is not None or completion_tokens is not None:
+            total_tokens = (prompt_tokens or 0) + (completion_tokens or 0)
+
+        if prompt_tokens is not None or completion_tokens is not None:
+            try:
+                prompt_cost, completion_cost = litellm.cost_per_token(
+                    model=model,
+                    prompt_tokens=prompt_tokens or 0,
+                    completion_tokens=completion_tokens or 0,
+                )
+                cost = round((prompt_cost or 0) + (completion_cost or 0), 6)
+            except:
+                pass
+
+        if (
+            prompt_tokens is None
+            and completion_tokens is None
+            and total_tokens is None
+            and cost is None
+        ):
+            return None
+
+        return {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+            "cost": cost,
+            "estimated": True,
+        }
 
     # If you change model, set _is_loaded to false
     @property
@@ -435,35 +485,98 @@ def fixed_litellm_completions(**params):
 
     params["model"] = params["model"].replace(":latest", "")
 
+    def normalize_usage(usage, response_cost=None):
+        if usage is None and response_cost is None:
+            return None
+
+        if usage is not None and not isinstance(usage, dict):
+            usage = {
+                "prompt_tokens": getattr(usage, "prompt_tokens", None),
+                "completion_tokens": getattr(usage, "completion_tokens", None),
+                "total_tokens": getattr(usage, "total_tokens", None),
+            }
+
+        usage = usage or {}
+        prompt_tokens = usage.get("prompt_tokens", usage.get("input_tokens"))
+        completion_tokens = usage.get("completion_tokens", usage.get("output_tokens"))
+        total_tokens = usage.get("total_tokens")
+
+        if total_tokens is None and (
+            prompt_tokens is not None or completion_tokens is not None
+        ):
+            total_tokens = (prompt_tokens or 0) + (completion_tokens or 0)
+
+        if (
+            prompt_tokens is None
+            and completion_tokens is None
+            and total_tokens is None
+            and response_cost is None
+        ):
+            return None
+
+        return {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+            "cost": response_cost,
+        }
+
+    interpreter = params.pop("interpreter", None)
+    if interpreter is not None:
+        interpreter.last_usage = None
+
+    def capture_usage(kwargs, completion_response, start_time, end_time):
+        if interpreter is None:
+            return
+
+        usage = getattr(completion_response, "usage", None)
+        if usage is None and isinstance(completion_response, dict):
+            usage = completion_response.get("usage")
+
+        interpreter.last_usage = normalize_usage(
+            usage, response_cost=kwargs.get("response_cost")
+        )
+
+    existing_success_callback = litellm.success_callback
+    if existing_success_callback is None:
+        litellm.success_callback = [capture_usage]
+    elif isinstance(existing_success_callback, list):
+        litellm.success_callback = existing_success_callback + [capture_usage]
+    else:
+        litellm.success_callback = [existing_success_callback, capture_usage]
+
     # Run completion
     attempts = 4
     first_error = None
 
     params["num_retries"] = 0
 
-    for attempt in range(attempts):
-        try:
-            yield from litellm.completion(**params)
-            return  # If the completion is successful, exit the function
-        except KeyboardInterrupt:
-            print("Exiting...")
-            sys.exit(0)
-        except Exception as e:
-            if attempt == 0:
-                # Store the first error
-                first_error = e
-            if (
-                isinstance(e, litellm.exceptions.AuthenticationError)
-                and "api_key" not in params
-            ):
-                print(
-                    "LiteLLM requires an API key. Trying again with a dummy API key. In the future, if this fixes it, please set a dummy API key to prevent this message. (e.g `interpreter --api_key x` or `self.api_key = 'x'`)"
-                )
-                # So, let's try one more time with a dummy API key:
-                params["api_key"] = "x"
-            if attempt == 1:
-                # Try turning up the temperature?
-                params["temperature"] = params.get("temperature", 0.0) + 0.1
+    try:
+        for attempt in range(attempts):
+            try:
+                yield from litellm.completion(**params)
+                return  # If the completion is successful, exit the function
+            except KeyboardInterrupt:
+                print("Exiting...")
+                sys.exit(0)
+            except Exception as e:
+                if attempt == 0:
+                    # Store the first error
+                    first_error = e
+                if (
+                    isinstance(e, litellm.exceptions.AuthenticationError)
+                    and "api_key" not in params
+                ):
+                    print(
+                        "LiteLLM requires an API key. Trying again with a dummy API key. In the future, if this fixes it, please set a dummy API key to prevent this message. (e.g `interpreter --api_key x` or `self.api_key = 'x'`)"
+                    )
+                    # So, let's try one more time with a dummy API key:
+                    params["api_key"] = "x"
+                if attempt == 1:
+                    # Try turning up the temperature?
+                    params["temperature"] = params.get("temperature", 0.0) + 0.1
 
-    if first_error is not None:
-        raise first_error  # If all attempts fail, raise the first error
+        if first_error is not None:
+            raise first_error  # If all attempts fail, raise the first error
+    finally:
+        litellm.success_callback = existing_success_callback

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -486,9 +486,6 @@ def fixed_litellm_completions(**params):
     params["model"] = params["model"].replace(":latest", "")
 
     def normalize_usage(usage, response_cost=None):
-        if usage is None and response_cost is None:
-            return None
-
         if usage is not None and not isinstance(usage, dict):
             usage = {
                 "prompt_tokens": getattr(usage, "prompt_tokens", None),
@@ -506,20 +503,17 @@ def fixed_litellm_completions(**params):
         ):
             total_tokens = (prompt_tokens or 0) + (completion_tokens or 0)
 
-        if (
-            prompt_tokens is None
-            and completion_tokens is None
-            and total_tokens is None
-            and response_cost is None
-        ):
-            return None
-
-        return {
+        normalized_usage = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
             "cost": response_cost,
         }
+
+        if all(value is None for value in normalized_usage.values()):
+            return None
+
+        return normalized_usage
 
     interpreter = params.pop("interpreter", None)
     if interpreter is not None:
@@ -537,13 +531,10 @@ def fixed_litellm_completions(**params):
             usage, response_cost=kwargs.get("response_cost")
         )
 
-    existing_success_callback = litellm.success_callback
-    if existing_success_callback is None:
-        litellm.success_callback = [capture_usage]
-    elif isinstance(existing_success_callback, list):
-        litellm.success_callback = existing_success_callback + [capture_usage]
-    else:
-        litellm.success_callback = [existing_success_callback, capture_usage]
+    success_callback = params.pop("success_callback", [])
+    if not isinstance(success_callback, list):
+        success_callback = [success_callback]
+    params["success_callback"] = success_callback + [capture_usage]
 
     # Run completion
     attempts = 4
@@ -551,32 +542,29 @@ def fixed_litellm_completions(**params):
 
     params["num_retries"] = 0
 
-    try:
-        for attempt in range(attempts):
-            try:
-                yield from litellm.completion(**params)
-                return  # If the completion is successful, exit the function
-            except KeyboardInterrupt:
-                print("Exiting...")
-                sys.exit(0)
-            except Exception as e:
-                if attempt == 0:
-                    # Store the first error
-                    first_error = e
-                if (
-                    isinstance(e, litellm.exceptions.AuthenticationError)
-                    and "api_key" not in params
-                ):
-                    print(
-                        "LiteLLM requires an API key. Trying again with a dummy API key. In the future, if this fixes it, please set a dummy API key to prevent this message. (e.g `interpreter --api_key x` or `self.api_key = 'x'`)"
-                    )
-                    # So, let's try one more time with a dummy API key:
-                    params["api_key"] = "x"
-                if attempt == 1:
-                    # Try turning up the temperature?
-                    params["temperature"] = params.get("temperature", 0.0) + 0.1
+    for attempt in range(attempts):
+        try:
+            yield from litellm.completion(**params)
+            return  # If the completion is successful, exit the function
+        except KeyboardInterrupt:
+            print("Exiting...")
+            sys.exit(0)
+        except Exception as e:
+            if attempt == 0:
+                # Store the first error
+                first_error = e
+            if (
+                isinstance(e, litellm.exceptions.AuthenticationError)
+                and "api_key" not in params
+            ):
+                print(
+                    "LiteLLM requires an API key. Trying again with a dummy API key. In the future, if this fixes it, please set a dummy API key to prevent this message. (e.g `interpreter --api_key x` or `self.api_key = 'x'`)"
+                )
+                # So, let's try one more time with a dummy API key:
+                params["api_key"] = "x"
+            if attempt == 1:
+                # Try turning up the temperature?
+                params["temperature"] = params.get("temperature", 0.0) + 0.1
 
-        if first_error is not None:
-            raise first_error  # If all attempts fail, raise the first error
-    finally:
-        litellm.success_callback = existing_success_callback
+    if first_error is not None:
+        raise first_error  # If all attempts fail, raise the first error

--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -84,8 +84,22 @@ def respond(interpreter):
             interpreter.messages[-1]["type"] != "code"
         ):  # If it is, we should run the code (we do below)
             try:
+                completion = []
                 for chunk in interpreter.llm.run(messages_for_llm):
+                    if chunk.get("content"):
+                        completion.append(chunk["content"])
                     yield {"role": "assistant", **chunk}
+
+                if interpreter.last_usage is None and interpreter.last_usage_request:
+                    interpreter.last_usage = interpreter.llm.estimate_usage(
+                        interpreter.last_usage_request["model"],
+                        interpreter.last_usage_request["messages"],
+                        "".join(completion),
+                    )
+
+                usage_message = interpreter.format_usage()
+                if usage_message and interpreter.should_display_usage():
+                    yield {"role": "assistant", "type": "usage", "content": usage_message}
 
             except litellm.exceptions.BudgetExceededError:
                 interpreter.display_message(

--- a/interpreter/terminal_interface/magic_commands.py
+++ b/interpreter/terminal_interface/magic_commands.py
@@ -54,7 +54,8 @@ def handle_help(self, arguments):
         "%undo": "Remove previous messages and its response from the message history.",
         "%save_message [path]": "Saves messages to a specified JSON path. If no path is provided, it defaults to 'messages.json'.",
         "%load_message [path]": "Loads messages from a specified JSON path. If no path is provided, it defaults to 'messages.json'.",
-        "%tokens [prompt]": "EXPERIMENTAL: Calculate the tokens used by the next request based on the current conversation's messages and estimate the cost of that request; optionally provide a prompt to also calculate the tokens used by that prompt and the total amount of tokens that will be sent with the next request",
+        "%tokens [on/off]": "Toggle display of token counts and estimated cost after each assistant response.",
+        "%token_estimate [prompt]": "EXPERIMENTAL: Calculate the tokens used by the next request based on the current conversation's messages and estimate the cost of that request; optionally provide a prompt to also calculate the tokens used by that prompt and the total amount of tokens that will be sent with the next request",
         "%help": "Show this help message.",
         "%info": "Show system and interpreter information",
         "%jupyter": "Export the conversation to a Jupyter notebook file",
@@ -171,6 +172,19 @@ def handle_load_message(self, json_path):
 
 
 def handle_count_tokens(self, prompt):
+    if prompt in ["", "on", "true"]:
+        self.track_usage = True
+        self.display_message("> Token tracking enabled")
+        return
+    if prompt in ["off", "false"]:
+        self.track_usage = False
+        self.display_message("> Token tracking disabled")
+        return
+
+    handle_token_estimate(self, prompt)
+
+
+def handle_token_estimate(self, prompt):
     messages = [{"role": "system", "message": self.system_message}] + self.messages
 
     outputs = []
@@ -329,6 +343,7 @@ def handle_magic_command(self, user_input):
         "load_message": handle_load_message,
         "undo": handle_undo,
         "tokens": handle_count_tokens,
+        "token_estimate": handle_token_estimate,
         "info": handle_info,
         "jupyter": jupyter,
         "markdown": markdown,

--- a/interpreter/terminal_interface/profiles/defaults/default.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/default.yaml
@@ -23,6 +23,7 @@ computer:
 # safe_mode: "off"  # The safety mode for the LLM — one of "off", "ask", "auto"
 # offline: False  # If True, will disable some online features like checking for updates
 # verbose: False  # If True, will print detailed logs
+# track_usage: False  # If True, will show token counts and estimated cost after each assistant response
 
 # To use a separate model for the `wtf` command:
 # wtf:

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -72,6 +72,13 @@ def start_terminal_interface(interpreter):
             "attribute": {"object": interpreter, "attr_name": "verbose"},
         },
         {
+            "name": "track_cost",
+            "flags": ["--track-cost", "--track_cost"],
+            "help_text": "show token counts and estimated cost after each assistant response",
+            "type": bool,
+            "attribute": {"object": interpreter, "attr_name": "track_usage"},
+        },
+        {
             "name": "model",
             "nickname": "m",
             "help_text": "language model to use",
@@ -354,14 +361,15 @@ Use """ to write multi-line messages.
         action = arg.get("action", "store_true")
         nickname = arg.get("nickname")
 
-        name_or_flags = [f'--{arg["name"]}']
-        if nickname:
-            name_or_flags.append(f"-{nickname}")
-
-        # Construct argument name flags
-        flags = (
-            [f"-{nickname}", f'--{arg["name"]}'] if nickname else [f'--{arg["name"]}']
-        )
+        flags = arg.get("flags")
+        if flags is None:
+            flags = (
+                [f"-{nickname}", f'--{arg["name"]}']
+                if nickname
+                else [f'--{arg["name"]}']
+            )
+        elif nickname:
+            flags = [f"-{nickname}"] + flags
 
         if arg["type"] == bool:
             parser.add_argument(
@@ -476,6 +484,8 @@ Use """ to write multi-line messages.
     ### Set attributes on interpreter, because the arguments passed in via the CLI should override profile
 
     set_attributes(args, arguments)
+    if args.verbose:
+        interpreter.track_usage = True
     interpreter.disable_telemetry = (
         os.getenv("DISABLE_TELEMETRY", "false").lower() == "true"
         or args.disable_telemetry

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -183,6 +183,9 @@ def terminal_interface(interpreter, message):
                     # Specialized models can emit a code review.
                     print(chunk.get("content"), end="", flush=True)
 
+                if chunk["type"] == "usage" and chunk.get("content"):
+                    interpreter.display_message(chunk["content"])
+
                 # Execution notice
                 if chunk["type"] == "confirmation":
                     if not interpreter.auto_run:

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -8,6 +8,7 @@ import pytest
 
 #####
 from interpreter import AsyncInterpreter, OpenInterpreter
+from interpreter.core.llm.llm import fixed_litellm_completions
 from interpreter.terminal_interface.magic_commands import handle_magic_command
 from interpreter.terminal_interface.utils.count_tokens import (
     count_messages_tokens,
@@ -1117,6 +1118,32 @@ def test_format_usage_marks_estimated_usage():
     }
 
     assert interpreter.format_usage() == "> Tokens (estimated): 12 in, 34 out, 46 total"
+
+
+def test_fixed_litellm_completions_uses_request_scoped_success_callback(monkeypatch):
+    import litellm
+
+    original_success_callback = litellm.success_callback
+    seen = {}
+
+    def fake_completion(**params):
+        seen["success_callback"] = params.get("success_callback")
+        yield {"choices": []}
+
+    monkeypatch.setattr(litellm, "completion", fake_completion)
+
+    list(
+        fixed_litellm_completions(
+            model="gpt-4o",
+            messages=[],
+            stream=True,
+            interpreter=interpreter,
+        )
+    )
+
+    assert litellm.success_callback is original_success_callback
+    assert isinstance(seen["success_callback"], list)
+    assert len(seen["success_callback"]) == 1
 
 
 @pytest.mark.skip(reason="Computer with display only + no way to fail test")

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -8,6 +8,7 @@ import pytest
 
 #####
 from interpreter import AsyncInterpreter, OpenInterpreter
+from interpreter.terminal_interface.magic_commands import handle_magic_command
 from interpreter.terminal_interface.utils.count_tokens import (
     count_messages_tokens,
     count_tokens,
@@ -1071,6 +1072,51 @@ def test_get_selected_text():
     text = interpreter.computer.os.get_selected_text()
     print(text)
     assert False
+
+
+def test_tokens_magic_command_toggles_usage_tracking():
+    interpreter.track_usage = False
+
+    handle_magic_command(interpreter, "%tokens")
+    assert interpreter.track_usage is True
+
+    handle_magic_command(interpreter, "%tokens off")
+    assert interpreter.track_usage is False
+
+
+def test_format_usage_includes_cost_when_available():
+    interpreter.last_usage = {
+        "prompt_tokens": 12,
+        "completion_tokens": 34,
+        "total_tokens": 46,
+        "cost": 0.001234,
+    }
+
+    assert (
+        interpreter.format_usage()
+        == "> Tokens: 12 in, 34 out, 46 total | Estimated cost: $0.001234"
+    )
+
+
+def test_should_display_usage_respects_terminal_state():
+    interpreter.in_terminal_interface = True
+    interpreter.track_usage = True
+    interpreter.verbose = False
+    assert interpreter.should_display_usage() is True
+
+    interpreter.in_terminal_interface = False
+    assert interpreter.should_display_usage() is False
+
+
+def test_format_usage_marks_estimated_usage():
+    interpreter.last_usage = {
+        "prompt_tokens": 12,
+        "completion_tokens": 34,
+        "total_tokens": 46,
+        "estimated": True,
+    }
+
+    assert interpreter.format_usage() == "> Tokens (estimated): 12 in, 34 out, 46 total"
 
 
 @pytest.mark.skip(reason="Computer with display only + no way to fail test")


### PR DESCRIPTION
### Describe the changes you have made:

  ## Add per-response token usage display in the terminal

  This PR implements issue #1754 by showing token usage after each completed assistant response in the terminal.

<img width="554" height="28" alt="Screenshot 2026-05-25 at 10 59 17 PM" src="https://github.com/user-attachments/assets/b6a85172-b64d-476b-b1f7-1b5ca7b63e98" />

  ### What changed

  - Added terminal usage display after completed assistant responses
  - Added `%tokens` as a session toggle for usage display
  - Added `--track-cost` / `--track_cost` to enable usage display at startup
  - Made `--verbose` also enable usage display for that run
  - Preserved the old next-request estimator under `%token_estimate`
  - Added a fallback estimator for providers/local models that do not return usage metadata
  - Marked fallback output clearly as estimated: `Tokens (estimated)`

  ### Notes

  - Provider-reported usage is preferred when available
  - Local models like `phi3` may not return usage metadata, so this PR falls back to estimating prompt/completion tokens from the actual
  request/response content
  - Usage display is emitted only after a completed assistant turn

  ### Testing

  Tested from the source tree with a local model:

  - Launch:
    `PYTHONPATH=. ./ven/bin/python -c "from interpreter.terminal_interface.start_terminal_interface import main; main()" --local`
  - Enable tracking:
    `%tokens`
  - Verified completed assistant turns display:
    `> Tokens (estimated): ...`

  Also verified:

  - `%tokens` toggles tracking on/off
  - the source-tree CLI parser accepts `--track-cost`
  - fallback estimation works when provider usage metadata is unavailable

  ### Reference any relevant issues (e.g. "Fixes #000"):

  Fixes #1754

  ### Pre-Submission Checklist (optional but appreciated):

  - [ ] I have included relevant documentation updates (stored in /docs)
  - [x] I have read `docs/CONTRIBUTING.md`
  - [x] I have read `docs/ROADMAP.md`

  ### OS Tests (optional but appreciated):

  - [ ] Tested on Windows
  - [x] Tested on MacOS
  - [ ] Tested on Linux