### PR TITLE
Prepare Open Interpreter 0.0.28

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app_test_support"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "codex-acp-server"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ansi-escape"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "ansi-to-tui",
  "ratatui",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-daemon"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "clap",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-test-client"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "clap",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "axum",
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "pretty_assertions",
  "tokio",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "serde",
  "serde_json",
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "codex-bwrap"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "cc",
  "libc",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chat-wire-compat"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bytes",
  "codex-api",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "clap",
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cli"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-config"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-client"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2633,7 +2633,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-mock-client"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "chrono",
  "codex-cloud-tasks-client",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-protocol",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-host"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-protocol",
  "pretty_assertions",
@@ -2686,11 +2686,11 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.0.27"
+version = "0.0.28"
 
 [[package]]
 name = "codex-config"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "codex-config",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors-extension"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-connectors",
  "codex-core-plugins",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-api"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-analytics",
  "codex-app-server-protocol",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "clap",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy-legacy"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "allocative",
  "anyhow",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-utils-absolute-path",
  "pretty_assertions",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-hooks",
  "pretty_assertions",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "clap",
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -3275,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "notify",
  "pretty_assertions",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "codex-goal-extension"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "codex-home"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bytes",
  "codex-utils-cargo-bin",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-product-info",
  "codex-utils-absolute-path",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "keyring",
  "tracing",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "clap",
  "codex-core",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "codex-lmstudio"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-core",
  "codex-model-provider-info",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-extension"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-config",
  "codex-connectors-extension",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -3631,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "codex-message-history"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-config",
  "memchr",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-api",
  "codex-product-info",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3814,7 +3814,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ollama"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "assert_matches",
  "async-stream",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -3886,14 +3886,14 @@ dependencies = [
 
 [[package]]
 name = "codex-product-info"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "chardetng",
@@ -3949,7 +3949,7 @@ dependencies = [
 
 [[package]]
 name = "codex-realtime-webrtc"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "libwebrtc",
  "thiserror 2.0.18",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "codex-responses-api-proxy"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "clap",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "axum",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -4068,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "codex-network-proxy",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "age",
  "anyhow",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "clap",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-core-skills",
  "codex-exec-server",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "codex-stdio-to-uds"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "codex-uds",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "pretty_assertions",
  "tracing",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "codex-test-binary-support"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-arg0",
  "tempfile",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "codex-thread-manager-sample"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "clap",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "codex-thread-store"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "chrono",
  "codex-git-utils",
@@ -4269,7 +4269,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-code-mode",
  "codex-connectors",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tui"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "async-io",
  "pretty_assertions",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "dirs",
  "dunce",
@@ -4431,14 +4431,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "lru 0.16.3",
  "sha1 0.10.6",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cargo-bin"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "assert_cmd",
  "runfiles",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -4468,15 +4468,15 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-elapsed"
-version = "0.0.27"
+version = "0.0.28"
 
 [[package]]
 name = "codex-utils-fuzzy-match"
-version = "0.0.27"
+version = "0.0.28"
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-product-info",
  "codex-utils-absolute-path",
@@ -4487,7 +4487,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4500,7 +4500,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-oss"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-core",
  "codex-lmstudio",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4528,7 +4528,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-exec-server",
  "codex-utils-absolute-path",
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "assert_matches",
  "thiserror 2.0.18",
@@ -4593,14 +4593,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-sandbox-summary"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-core",
  "codex-model-provider-info",
@@ -4611,7 +4611,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-sleep-inhibitor"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "core-foundation 0.9.4",
  "libc",
@@ -4621,14 +4621,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "pretty_assertions",
  "regex-lite",
@@ -4638,14 +4638,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "codex-v8-poc"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "pretty_assertions",
  "v8",
@@ -4653,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "codex-web-search-extension"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -4673,7 +4673,7 @@ dependencies = [
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "codex-http-client",
  "codex-utils-rustls-provider",
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "core_test_support"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9336,7 +9336,7 @@ dependencies = [
 
 [[package]]
 name = "mcp_test_support"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "codex-login",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -133,7 +133,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.27"
+version = "0.0.28"
 # Track the edition for all workspace crates in one place. Individual
 # crates can still override this value, but keeping it here means new
 # crates created with `cargo new -w ...` automatically inherit the 2024


### PR DESCRIPTION
## Summary

- bump the Open Interpreter workspace release from 0.0.27 to 0.0.28
- make the merged Kimi K3 skill-dispatch fixes available to standalone installs

## Validation

- PR #1802 full Cargo CI: passed
- this release PR must pass repository smoke and full Cargo CI before merge