### PR TITLE
fix: route "cmd" code blocks to the shell instead of rejecting them

### DIFF
--- a/interpreter/core/computer/terminal/languages/shell.py
+++ b/interpreter/core/computer/terminal/languages/shell.py
@@ -8,7 +8,7 @@ from .subprocess_language import SubprocessLanguage
 class Shell(SubprocessLanguage):
     file_extension = "sh"
     name = "Shell"
-    aliases = ["bash", "sh", "zsh", "batch", "bat"]
+    aliases = ["bash", "sh", "zsh", "batch", "bat", "cmd"]
 
     def __init__(
         self,

--- a/tests/core/computer/test_terminal.py
+++ b/tests/core/computer/test_terminal.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest import mock
+
+from interpreter.core.computer.terminal.languages.shell import Shell
+from interpreter.core.computer.terminal.terminal import Terminal
+
+
+class TestTerminalGetLanguage(unittest.TestCase):
+    def setUp(self):
+        self.terminal = Terminal(mock.Mock())
+
+    def test_cmd_maps_to_shell(self):
+        # "cmd" is what models commonly emit for the Windows command prompt.
+        # The Shell language already launches cmd.exe on Windows, so "cmd"
+        # should resolve to it instead of being reported as unsupported.
+        self.assertIs(self.terminal.get_language("cmd"), Shell)
+
+    def test_cmd_is_case_insensitive(self):
+        self.assertIs(self.terminal.get_language("CMD"), Shell)
+
+    def test_existing_shell_aliases_still_resolve(self):
+        for alias in ("bash", "sh", "zsh", "batch", "bat"):
+            self.assertIs(self.terminal.get_language(alias), Shell)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Models routinely tag Windows command-prompt code blocks as `cmd`, but that language name was never registered, so it fell through to "`cmd` disabled or not supported." and the code was silently dropped.

Root cause: the Shell language lists `batch`/`bat`/`bash`/etc. as aliases but not `cmd`, so `Terminal.get_language("cmd")` returns `None`. The Shell language already launches `cmd.exe` on Windows, so it can run this code — it just wasn't reachable by that name.

Fix: add `"cmd"` to the Shell aliases. `cmd` blocks now resolve to the shell and run like `bat`/`batch` already do.

Added tests/core/computer/test_terminal.py covering `get_language("cmd")`, case-insensitivity, and the existing aliases as a guard. `pytest tests/core/computer/` passes (8 tests); black/isort clean.

Fixes #1023
