### PR TITLE
Add Kimi K3 guide and restore shared skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 </p>
 
 > [!NOTE]
-> **Kimi K3 is supported today.** Open Interpreter natively emulates the
-> current Kimi Code harness to maximize provider-recommended performance in a
-> familiar Codex TUI.
+> **Today: Kimi K3 is here.** We have reimplemented the provider-recommended
+> [Kimi Code](https://www.kimi.com/coding/en) harness in Rust, giving you
+> maximum K3 performance with a Codex-like interface.
+> [**Kimi Docs →**](https://www.openinterpreter.com/docs/terminal/kimi-k3?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=kimi_k3_note)
 
 <br>
 
@@ -64,7 +65,7 @@ profile.
 
 Read more in the [harness docs](https://www.openinterpreter.com/docs/terminal/harness?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=harness_docs) and [model provider docs](https://www.openinterpreter.com/docs/terminal/providers?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=model_provider_docs).
 
-### Editors and the Codex SDK
+### ACP compatible, Codex compatible
 
 Open Interpreter works in [ACP-compatible editors and clients](https://agentclientprotocol.com/get-started/clients). Configure the client to launch `interpreter acp`; see the [ACP guide](https://www.openinterpreter.com/docs/terminal/acp) for examples.
 
@@ -100,6 +101,7 @@ Open Interpreter ships with a QA skill that lets any model operate and test inte
 - [Configuration](https://www.openinterpreter.com/docs/terminal/config?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=configuration)
 - [CLI reference](https://www.openinterpreter.com/docs/terminal/cli-reference?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=cli_reference)
 - [Harnesses](https://www.openinterpreter.com/docs/terminal/harness?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=harnesses)
+- [Kimi K3](https://www.openinterpreter.com/docs/terminal/kimi-k3?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=kimi_k3_docs)
 - [Model providers](https://www.openinterpreter.com/docs/terminal/providers?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=model_providers)
 - [Agent Client Protocol](https://www.openinterpreter.com/docs/terminal/acp)
 - [Codex SDK](https://www.openinterpreter.com/docs/terminal/sdk)

--- a/codex-rs/core/src/harness/kimi_code.rs
+++ b/codex-rs/core/src/harness/kimi_code.rs
@@ -1,11 +1,13 @@
 use crate::client_common::Prompt;
 use crate::harness::kimi_cli;
+use crate::harness::session_skills::parse_session_skills;
 use codex_chat_wire_compat::ToolKinds;
 use codex_chat_wire_compat::ToolOutputKind;
 use codex_protocol::openai_models::ModelInfo;
 use serde_json::Value;
 use serde_json::json;
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::hash::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -98,8 +100,20 @@ fn cached_system_prompt(prompt: &Prompt, conversation_id: &str) -> String {
 }
 
 /// Renders Kimi Code's source-backed model-facing skill listing.
-fn session_skills_listing(_prompt: &Prompt) -> String {
-    KIMI_CODE_BUILTIN_SKILLS.to_string()
+fn session_skills_listing(prompt: &Prompt) -> String {
+    let session_skills = parse_session_skills(&prompt.input);
+    let mut listing = KIMI_CODE_BUILTIN_SKILLS.to_string();
+    if !session_skills.is_empty() {
+        listing.push_str("\n### Open Interpreter");
+        for skill in session_skills {
+            let _ = write!(
+                listing,
+                "\n- {}: {}\n  Path: {}",
+                skill.name, skill.description, skill.path
+            );
+        }
+    }
+    listing
 }
 
 fn add_auto_permission_reminders(messages: Vec<Value>) -> Vec<Value> {
@@ -381,7 +395,7 @@ mod tests {
     }
 
     #[test]
-    fn kimi_code_request_does_not_render_codex_session_skills() {
+    fn kimi_code_request_renders_open_interpreter_session_skills() {
         let prompt = Prompt {
             input: vec![
                 ResponseItem::Message {
@@ -423,8 +437,12 @@ mod tests {
             .as_str()
             .expect("system content");
         assert!(!system.contains("{{ KIMI_SKILLS }}"));
-        assert!(!system.contains("qa-testing"));
-        assert!(!system.contains("### Extra"));
+        assert!(system.contains("### Open Interpreter"));
+        assert!(
+            system.contains("- qa-testing: Run the project's QA test plan against a live build")
+        );
+        assert!(system.contains("Path: /home/user/skills/.system/qa-testing/SKILL.md"));
+        assert!(!system.contains("<skills_instructions>"));
     }
 
     #[test]

--- a/docs.json
+++ b/docs.json
@@ -39,6 +39,7 @@
               "docs/prompting",
               "docs/workflows",
               "docs/models",
+              "docs/kimi-k3",
               "docs/harness",
               "docs/subagents"
             ]

--- a/docs/kimi-k3.md
+++ b/docs/kimi-k3.md
@@ -1,0 +1,126 @@
+---
+title: Kimi K3
+description: Use Kimi K3 with its provider-recommended Kimi Code harness in Open Interpreter.
+---
+
+[Kimi K3](https://www.kimi.com/blog/kimi-k3) is Kimi's flagship model for
+agentic coding and knowledge work. Open Interpreter reimplements the
+provider-recommended [Kimi Code](https://www.kimi.com/coding/en) harness in
+Rust, so K3 gets the request shape, tools, thinking history, and defaults it
+expects inside a Codex-like interface.
+
+## Start with a Kimi Code subscription
+
+Install Open Interpreter, open your project, and start the terminal UI:
+
+```bash
+curl -fsSL https://www.openinterpreter.com/install | sh
+cd my-project
+i
+```
+
+On Windows, install with PowerShell, then run `i` in your project:
+
+```powershell
+irm https://www.openinterpreter.com/install.ps1 | iex
+```
+
+On first launch, choose **Kimi For Coding**, complete the Kimi sign-in in your
+browser, then choose **Kimi K3**. In an existing session, open `/model` and make
+the same selections. Start a new session when switching to K3 so it begins with
+a fresh prompt cache and thinking history.
+
+If you already have a compatible Kimi Code API key, you can start directly:
+
+```bash
+KIMI_API_KEY="..." interpreter \
+  -c 'model_provider="kimi-for-coding"' \
+  -m k3
+```
+
+Open Interpreter selects `kimi-code` automatically for Kimi providers. You do
+not need to install or run the external Kimi Code CLI.
+
+## Use a Moonshot Platform API key
+
+Kimi K3 is also available as `kimi-k3` through the Moonshot Platform API:
+
+```bash
+MOONSHOT_API_KEY="..." interpreter \
+  -c 'model_provider="moonshotai"' \
+  -m kimi-k3
+```
+
+For a single non-interactive task:
+
+```bash
+MOONSHOT_API_KEY="..." interpreter exec \
+  -c 'model_provider="moonshotai"' \
+  -m kimi-k3 \
+  "Review this repository and fix the highest-impact bug."
+```
+
+The Kimi Code harness is inferred for this provider as well. You can confirm or
+change the active harness with `/harness`.
+
+## Context and reasoning
+
+Kimi currently recommends a fresh session when selecting K3 because switching
+models invalidates the existing prompt cache. K3 uses maximum reasoning effort
+at launch. Kimi Code subscriptions provide a 256K context window on Moderato
+and up to 1M tokens on Allegretto and higher plans.
+
+See Kimi's current [model configuration](https://www.kimi.com/code/docs/en/kimi-code/models.html)
+for entitlement and reasoning details.
+
+## Pricing
+
+Kimi lists these Kimi Code subscription prices as of July 16, 2026:
+
+| Plan | Monthly | Annual billing, per month | Kimi Code credits | K3 context |
+| --- | ---: | ---: | ---: | --- |
+| Moderato | $19 | $15 | 1× | 256K |
+| Allegretto | $39 | $31 | 5× | Up to 1M |
+| Allegro | $99 | $79 | 15× | Up to 1M |
+| Vivace | $199 | $159 | 30× | Up to 1M |
+
+Kimi's direct API pricing for K3 at launch is $0.30 per million cache-hit input
+tokens, $3.00 per million cache-miss input tokens, and $15.00 per million
+output tokens. Prices and plan entitlements can change; check Kimi's
+[current membership pricing](https://www.kimi.com/help/membership/membership-pricing)
+and [K3 launch post](https://www.kimi.com/blog/kimi-k3) before purchasing.
+
+## Computer use
+
+Kimi K3 can use Open Interpreter's bundled QA skill to operate and test
+interfaces. Ask it to test a web app and it can use
+[`agent-browser`](https://github.com/vercel-labs/agent-browser) in a real
+browser. Ask it to test a native desktop app and it can use
+[`trycua`](https://github.com/trycua/cua) for computer use.
+
+For example:
+
+```text
+Run this app, test the sign-in flow like a user, and fix anything that breaks.
+```
+
+The normal sandbox and approval settings still apply. Keep the request
+specific, and review actions that interact with accounts or external systems.
+
+## ACP and Codex SDK
+
+Use Kimi K3 from any supported editor or client by configuring it to launch
+`interpreter acp`; see the [ACP guide](/docs/acp) and the current
+[ACP client directory](https://agentclientprotocol.com/get-started/clients).
+
+Existing Codex SDK integrations need only point their binary override at Open
+Interpreter:
+
+```diff
+-const codex = new Codex();
++const codex = new Codex({ codexPathOverride: "interpreter" });
+```
+
+Set `model_provider` to `kimi-for-coding` with model `k3`, or to `moonshotai`
+with model `kimi-k3`. See the [Codex SDK guide](/docs/sdk) for complete
+TypeScript and Python examples.


### PR DESCRIPTION
Adds the linked Kimi K3 guide requested for the README, including Kimi Code subscription and Moonshot API setup, current official pricing, computer use, ACP, and Codex SDK usage. Renames the compatibility section and updates the launch note. Also preserves Open Interpreter session skills in the native Kimi Code skill listing so K3 can discover and invoke the bundled `qa-testing` skill while retaining Kimi Code built-ins.