### PR TITLE
Use UTF-8 when exporting/loading conversations (fixes Windows UnicodeEncodeError)

### DIFF
--- a/interpreter/terminal_interface/conversation_navigator.py
+++ b/interpreter/terminal_interface/conversation_navigator.py
@@ -76,8 +76,12 @@ def conversation_navigator(interpreter):
 
     selected_filename = readable_names_and_filenames[answers["name"]]
 
-    # Open the selected file and load the JSON data
-    with open(os.path.join(conversations_dir, selected_filename), "r") as f:
+    # Open the selected file and load the JSON data. Read as UTF-8 to match how
+    # conversations are written and to avoid UnicodeDecodeError on non-ASCII
+    # content under the Windows locale codepage.
+    with open(
+        os.path.join(conversations_dir, selected_filename), "r", encoding="utf-8"
+    ) as f:
         messages = json.load(f)
 
     # Pass the data into render_past_conversation

--- a/interpreter/terminal_interface/utils/export_to_markdown.py
+++ b/interpreter/terminal_interface/utils/export_to_markdown.py
@@ -1,6 +1,9 @@
 def export_to_markdown(messages: list[dict], export_path: str):
     markdown = messages_to_markdown(messages)
-    with open(export_path, 'w') as f:
+    # Force UTF-8 so emoji / CJK / accented characters export correctly. Without
+    # this, text mode falls back to the locale codepage (cp1252 on Windows),
+    # which raises UnicodeEncodeError on non-Latin-1 content.
+    with open(export_path, "w", encoding="utf-8") as f:
         f.write(markdown)
     print(f"Exported current conversation to {export_path}")
 

--- a/tests/test_export_to_markdown.py
+++ b/tests/test_export_to_markdown.py
@@ -1,0 +1,68 @@
+"""
+Tests for exporting conversations to Markdown.
+
+These guard against a Windows-specific regression: on Windows, the text-mode
+default for open() is the locale codepage (e.g. cp1252), not UTF-8. Any
+conversation containing emoji or non-Latin-1 characters (CJK, accents, ...)
+therefore raised UnicodeEncodeError on export, which silently failed for
+Windows users while working fine on the maintainers' POSIX machines (whose
+default is already UTF-8). The fix is to pass encoding="utf-8" explicitly.
+"""
+
+import builtins
+
+from interpreter.terminal_interface.utils.export_to_markdown import export_to_markdown
+
+# A user/assistant exchange that mixes an accent, CJK and an emoji - all of
+# which are unrepresentable in cp1252 and so trip the bug.
+NON_ASCII_MESSAGES = [
+    {"role": "user", "type": "message", "content": "Comment dit-on « café » ? 你好 🎉"},
+    {
+        "role": "assistant",
+        "type": "message",
+        "content": "On dit « café ». 干杯 🥂",
+    },
+]
+
+
+def _force_windows_default_encoding(monkeypatch):
+    """Make open() behave like Windows: default text encoding is cp1252.
+
+    Python resolves the default text encoding from the OS, so on macOS/Linux
+    the bug is invisible. We wrap builtins.open so that any text-mode call
+    without an explicit ``encoding`` falls back to cp1252, reproducing the
+    Windows codepage behaviour deterministically and cross-platform.
+    """
+    real_open = builtins.open
+
+    def windows_open(file, mode="r", *args, **kwargs):
+        if "b" not in mode and "encoding" not in kwargs and len(args) < 3:
+            kwargs["encoding"] = "cp1252"
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", windows_open)
+    return real_open
+
+
+def test_export_markdown_unicode(tmp_path, monkeypatch):
+    """Exporting non-ASCII content must not crash and must round-trip as UTF-8.
+
+    Under the simulated Windows codepage, the pre-fix bare open(path, "w")
+    raised UnicodeEncodeError. With encoding="utf-8" the export succeeds and
+    the emoji/CJK/accented text survives a UTF-8 read.
+    """
+    real_open = _force_windows_default_encoding(monkeypatch)
+    export_path = tmp_path / "conversation.md"
+
+    # Pre-fix this line raises UnicodeEncodeError under the cp1252 default.
+    export_to_markdown(NON_ASCII_MESSAGES, str(export_path))
+
+    # Read back with the real open so the wrapper's cp1252 fallback can't mask
+    # a wrongly-encoded file - the bytes on disk must be valid UTF-8.
+    with real_open(export_path, "r", encoding="utf-8") as f:
+        contents = f.read()
+
+    assert "café" in contents
+    assert "你好" in contents
+    assert "🎉" in contents
+    assert "干杯" in contents


### PR DESCRIPTION
## Problem

`export_to_markdown()` opens the output file in text mode without an explicit encoding:

```python
with open(export_path, 'w') as f:
    f.write(markdown)
```

In Python, text-mode `open()` falls back to the OS locale codepage when no `encoding` is given. On Windows that's typically **cp1252**, which can't represent emoji or non-Latin-1 characters (CJK, accented text). Since Open Interpreter transcripts frequently contain exactly those, exporting such a conversation raises `UnicodeEncodeError` and the export fails. On macOS/Linux the default is already UTF-8, so this never surfaces for most maintainers.

`conversation_navigator.py` has the mirror problem on the read side — loading a saved conversation with bare `open(..., "r")` can raise `UnicodeDecodeError` under the same Windows codepage.

This matches the recurring Windows encoding reports (e.g. #1464, #1049).

## Fix

Pass `encoding="utf-8"` explicitly on both the write and the read path — two one-line changes. No new dependencies, no behaviour change on POSIX.

## Test

Added `tests/test_export_to_markdown.py`. The test exports a conversation containing an emoji + CJK + accented text, then reads it back as UTF-8 and asserts the content round-trips. To reproduce the Windows-only failure on any platform, it wraps `open()` so text-mode calls default to cp1252 (simulating the Windows codepage). Before the fix the test fails with `UnicodeEncodeError`; after it, it passes.

```
poetry run pytest tests/test_export_to_markdown.py -s -x -k test_
```

> AGPL-3.0: same license as the project.

_AI-assistance: drafted with Claude, fully reviewed and tested by me._
