### PR TITLE
Load Open Interpreter skills in Kimi Code mode

### DIFF
--- a/codex-rs/core/src/tools/handlers/harness_aliases.rs
+++ b/codex-rs/core/src/tools/handlers/harness_aliases.rs
@@ -2781,6 +2781,9 @@ fn zcode_tool_input_text(name: &str, arguments: &str) -> String {
 async fn handle_zcode_skill(
     invocation: ToolInvocation,
 ) -> Result<Box<dyn ToolOutput>, FunctionCallError> {
+    if is_kimi_code(&invocation) {
+        return super::kimi_code_skill::handle(invocation).await;
+    }
     let arguments = function_arguments(&invocation.payload)?;
     let input: serde_json::Value = serde_json::from_str(arguments).unwrap_or_else(|_| json!({}));
     let skill = input
@@ -2807,12 +2810,6 @@ async fn handle_zcode_skill(
                 base_dir.display()
             ),
             Some(true),
-        )));
-    }
-    if is_kimi_code(&invocation) {
-        return Ok(boxed_tool_output(FunctionToolOutput::from_text(
-            format!("Skill \"{skill}\" not found in the current skill listing."),
-            Some(false),
         )));
     }
     Ok(boxed_tool_output(FunctionToolOutput::from_text(

--- a/codex-rs/core/src/tools/handlers/kimi_code_skill.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_skill.rs
@@ -1,0 +1,179 @@
+use crate::function_tool::FunctionCallError;
+use crate::tools::context::FunctionToolOutput;
+use crate::tools::context::ToolInvocation;
+use crate::tools::context::ToolOutput;
+use crate::tools::context::ToolPayload;
+use crate::tools::context::boxed_tool_output;
+use codex_protocol::models::ContentItem;
+use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::SkillScope;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct KimiSkillArgs {
+    skill: String,
+    #[serde(default)]
+    args: Option<String>,
+}
+
+pub(super) async fn handle(
+    invocation: ToolInvocation,
+) -> Result<Box<dyn ToolOutput>, FunctionCallError> {
+    let ToolPayload::Function { arguments } = &invocation.payload else {
+        return Err(FunctionCallError::RespondToModel(
+            "Kimi Code Skill received unsupported payload".to_string(),
+        ));
+    };
+    let input: KimiSkillArgs = serde_json::from_str(arguments).map_err(|err| {
+        FunctionCallError::RespondToModel(format!("failed to parse Skill arguments: {err}"))
+    })?;
+    let outcome = invocation.turn.turn_skills.snapshot.outcome();
+    let Some(skill) = outcome
+        .skills
+        .iter()
+        .find(|candidate| candidate.name == input.skill && outcome.is_skill_enabled(candidate))
+        .cloned()
+    else {
+        return Ok(boxed_tool_output(FunctionToolOutput::from_text(
+            format!(
+                "Skill \"{skill}\" not found in the current skill listing.",
+                skill = input.skill
+            ),
+            /*success*/ Some(false),
+        )));
+    };
+
+    let contents = match invocation
+        .turn
+        .turn_skills
+        .snapshot
+        .read_skill_text(&skill)
+        .await
+    {
+        Ok(contents) => contents,
+        Err(err) => {
+            return Ok(boxed_tool_output(FunctionToolOutput::from_text(
+                format!(
+                    "Failed to load Skill \"{skill}\": {err}",
+                    skill = input.skill
+                ),
+                /*success*/ Some(false),
+            )));
+        }
+    };
+    let args = input.args.as_deref().unwrap_or_default();
+    let source = kimi_skill_source(skill.scope);
+    let directory = skill
+        .path_to_skills_md
+        .parent()
+        .unwrap_or_else(|| skill.path_to_skills_md.clone())
+        .to_string_lossy()
+        .into_owned();
+    let body = expand_skill_body(&contents, args);
+    let message = ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: format!(
+                "Skill tool loaded instructions for this request. Follow them.\n\n<kimi-skill-loaded name=\"{}\" trigger=\"model-tool\" source=\"{source}\" dir=\"{}\" args=\"{}\">\n{body}\n</kimi-skill-loaded>",
+                escape_xml_attribute(&skill.name),
+                escape_xml_attribute(&directory),
+                escape_xml_attribute(args),
+            ),
+        }],
+        phase: None,
+        internal_chat_message_metadata_passthrough: None,
+    };
+    invocation
+        .session
+        .record_conversation_items(invocation.turn.as_ref(), &[message])
+        .await;
+
+    Ok(boxed_tool_output(FunctionToolOutput::from_text(
+        format!(
+            "Skill \"{name}\" loaded inline. Follow its instructions.",
+            name = skill.name
+        ),
+        /*success*/ Some(true),
+    )))
+}
+
+fn kimi_skill_source(scope: SkillScope) -> &'static str {
+    match scope {
+        SkillScope::Repo => "project",
+        SkillScope::User => "user",
+        SkillScope::System | SkillScope::Admin => "extra",
+    }
+}
+
+fn expand_skill_body(contents: &str, args: &str) -> String {
+    let body = strip_frontmatter(contents).trim();
+    if args.is_empty() {
+        return body.to_string();
+    }
+
+    let escaped_args = escape_xml_tags(args);
+    if body.contains("$ARGUMENTS") {
+        body.replace("$ARGUMENTS", &escaped_args)
+    } else {
+        format!("{body}\n\nARGUMENTS: {escaped_args}")
+    }
+}
+
+fn strip_frontmatter(contents: &str) -> &str {
+    contents
+        .strip_prefix("---\n")
+        .and_then(|contents| contents.split_once("\n---\n").map(|(_, body)| body))
+        .or_else(|| {
+            contents
+                .strip_prefix("---\r\n")
+                .and_then(|contents| contents.split_once("\r\n---\r\n").map(|(_, body)| body))
+        })
+        .unwrap_or(contents)
+}
+
+fn escape_xml_attribute(value: &str) -> String {
+    escape_xml_tags(value)
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+}
+
+fn escape_xml_tags(value: &str) -> String {
+    value.replace('<', "&lt;").replace('>', "&gt;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_body_without_frontmatter_or_empty_arguments_suffix() {
+        let contents = "---\nname: qa-testing\ndescription: Test apps\n---\n\n# QA testing\n\nUse cua-driver.\n";
+
+        assert_eq!(
+            expand_skill_body(contents, ""),
+            "# QA testing\n\nUse cua-driver."
+        );
+    }
+
+    #[test]
+    fn appends_and_escapes_arguments_when_body_has_no_placeholder() {
+        assert_eq!(
+            expand_skill_body("# Review", "<raw \"value\">"),
+            "# Review\n\nARGUMENTS: &lt;raw \"value\"&gt;"
+        );
+    }
+
+    #[test]
+    fn replaces_arguments_placeholder() {
+        assert_eq!(expand_skill_body("Raw: $ARGUMENTS", "a & b"), "Raw: a & b");
+    }
+
+    #[test]
+    fn maps_host_skill_scopes_to_kimi_sources() {
+        assert_eq!(kimi_skill_source(SkillScope::Repo), "project");
+        assert_eq!(kimi_skill_source(SkillScope::User), "user");
+        assert_eq!(kimi_skill_source(SkillScope::System), "extra");
+        assert_eq!(kimi_skill_source(SkillScope::Admin), "extra");
+    }
+}

--- a/codex-rs/core/src/tools/handlers/kimi_code_skill.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_skill.rs
@@ -27,48 +27,63 @@ pub(super) async fn handle(
     let input: KimiSkillArgs = serde_json::from_str(arguments).map_err(|err| {
         FunctionCallError::RespondToModel(format!("failed to parse Skill arguments: {err}"))
     })?;
-    let outcome = invocation.turn.turn_skills.snapshot.outcome();
-    let Some(skill) = outcome
-        .skills
-        .iter()
-        .find(|candidate| candidate.name == input.skill && outcome.is_skill_enabled(candidate))
-        .cloned()
-    else {
-        return Ok(boxed_tool_output(FunctionToolOutput::from_text(
-            format!(
-                "Skill \"{skill}\" not found in the current skill listing.",
-                skill = input.skill
-            ),
-            /*success*/ Some(false),
-        )));
+    let args = input.args.as_deref().unwrap_or_default();
+    let skill_name = input.skill.as_str();
+    let builtin_contents = match skill_name {
+        "check-kimi-code-docs" => Some(include_str!("kimi_code_skills/check-kimi-code-docs.md")),
+        "update-config" => Some(include_str!("kimi_code_skills/update-config.md")),
+        "write-goal" => Some(include_str!("kimi_code_skills/write-goal.md")),
+        _ => None,
     };
-
-    let contents = match invocation
-        .turn
-        .turn_skills
-        .snapshot
-        .read_skill_text(&skill)
-        .await
-    {
-        Ok(contents) => contents,
-        Err(err) => {
+    let (contents, source, directory) = if let Some(contents) = builtin_contents {
+        (
+            contents.to_string(),
+            "builtin",
+            format!("builtin://{skill_name}"),
+        )
+    } else {
+        let outcome = invocation.turn.turn_skills.snapshot.outcome();
+        let Some(skill) = outcome
+            .skills
+            .iter()
+            .find(|candidate| candidate.name == input.skill && outcome.is_skill_enabled(candidate))
+            .cloned()
+        else {
             return Ok(boxed_tool_output(FunctionToolOutput::from_text(
                 format!(
-                    "Failed to load Skill \"{skill}\": {err}",
+                    "Skill \"{skill}\" not found in the current skill listing.",
                     skill = input.skill
                 ),
                 /*success*/ Some(false),
             )));
-        }
+        };
+        let contents = match invocation
+            .turn
+            .turn_skills
+            .snapshot
+            .read_skill_text(&skill)
+            .await
+        {
+            Ok(contents) => contents,
+            Err(err) => {
+                return Ok(boxed_tool_output(FunctionToolOutput::from_text(
+                    format!(
+                        "Failed to load Skill \"{skill}\": {err}",
+                        skill = input.skill
+                    ),
+                    /*success*/ Some(false),
+                )));
+            }
+        };
+        let source = kimi_skill_source(skill.scope);
+        let directory = skill
+            .path_to_skills_md
+            .parent()
+            .unwrap_or_else(|| skill.path_to_skills_md.clone())
+            .to_string_lossy()
+            .into_owned();
+        (contents, source, directory)
     };
-    let args = input.args.as_deref().unwrap_or_default();
-    let source = kimi_skill_source(skill.scope);
-    let directory = skill
-        .path_to_skills_md
-        .parent()
-        .unwrap_or_else(|| skill.path_to_skills_md.clone())
-        .to_string_lossy()
-        .into_owned();
     let body = expand_skill_body(&contents, args);
     let message = ResponseItem::Message {
         id: None,
@@ -76,7 +91,7 @@ pub(super) async fn handle(
         content: vec![ContentItem::InputText {
             text: format!(
                 "Skill tool loaded instructions for this request. Follow them.\n\n<kimi-skill-loaded name=\"{}\" trigger=\"model-tool\" source=\"{source}\" dir=\"{}\" args=\"{}\">\n{body}\n</kimi-skill-loaded>",
-                escape_xml_attribute(&skill.name),
+                escape_xml_attribute(&input.skill),
                 escape_xml_attribute(&directory),
                 escape_xml_attribute(args),
             ),
@@ -92,7 +107,7 @@ pub(super) async fn handle(
     Ok(boxed_tool_output(FunctionToolOutput::from_text(
         format!(
             "Skill \"{name}\" loaded inline. Follow its instructions.",
-            name = skill.name
+            name = input.skill
         ),
         /*success*/ Some(true),
     )))
@@ -175,5 +190,24 @@ mod tests {
         assert_eq!(kimi_skill_source(SkillScope::User), "user");
         assert_eq!(kimi_skill_source(SkillScope::System), "extra");
         assert_eq!(kimi_skill_source(SkillScope::Admin), "extra");
+    }
+
+    #[test]
+    fn provider_default_skill_assets_match_the_captured_catalog() {
+        for (name, contents) in [
+            (
+                "check-kimi-code-docs",
+                include_str!("kimi_code_skills/check-kimi-code-docs.md"),
+            ),
+            (
+                "update-config",
+                include_str!("kimi_code_skills/update-config.md"),
+            ),
+            ("write-goal", include_str!("kimi_code_skills/write-goal.md")),
+        ] {
+            assert!(contents.starts_with("---\nname: "));
+            assert!(contents.contains(&format!("name: {name}\n")));
+            assert!(!expand_skill_body(contents, "").is_empty());
+        }
     }
 }

--- a/codex-rs/core/src/tools/handlers/kimi_code_skills/LICENSE.txt
+++ b/codex-rs/core/src/tools/handlers/kimi_code_skills/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Moonshot AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/codex-rs/core/src/tools/handlers/kimi_code_skills/check-kimi-code-docs.md
+++ b/codex-rs/core/src/tools/handlers/kimi_code_skills/check-kimi-code-docs.md
@@ -1,0 +1,44 @@
+---
+name: check-kimi-code-docs
+description: Answer questions about the Kimi Code product using the official documentation — CLI usage, configuration, slash commands, features, membership and quota, API onboarding, third-party tool setup, and error codes. Use when the user asks how Kimi Code works, how to set something up, or what a Kimi Code error message means.
+---
+
+# Check Kimi Code docs (check-kimi-code-docs)
+
+Answer Kimi Code **product** questions from the official documentation site, not from memory. This skill covers product usage ("how do I configure a provider", "what does this error mean", "how does membership quota work"); it is not for developing the Kimi Code repository itself.
+
+## The single source of truth
+
+Official documentation (English):
+
+```
+https://www.kimi.com/code/docs/en/
+```
+
+Fetch pages with **FetchURL** before answering. All page links below are relative to this base.
+
+## Which page to read for which question
+
+| Question topic | Page (relative to the base URL) |
+| --- | --- |
+| What Kimi Code is; Base URL / API Key; standard vs high-speed model; platform comparison | `./` (home overview) |
+| Membership plans, quota and rate limits, fuel packs | `kimi-code/membership.html` |
+| Install / login / usage FAQ | `kimi-code/faq.html` |
+| Error codes and their meaning (e.g. 401 for high-speed model access) | `kimi-code/error-reference.html` |
+| Product news and recent changes | `kimi-code/whats-new.html` |
+| Community guidelines; contact and feedback | `kimi-code/community-guidelines.html`, `kimi-code/contact-and-feedback.html` |
+| `config.toml` fields, providers/models, environment variables, data locations, config overrides | `kimi-code-cli/configuration/` — `config-files.html`, `providers.html`, `env-vars.html`, `data-locations.html`, `overrides.html` |
+| Skills, MCP, hooks, plugins, themes, agents/sub-agents, Kimi Datasource | `kimi-code-cli/customization/` — `skills.html`, `mcp.html`, `hooks.html`, `plugins.html`, `themes.html`, `agents.html`; Kimi Datasource lives at `plugins.html#kimi-datasource` |
+| Getting started, sessions and context, goals, interaction and input, IDEs, migration, use cases | `kimi-code-cli/guides/` — `getting-started.html`, `sessions.html`, `goals.html`, `interaction.html`, `ides.html`, `migration.html`, `use-cases.html` |
+| Slash commands, keyboard shortcuts, builtin tools, `kimi` command flags, ACP | `kimi-code-cli/reference/` — `slash-commands.html`, `keyboard.html`, `tools.html`, `kimi-command.html`, `kimi-acp.html` |
+| CLI changelog | `kimi-code-cli/release-notes/changelog.html` |
+| Using Kimi Code in Claude Code and other third-party agents | `third-party-tools/other-coding-agents.html` |
+
+If no row fits the question, fetch the docs home page and follow its navigation links.
+
+## How to answer
+
+1. Pick the page from the table above.
+2. **FetchURL the page before answering** — answer strictly from the fetched content, never from memory.
+3. Cite the page link(s) you used at the end of the answer.
+4. If the fetch fails or the docs do not cover the question, say so plainly: answer from what you already know, attach the docs entry link (`https://www.kimi.com/code/docs/en/`), and mark which parts you could not verify. **Never invent config keys, command names, model IDs, or product behaviors.**

--- a/codex-rs/core/src/tools/handlers/kimi_code_skills/update-config.md
+++ b/codex-rs/core/src/tools/handlers/kimi_code_skills/update-config.md
@@ -1,0 +1,104 @@
+---
+name: update-config
+description: Inspect or edit kimi-code's own config — `config.toml` (model, provider, permission, hooks) and `tui.toml` (theme, editor, notifications, auto-update). Use when the user asks what a setting does or wants to change one.
+---
+
+# Configure kimi-code (update-config)
+
+Help the user inspect, change, and validate kimi-code's configuration files. The files are **TOML** with **snake_case** keys.
+
+## The two config files
+
+kimi-code has two TOML config files, both under `<KIMI_CODE_HOME>/`, both snake_case, but with different ownership — decide which one the user means before doing anything.
+
+The runtime resolves the data directory as `KIMI_CODE_HOME` first, falling back to `~/.kimi-code`. Before doing anything, resolve the actual directory with Bash so you don't write to the wrong place. Check whether `KIMI_CODE_HOME` is set and fall back to `~/.kimi-code` when it is empty:
+
+```bash
+echo "$KIMI_CODE_HOME"
+echo "$HOME/.kimi-code"
+```
+
+Use the first line when it is non-empty; otherwise use the second line. In the rest of this skill, `<KIMI_CODE_HOME>` means that resolved root — **never assume `~/.kimi-code`**.
+
+- **`config.toml`** — agent / runtime settings: `default_model`, `providers`, `models`, `thinking`, `permission`, `hooks`, `loop_control`, etc.
+- **`tui.toml`** — terminal-UI / client preferences: `theme`, `[editor].command`, `[notifications]`, `[upgrade].auto_install` (auto-update). These can usually also be changed with the interactive commands `/config`, `/theme`, `/editor`, which is easier — prefer pointing the user at those.
+
+The "read → copy → Edit → validate → back up → overwrite" flow below applies to both files; only **which reload command applies** differs (see Capability 4).
+
+## Prerequisite 1: the official docs are the single source of truth
+
+Before touching any config, use **FetchURL** to fetch the official config docs as the one authoritative reference for fields (key names, types, allowed values, owning section):
+
+```
+https://moonshotai.github.io/kimi-code/en/configuration/config-files.html
+```
+
+- Use the **snake_case key names and sections exactly as documented** — don't invent them, don't guess camelCase.
+- If FetchURL is unavailable or the fetch fails, tell the user plainly that you can't reach the online docs, and ask them to paste the relevant section or confirm whether to proceed from what you already know. **Never edit blindly without an authoritative reference.**
+
+## Prerequisite 2: read the target file before any change
+
+Before any modification, use **Read** on the target config file (decide whether it's `config.toml` or `tui.toml` per the above):
+
+- Location: `<KIMI_CODE_HOME>/config.toml` or `<KIMI_CODE_HOME>/tui.toml`. For other scopes/files, defer to the official docs.
+- A missing or empty file is fine — you'll create a minimal skeleton later.
+- If the file exists but **fails to parse as TOML**, report the error verbatim and **stop** — never overwrite a broken file in place (it could destroy the user's existing config).
+
+---
+
+## Capability 1: explain configuration (read-only, no file changes)
+
+When the user asks "what config is there", "what does this setting do", or "how do I use it":
+
+1. Fetch the official docs (Prerequisite 1).
+2. Read the current `config.toml` (Prerequisite 2).
+3. Answer against both: list the relevant sections / keys, what each is for, **current value vs default**, and the allowed-value range; say which file and section each lives in.
+4. Present it as a compact grouped list or table. **Stay read-only — write no files.**
+
+## Capability 2: make changes for the user (copy → Edit → validate → back up → overwrite)
+
+Don't edit the target file in place, and **don't rewrite it from scratch** — instead copy it, Edit the copy, and keep the original out of any broken state the whole time:
+
+1. **Clarify intent**: which key, what value, and which file (`config.toml` or `tui.toml`). Ask in one line if ambiguous; for discrete choices (e.g. scope) AskUserQuestion is fine, but use plain questions for free-form input.
+2. **Read the target file** (Prerequisite 2): Read it to understand the current state and confirm it parses.
+3. **Copy out a candidate (do not create from scratch)**: use **Bash** to copy the target verbatim — `cp config.toml config-new.toml` (same directory, `-new` suffix; for tui.toml, `cp tui.toml tui-new.toml`). **Leave the original untouched for now.**
+   - Only when the target doesn't exist (nothing to copy) should you use **Write** to create a minimal skeleton candidate (e.g. just the comment line `# <KIMI_CODE_HOME>/config.toml`).
+4. **Edit the candidate**: use the **Edit** tool on the candidate to **change/add only the target key** — never rewrite the whole file. That way every existing section, entry, comment, and bit of formatting stays exactly as-is; only what should change changes. The candidate is identical to the original, so use the content you read in step 2 to locate the Edit anchor. Check the change against the official docs (key / section / value type / allowed values, snake_case).
+5. **Validate the candidate** (see Capability 3, via `kimi doctor`). **If anything fails, keep Editing the candidate and re-validate, looping until it all passes.**
+6. **Back up and overwrite** (only after validation fully passes):
+   - **Back up the old file — always create a new timestamped backup, keep all of them, never overwrite an existing backup.** Copy this exactly with **Bash** (for config.toml): `cp config.toml "config.toml.$(date +%Y%m%d-%H%M%S).bak"`; for tui.toml: `cp tui.toml "tui.toml.$(date +%Y%m%d-%H%M%S).bak"`. Skip the backup only if the target didn't exist.
+   - Overwrite with the candidate: `mv config-new.toml config.toml`.
+   - If reload errors after the overwrite, the user can recover from **the most recent timestamped backup**.
+7. Tell the user how to apply it (see Capability 4).
+
+## Capability 3: validate the candidate file (must pass before overwrite)
+
+Use **`kimi doctor`** to validate the candidate you wrote — it doesn't start the TUI and doesn't modify any file; it runs kimi's own parser + schema (syntax and schema together), so it's the authoritative check. Pick the subcommand by which file you changed, and pass the **candidate** path explicitly:
+
+- changed `config.toml` → `kimi doctor config <config-new.toml path>`
+- changed `tui.toml` → `kimi doctor tui <tui-new.toml path>`
+
+When a path is passed explicitly the file must exist (your candidate does, so that's fine). **Exit code 0 = pass (valid or skipped); non-zero = a specified file is missing or the config is invalid** — show the output verbatim, fix the candidate, and re-run, looping until it's 0.
+
+Then do two checks `kimi doctor` can't:
+
+1. **Cross-check values against the official docs** (single source of truth): are the key / section / enum values as documented, and snake_case? doctor guarantees "schema-valid", but "valid yet not what the user wanted" (e.g. a misspelled model alias) needs the docs.
+2. **Completeness**: every existing entry is still present (the candidate fully replaces the target — a dropped line is a deletion).
+
+> To also check whether the currently **active** config is OK overall, run `kimi doctor` with no path (it checks the default `config.toml` + `tui.toml`, showing a missing one as skipped).
+
+## Capability 4: tell the user how to apply changes
+
+Once local validation passes, tell the user how to make the change take effect — **the reload command depends on which file you changed**:
+
+- changed **`config.toml`** → run **`/reload`** in the TUI (reloads the session and applies `config.toml`; it also reloads `tui.toml`).
+- changed **`tui.toml`** → run **`/reload-tui`** (reloads only `tui.toml`, lighter); `/reload` works too (reloads both).
+- changed both → a single **`/reload`** covers it.
+
+Note: `/reload` is available **only when idle** — if a reply is streaming, press Esc / Ctrl-C to stop first. `kimi doctor` already validated the schema before the overwrite, so reload should apply cleanly; if it still errors, follow the message to fix it or recover from the most recent timestamped backup. If you don't want to reload now, the **next new session** picks it up automatically.
+
+## Don'ts
+
+- **Always back up before overwriting**, with a **timestamped name and all history kept** — don't skip the backup, don't keep only a single `.bak`, don't overwrite an old backup.
+- Don't drop unrelated entries (the candidate fully replaces the target — a dropped line is a deletion).
+- When you can't reach the docs / have no authoritative reference, don't edit by guessing.

--- a/codex-rs/core/src/tools/handlers/kimi_code_skills/write-goal.md
+++ b/codex-rs/core/src/tools/handlers/kimi_code_skills/write-goal.md
@@ -1,0 +1,94 @@
+---
+name: write-goal
+description: Help the user craft a well-specified `/goal` objective for goal mode — turn a rough intention into a completion contract with a clear finish line, proof, boundaries, and stop rule. Use when the user asks for help writing, refining, or improving a goal.
+---
+
+# Write a good goal (write-goal)
+
+Help the user turn a rough intention into a `/goal` objective that goal mode can pursue across many turns without supervision. A goal is not a task description — it is a completion contract. It says what must become *true*, how that truth is *proven*, where the work may and may not *reach*, and when to *stop and report* instead of grinding on.
+
+This skill is about authoring the objective text together with the user. Drafting and starting are separate steps: you settle the wording first, and only once the user has approved it do you start the goal by calling `CreateGoal`. The user still gets a final confirmation before it runs.
+
+## Ask, don't narrate
+
+**This is the most important rule in this skill. Every decision you put to the user goes through `AskUserQuestion`. No exceptions except one (below).**
+
+Goal authoring is a chain of choices — what to scope, which phrasing, whether to add a budget and how large, which permission mode to start under. For every one of them: **stop and call `AskUserQuestion`.** Batch related choices in the same `AskUserQuestion` call when that helps the user decide. Do not write a paragraph that lists options and asks the user to reply in prose. Do not say "let me know if you'd prefer A or B." Do not bundle three questions into a wall of text. If you catch yourself typing out choices for the user to answer in free text, delete it and call `AskUserQuestion` instead.
+
+A prose menu is a defect, not a style choice: it is slower for the user, easy to skim past, and usually gets a vague answer that forces another round. The only time you may ask in plain text is when `AskUserQuestion` is genuinely unavailable — auto mode, or a host that does not support it — and only then do you fall back to a short message with clearly labelled options and wait. Plain prose for *open-ended* input ("what would prove this is done?") is fine; the rule is about **choices between options**, which always use the tool.
+
+## Rules of engagement
+
+- **Only help when the user has asked for it.** Never volunteer to wrap an ordinary request in a goal, and never start one on your own. A normal "fix this test" is a normal request; treat it as a goal only when the user says they want a goal. If a task looks like it would suit goal mode, you may mention that once — but wait for the user to choose.
+- **Write in the user's language.** Draft the objective in whatever language the user is writing to you in. If the project configuration or a saved memory names a preferred language, honor that instead. Keep the surrounding discussion in the same language.
+- **Show before you start.** Always present the full drafted goal back to the user and get their agreement before anything runs. The user should read the exact text that will become the objective, not a paraphrase of it.
+- **Draft with the user, not for them.** Goal-writing is a conversation. Offer a draft, explain the choices you made, invite changes, and fold the feedback in. Expect more than one round.
+- **Respect the user's final call.** If, after you have pointed out what is vague or risky, the user still wants a looser or thinner goal, write the goal they asked for. Note the trade-off once; do not keep relitigating it or quietly "improve" the wording against their wishes.
+
+## What makes a goal good
+
+The strongest goals share one shape: they define **proof, not effort**. "Keep improving the code" describes effort and never ends. "Done when `npm test` exits 0 and no file outside `src/auth` changed" describes proof and is checkable. Aim for a contract with these parts:
+
+1. **End state** — the condition that must become true. Name the finish line concretely: a passing suite, an empty queue, a search that returns zero matches, a deployed artifact.
+2. **Proof** — the observable evidence that the end state holds. Prefer things the agent can run and you can inspect afterward: a command's exit code, a test count, a `grep`/`rg` with no hits, a file that now exists, a metric over a threshold.
+3. **Boundaries** — what the work may and may not touch. Name the scope (which module, which directory) and the off-limits actions (do not edit the spec, do not change unrelated files, do not make destructive data changes).
+4. **The loop** — when the work is iterative, say how to iterate: rerun the check after each change, work through the queue item by item, replay the failing cases until they pass.
+5. **The stop rule** — how to end honestly when "done" is not reachable. A "stop and ask before widening scope" clause and an explicit blocked path ("if an external service is down, record it and move on") let the agent report instead of faking a pass or looping forever. This is about *honesty*, not a spending limit — keep it separate from any budget (see below).
+
+Two habits make almost any goal better:
+
+- **Make it queue-shaped.** Goals that shrink a list work best: failing tests, open issues, error traces, files to migrate, rows to process. A queue gives the agent a worklist and gives you a countable definition of done.
+- **Lean on existing verification.** Tests, CI, type-checks, lint, eval suites, browser audits, and zero-match searches are leverage — they are what let a goal run unattended and still be trusted. If a task has no way to prove completion, help the user add one or reconsider whether goal mode fits.
+
+Longer runs are not better runs. A tight contract that finishes in a handful of turns beats an open-ended one that burns hours re-running the whole suite after every edit.
+
+## Budgets are opt-in
+
+Goal mode can run under a turn or token budget, but **do not set one by default, and never bake a turn cap into the objective text.** A well-specified goal already stops on its own — when the proof passes or a blocker is hit — so an arbitrary cap usually does nothing except risk cutting off work midway.
+
+When a budget is genuinely useful — typically an open-ended or exploratory goal that could run long unattended — you may suggest one, framed around the number users actually feel: token cost. Let the user choose the value, and sanity-check it against the work. A cap far larger than the task needs (say a thousand turns for a goal that will finish in a few) is not a safety net; it just invites wasted tokens. If the user asks for a value that looks oversized, say so and offer a smaller one, but respect their final call.
+
+## Workflow
+
+1. **Understand the intention.** Ask what outcome the user actually wants and what would prove it is done. If a finish line or a check is missing, that gap is the first thing to resolve together. As soon as the open questions reduce to concrete options, put them to the user with **AskUserQuestion** — do not list the options in prose.
+2. **Draft the goal.** Write a concrete objective in the user's language, covering as many parts of the contract above as the task warrants. Keep it readable — one or a few sentences for simple work, a short structured block (end state, checks, boundaries, stop rule) for larger work.
+3. **Show it and explain.** Present the draft in full and walk through the choices: what you picked as the finish line, what proves it, what you fenced off, when it stops. Point out anything still soft.
+4. **Revise together.** Take the user's edits and produce a new draft. When you are weighing alternative phrasings or scopes, offer them as an **AskUserQuestion** choice instead of describing them. Repeat until they are satisfied. If they want it looser than you would recommend, say so once, then write their version.
+5. **Start it.** Once the user approves the wording, start the goal by calling `CreateGoal` with the agreed objective (and a `completionCriterion` if you settled on one). Do not just print the text for the user to paste, and do not start before they have approved. Starting still surfaces a final confirmation, so the user keeps the last word on whether it runs.
+
+## A reusable shape
+
+For a non-trivial goal, this fill-in-the-blanks structure covers the contract:
+
+```
+<What must become true.>
+Done when <command/search/state that proves it>.
+Scope: only <files/area>; do not <off-limits action>.
+Loop: <how to iterate — rerun the check after each change, etc.>.
+If <blocking condition>, stop and report instead of forcing a pass.
+```
+
+Not every goal needs every line, and none of them is a turn cap — the goal stops when the proof passes or a blocker is hit. A small, well-scoped task can be a single clear sentence. Add structure as the work grows or the cost of a wrong autonomous run rises.
+
+## Weak to strong
+
+- Weak: `Find all bugs in this codebase.` — no finish line, no proof, no stop. The agent may block at once or run far past what you wanted.
+  Strong: `Fix every test in test/auth that currently fails, rerun npm test until it exits 0, change no file outside test/ or src/auth, and report anything you cannot fix with its location and why.`
+- Weak: `Optimize the project.` — no scope, no measure.
+  Strong: `Migrate the payment module to the new API, make npm test -- payment exit 0, keep the diff limited to payment-related files, and stop and ask before touching shared infrastructure.`
+- Weak: `Make it faster.`
+  Strong: `Make renderFrame at least 3x faster measured by the bench/render benchmark; if you cannot reach 3x after several attempts, report the best result and why.`
+
+## Common mistakes
+
+| Mistake | Better |
+| --- | --- |
+| Starting or suggesting a goal the user did not ask for | Only draft a goal once the user asks; mention the option at most once otherwise |
+| Drafting in English when the user is writing in another language | Match the user's language (or the project / memory preference) |
+| Running the goal before the user has seen the exact text | Show the full draft and get agreement first |
+| Polishing the goal silently against the user's stated wishes | Note the trade-off once, then write the goal they asked for |
+| Burying a discrete choice in prose | Offer the options with AskUserQuestion (plain labelled options if it is unavailable) |
+| Specifying effort ("keep improving X") | Specify proof ("done when check X passes") |
+| Baking a turn cap into the objective or setting a budget unprompted | Let the goal stop on its proof; suggest a budget only when useful, framed on token cost |
+| No blocked path | Add an explicit "stop and report" rule for blockers |
+| A goal with no way to verify completion | Anchor it to tests, a search, a metric, or another inspectable check |

--- a/codex-rs/core/src/tools/handlers/mod.rs
+++ b/codex-rs/core/src/tools/handlers/mod.rs
@@ -12,6 +12,7 @@ mod harness_fs;
 mod kimi_code_aliases;
 mod kimi_code_extra;
 mod kimi_code_format;
+mod kimi_code_skill;
 mod list_available_plugins_to_install;
 pub(crate) mod list_available_plugins_to_install_spec;
 mod mcp;


### PR DESCRIPTION
## What this fixes

Kimi K3 could discover an Open Interpreter skill such as `qa-testing`, call the Kimi Code `Skill` tool, and then receive a false not-found result even though the skill was listed.

## Change

Resolve enabled host skills through the native skill snapshot, load their `SKILL.md`, and inject Kimi Code’s skill-loaded user message before returning the tool result. Missing skills retain the provider-compatible error.

## Validation

- native Kimi skill loading regression coverage passed
- `cargo test -p codex-core kimi_code_skill --lib`: 4 passed
- `just fix -p codex-core`: passed
- `just fmt`: passed