### PR TITLE
Restrict website docs dispatch to Killian

### DIFF
--- a/.github/workflows/website-docs-sync.yml
+++ b/.github/workflows/website-docs-sync.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   dispatch:
+    if: github.actor == 'KillianLucas'
     runs-on: ubuntu-latest
     env:
       WEBSITE_DOCS_SYNC_TOKEN: ${{ secrets.WEBSITE_DOCS_SYNC_TOKEN }}


### PR DESCRIPTION
## Summary

Run the public-to-private website docs dispatch only when the GitHub actor is `KillianLucas`. Contributor pull requests never trigger this workflow, and other write collaborators cannot use its manual or main-push trigger to contact the private website.