### PR TITLE
Organize model provider guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   </a>
 </p>
 
-### Installation
+## Installation
 
 macOS and Linux:
 
@@ -38,7 +38,7 @@ irm https://www.openinterpreter.com/install.ps1 | iex
 
 Then type `i` or `interpreter` in your terminal to start a session.
 
-### Harness Emulation
+## Harness Emulation
 
 Open Interpreter is a fork of OpenAI's Codex, with a focus on emulating the agent harness that gets the best performance out of low-cost models.
 
@@ -59,13 +59,9 @@ swe-agent
 minimal
 ```
 
-Kimi and Moonshot models use the current `kimi-code` harness by default.
-`kimi-cli` remains available for compatibility with the retired Python CLI
-profile.
+Read more in the [harness docs](https://www.openinterpreter.com/docs/terminal/harness?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=harness_docs) and [provider setup guides](https://www.openinterpreter.com/docs/terminal/providers?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=provider_guides).
 
-Read more in the [harness docs](https://www.openinterpreter.com/docs/terminal/harness?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=harness_docs) and [model provider docs](https://www.openinterpreter.com/docs/terminal/providers?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=model_provider_docs).
-
-### ACP compatible, Codex compatible
+## ACP compatible, Codex compatible
 
 Open Interpreter works in [ACP-compatible editors and clients](https://agentclientprotocol.com/get-started/clients). Configure the client to launch `interpreter acp`; see the [ACP guide](https://www.openinterpreter.com/docs/terminal/acp) for examples.
 
@@ -79,11 +75,11 @@ binary override:
 
 Open Interpreter speaks the same Codex exec protocol. See the [SDK guide](https://www.openinterpreter.com/docs/terminal/sdk) and run `scripts/test-codex-sdk-compat.sh` for a local, provider-free compatibility check.
 
-### Computer Use
+## Computer Use
 
 Open Interpreter ships with a QA skill that lets any model operate and test interfaces. It can drive web apps in a real browser with [agent-browser](https://github.com/vercel-labs/agent-browser), or operate and test native apps with [trycua](https://github.com/trycua/cua).
 
-### Features
+## Features
 
 - Runs commands inside native sandboxing on macOS, Linux, and Windows.
 - Switches providers and models from the TUI with `/model`.
@@ -93,7 +89,7 @@ Open Interpreter ships with a QA skill that lets any model operate and test inte
 - Keeps config and session state local under `~/.openinterpreter`.
 - Supports `exec`, MCP, skills, hooks, permissions, and `AGENTS.md`.
 
-### Documentation
+## Documentation
 
 - [Terminal docs](https://www.openinterpreter.com/docs/terminal?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=terminal_docs)
 - [Quickstart](https://www.openinterpreter.com/docs/terminal/quickstart?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=quickstart)
@@ -101,8 +97,10 @@ Open Interpreter ships with a QA skill that lets any model operate and test inte
 - [Configuration](https://www.openinterpreter.com/docs/terminal/config?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=configuration)
 - [CLI reference](https://www.openinterpreter.com/docs/terminal/cli-reference?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=cli_reference)
 - [Harnesses](https://www.openinterpreter.com/docs/terminal/harness?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=harnesses)
-- [Kimi K3](https://www.openinterpreter.com/docs/terminal/kimi-k3?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=kimi_k3_docs)
-- [Model providers](https://www.openinterpreter.com/docs/terminal/providers?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=model_providers)
+- [Model provider guides](https://www.openinterpreter.com/docs/terminal/providers?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=provider_guides)
+  - [Kimi K3](https://www.openinterpreter.com/docs/terminal/kimi-k3?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=kimi_k3_docs)
+  - [DeepSeek](https://www.openinterpreter.com/docs/terminal/deepseek?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=deepseek_docs)
+  - [Z.AI, GLM, and ZCode](https://www.openinterpreter.com/docs/terminal/zai-glm?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=zai_glm_docs)
 - [Agent Client Protocol](https://www.openinterpreter.com/docs/terminal/acp)
 - [Codex SDK](https://www.openinterpreter.com/docs/terminal/sdk)
 - [Sandbox & approvals](https://www.openinterpreter.com/docs/terminal/sandbox?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=sandbox_approvals)
@@ -118,6 +116,6 @@ sources require the provider credentials documented in the
 > [!NOTE]
 > This is the new Rust version of Open Interpreter, based on Codex. Looking for the original Python project? It lives on as a community-maintained fork at [endolith/open-interpreter](https://github.com/endolith/open-interpreter).
 
-### License
+## License
 
 Apache-2.0

--- a/docs.json
+++ b/docs.json
@@ -39,11 +39,19 @@
               "docs/prompting",
               "docs/workflows",
               "docs/models",
-              "docs/kimi-k3",
               "docs/harness",
               "docs/subagents"
             ]
           }
+        ]
+      },
+      {
+        "group": "Model providers",
+        "pages": [
+          "docs/providers",
+          "docs/kimi-k3",
+          "docs/deepseek",
+          "docs/zai-glm"
         ]
       },
       {
@@ -63,7 +71,6 @@
         "pages": [
           "docs/config",
           "docs/config-reference",
-          "docs/providers",
           "docs/authentication",
           {
             "group": "Project context",

--- a/docs/deepseek.md
+++ b/docs/deepseek.md
@@ -1,0 +1,105 @@
+---
+title: DeepSeek
+description: Use DeepSeek models with the default Claude Code bare harness or the optional DeepSeek TUI harness.
+---
+
+Open Interpreter connects directly to the
+[DeepSeek API](https://api-docs.deepseek.com/) with the built-in `deepseek`
+provider. It uses DeepSeek's OpenAI-compatible Chat endpoint and reads your key
+from `DEEPSEEK_API_KEY`.
+
+## Start With DeepSeek
+
+Create a key in the DeepSeek platform, export it, and start Open Interpreter:
+
+```bash
+export DEEPSEEK_API_KEY="..."
+interpreter
+```
+
+Open `/model`, select **DeepSeek**, then select a model. For a direct launch:
+
+```bash
+DEEPSEEK_API_KEY="..." interpreter \
+  -c 'model_provider="deepseek"' \
+  -m deepseek-v4-pro
+```
+
+For one non-interactive task:
+
+```bash
+DEEPSEEK_API_KEY="..." interpreter exec \
+  -c 'model_provider="deepseek"' \
+  -m deepseek-v4-pro \
+  "Review this repository and fix the highest-impact bug."
+```
+
+## Choose a Model
+
+The `/model` picker is generated from maintained provider catalogs and the
+provider's current model data. Use it as the source of truth for models
+available in your installed version.
+
+DeepSeek's current API model IDs are `deepseek-v4-pro` and
+`deepseek-v4-flash`. Use Pro for the higher-capacity option and Flash when cost
+or concurrency matters more. DeepSeek has announced that the legacy
+`deepseek-chat` and `deepseek-reasoner` IDs will be discontinued on July 24,
+2026, so new configurations should use the V4 IDs.
+See DeepSeek's [API updates](https://api-docs.deepseek.com/updates/) for current
+availability and its [pricing page](https://api-docs.deepseek.com/quick_start/pricing)
+before committing to a workload.
+
+## Harness Behavior
+
+DeepSeek models use `claude-code-bare` automatically when you have not set a
+harness. Open Interpreter carries that smaller Claude Code-shaped agent surface
+over DeepSeek's Chat Completions endpoint; it does not run an external CLI.
+
+To inspect or change the active harness, run `/harness`. The optional
+`deepseek-tui` mode is available when you specifically want its DeepSeek
+TUI/CodeWhale-shaped prompt and tools:
+
+```toml
+model_provider = "deepseek"
+model = "deepseek-v4-pro"
+harness = "deepseek-tui"
+```
+
+Remove the explicit `harness` line to return to the recommended automatic
+default.
+
+## Configuration
+
+The built-in provider is equivalent to this connection:
+
+```toml
+model_provider = "deepseek"
+model = "deepseek-v4-pro"
+
+[model_providers.deepseek]
+name = "DeepSeek"
+base_url = "https://api.deepseek.com"
+env_key = "DEEPSEEK_API_KEY"
+wire_api = "chat"
+```
+
+You normally do not need to copy that provider block. It is useful when you
+need to understand a proxy or custom deployment. If you change the endpoint,
+keep `wire_api = "chat"` for DeepSeek's OpenAI-compatible Chat API.
+
+## Editors and SDKs
+
+The same provider configuration works through `interpreter acp` in
+[ACP-compatible editors](/docs/acp) and through Open Interpreter's
+[Codex SDK compatibility](/docs/sdk).
+
+## Troubleshooting
+
+- A 401 or 403 usually means `DEEPSEEK_API_KEY` is missing, expired, or belongs
+  to a different endpoint.
+- If a legacy model ID stops working, open `/model` and select a current V4
+  model instead of hard-coding the replacement.
+- If the agent surface is unexpected, run `/harness` and remove any old
+  explicit `harness` value from `~/.openinterpreter/config.toml`.
+- If a proxy exposes a different protocol, match its `wire_api`; do not assume
+  every DeepSeek-compatible endpoint has the same transport.

--- a/docs/harness.md
+++ b/docs/harness.md
@@ -28,8 +28,9 @@ interpreter -c harness='"kimi-code"' "solve this task"
 | --- | --- | --- | --- |
 | unset or `""` | `responses` | Responses API | Native Open Interpreter/Codex-compatible surface |
 | unset or `""` | `chat` | Chat Completions compatibility | Generic OpenAI-compatible chat providers |
-| `claude-code` | `messages` | Anthropic Messages harness | [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) full agent surface |
-| `claude-code-bare` | `messages` | Anthropic Messages harness | [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) bare profile |
+| `claude-code` | `responses`, `chat`, or `messages` | Claude Code shaping over the provider transport | [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) full agent surface |
+| `claude-code-bare` | `responses`, `chat`, or `messages` | Claude Code shaping over the provider transport | [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) bare profile |
+| `zcode` | `messages` | Anthropic Messages harness | ZCode-shaped GLM coding-agent surface |
 | `deepseek-tui` | `chat` | Chat harness | [DeepSeek TUI](https://github.com/DeepSeek-TUI/DeepSeek-TUI) / [CodeWhale](https://www.codewhale.ai/) |
 | `kimi-code` | `chat` | Chat harness | Current [Kimi Code](https://www.kimi.com/code/docs/en/) / [GitHub](https://github.com/MoonshotAI/kimi-code) profile |
 | `kimi-cli` | `chat` | Chat harness | Legacy [Kimi CLI](https://moonshotai.github.io/kimi-cli/) / [GitHub](https://github.com/MoonshotAI/kimi-cli) profile |
@@ -45,6 +46,8 @@ surfaces informed the corresponding harness modes:
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview)
   from Anthropic.
+- ZCode, a GLM coding-agent surface used with Anthropic Messages-compatible
+  endpoints such as Z.AI's Coding Plan endpoint.
 - [DeepSeek TUI](https://github.com/DeepSeek-TUI/DeepSeek-TUI), with product
   context at [CodeWhale](https://www.codewhale.ai/).
 - Current [Kimi Code](https://www.kimi.com/code/docs/en/) and its
@@ -62,9 +65,9 @@ Harness routing is strict:
 
 | Provider `wire_api` | Compatible harnesses |
 | --- | --- |
-| `responses` | Native only. `claude-code` and `claude-code-bare` are rejected because they require `messages`. |
-| `chat` | Native chat compatibility, `deepseek-tui`, `kimi-code`, `kimi-cli`, `qwen-code`, `swe-agent`, and `minimal`. |
-| `messages` | `claude-code` and `claude-code-bare` only. Native mode is rejected because Messages requires a harness-native transport. |
+| `responses` | Native Responses, `claude-code`, and `claude-code-bare`. |
+| `chat` | Native chat compatibility, `claude-code`, `claude-code-bare`, `deepseek-tui`, `kimi-code`, `kimi-cli`, `qwen-code`, `swe-agent`, and `minimal`. |
+| `messages` | `claude-code`, `claude-code-bare`, and `zcode`. Native mode is rejected because Messages requires a harness-native transport. |
 
 This means an Anthropic-style provider normally needs:
 
@@ -86,7 +89,7 @@ the selected provider/model:
 | Anthropic, Claude model ids, Anthropic base URL, or any `messages` provider | `claude-code` |
 | Kimi/Moonshot provider ids, names, base URLs, or model ids | `kimi-code` |
 | Qwen/QwQ/DashScope provider ids, names, base URLs, or model ids | `qwen-code` |
-| DeepSeek provider ids, names, base URLs, or model ids | `deepseek-tui` |
+| DeepSeek provider ids, names, base URLs, or model ids | `claude-code-bare` |
 
 Explicit `harness = "..."` always wins.
 
@@ -94,10 +97,11 @@ Explicit `harness = "..."` always wins.
 
 ### `claude-code`
 
-Uses the Anthropic Messages API and builds Claude Code-shaped requests. It
-adds Claude Code headers, a Claude Code system prompt, Anthropic thinking
-configuration, context-management settings, title-generation requests, and a
-Claude-shaped tool surface.
+Builds Claude Code-shaped requests over the selected provider's Responses,
+Chat, or Anthropic Messages transport. It adds a Claude Code system prompt,
+thinking configuration, context-management settings, title-generation
+requests, and a Claude-shaped tool surface. Transport-specific headers and
+message conversion are applied when the provider requires them.
 
 It maps supported tools into Anthropic tool definitions and includes handlers
 for Bash/PowerShell, Read, Write, Edit, TodoWrite, Glob, Grep, web search/fetch,
@@ -105,9 +109,20 @@ LSP, scheduled wakeups, and Claude-style subagents.
 
 ### `claude-code-bare`
 
-Uses the same `messages` route as `claude-code`, but with the bare Claude Code
-profile. The bare profile uses a smaller prompt/profile shape and different
-output config defaults.
+Uses the same provider transport as `claude-code`, but with the bare Claude
+Code profile. The bare profile uses a smaller prompt/profile shape and
+different output config defaults. DeepSeek selects this profile automatically.
+
+### `zcode`
+
+Uses Anthropic Messages-compatible requests with a ZCode-shaped system prompt,
+headers, tools, todo and plan behavior, skills, session context, and subagent
+surface. Tool calls still run inside Open Interpreter's native Rust runtime.
+
+The harness requires `wire_api = "messages"`. The built-in Z.AI and Z.AI
+Coding Plan providers use `wire_api = "chat"`, so use the Messages endpoint
+configuration in [Z.AI, GLM, and ZCode](/docs/zai-glm) when you want the actual
+ZCode route.
 
 ### `kimi-code`
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -125,6 +125,7 @@ Some model families get a default harness when no explicit harness is set:
 | Claude/Anthropic/Messages | `claude-code` |
 | Kimi/Moonshot | `kimi-code` |
 | Qwen/QwQ/DashScope | `qwen-code` |
-| DeepSeek | `deepseek-tui` |
+| DeepSeek | `claude-code-bare` |
 
-See [Harness](/docs/harness) for the wire-api compatibility matrix.
+See [Harness](/docs/harness) for the wire-api compatibility matrix and
+[Model providers](/docs/providers) for provider-specific setup guides.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,11 +1,52 @@
 ---
-title: Providers
-description: Supported provider ids, wire APIs, auth modes, and catalog generation.
+title: Model Providers
+description: Choose a provider, connect an account or API key, and use the right harness for its models.
 ---
 
-Open Interpreter separates the provider from the model. The active provider
-decides where requests are sent, how credentials are attached, which wire API
-is used, and which bundled model metadata seeds the picker.
+Providers connect Open Interpreter to model services. A provider decides where
+requests are sent and how you authenticate; a model is the model ID you run; a
+harness controls the agent-facing prompt, tools, and message behavior.
+
+For most providers, start Open Interpreter and use `/model`:
+
+```text
+> /model
+```
+
+Choose the provider, authenticate or set the requested environment variable,
+then choose a model. Open Interpreter automatically selects a provider-specific
+harness when one is configured for that model family. You can inspect or
+override it with `/harness`.
+
+## Provider Guides
+
+| Provider family | Authentication | Default behavior | Guide |
+| --- | --- | --- | --- |
+| Kimi K3 and Moonshot | Kimi Code sign-in, `KIMI_API_KEY`, or `MOONSHOT_API_KEY` | `kimi-code` harness | [Kimi K3](/docs/kimi-k3) |
+| DeepSeek | `DEEPSEEK_API_KEY` | `claude-code-bare` harness | [DeepSeek](/docs/deepseek) |
+| Z.AI, Zhipu AI, and GLM | `ZAI_API_KEY` or `ZHIPU_API_KEY` | Generic Chat, or `zcode` with a Messages endpoint | [Z.AI, GLM, and ZCode](/docs/zai-glm) |
+
+These guides cover the provider IDs, current model-selection path, API or
+subscription setup, harness behavior, direct CLI use, and common mistakes.
+
+## Provider, Model, and Harness
+
+Keep the three layers separate when troubleshooting:
+
+| Layer | Example | What it controls |
+| --- | --- | --- |
+| Provider | `deepseek` | Endpoint, credentials, and wire API |
+| Model | `deepseek-v4-pro` | The model sent to that endpoint |
+| Harness | `claude-code-bare` | Agent prompt, tools, and request shaping |
+
+The provider's `wire_api` must support the selected harness. See
+[Harness](/docs/harness) for the compatibility matrix.
+
+## Provider Reference
+
+The active provider decides where requests are sent, how credentials are
+attached, which wire API is used, and which bundled model metadata seeds the
+picker.
 
 The source of truth is code, not this table:
 
@@ -236,7 +277,7 @@ harness mode from the provider/model family:
 | `wire_api = "messages"`, Anthropic provider/name/base URL, or `claude` model ids | `claude-code` |
 | `kimi`, `moonshot`, `api.kimi.com`, `api.moonshot.ai`, or `api.moonshot.cn` | `kimi-code` |
 | `qwen`, `qwq`, `dashscope`, or DashScope compatible-mode base URLs | `qwen-code` |
-| `deepseek` or `api.deepseek.com` | `deepseek-tui` |
+| `deepseek` or `api.deepseek.com` | `claude-code-bare` |
 
 You can override this with `harness = "..."` in config. See
 [Harness](/docs/harness) for route compatibility.

--- a/docs/zai-glm.md
+++ b/docs/zai-glm.md
@@ -1,0 +1,130 @@
+---
+title: Z.AI, GLM, and ZCode
+description: Use GLM models through Z.AI or Zhipu AI, with generic Chat or the native ZCode harness.
+---
+
+Open Interpreter includes providers for the global Z.AI platform, its GLM
+Coding Plan, and the corresponding Zhipu AI services in China. It also includes
+a native `zcode` harness for GLM coding workflows.
+
+## Choose the Right Provider
+
+| Account or service | Provider ID | Credential | Endpoint type |
+| --- | --- | --- | --- |
+| Z.AI pay-as-you-go API | `zai` | `ZAI_API_KEY` | General OpenAI-compatible Chat API |
+| Z.AI GLM Coding Plan | `zai-coding-plan` | `ZAI_API_KEY` | Coding Plan OpenAI-compatible Chat API |
+| Zhipu AI pay-as-you-go API | `zhipuai` | `ZHIPU_API_KEY` | General OpenAI-compatible Chat API |
+| Zhipu AI Coding Plan | `zhipuai-coding-plan` | `ZHIPU_API_KEY` | Coding Plan OpenAI-compatible Chat API |
+
+Z.AI documents separate general and Coding Plan endpoints. Use the Coding Plan
+provider only for an eligible subscription; using the general endpoint does
+not consume Coding Plan quota. Confirm that your client and use case comply
+with Z.AI's current Coding Plan usage policy before relying on subscription
+quota.
+
+## Start With the Built-In Provider
+
+Export the key for your account, start Open Interpreter, then use `/model` to
+select the matching provider and a GLM model:
+
+```bash
+export ZAI_API_KEY="..."
+interpreter
+```
+
+For a direct Z.AI Coding Plan launch:
+
+```bash
+ZAI_API_KEY="..." interpreter \
+  -c 'model_provider="zai-coding-plan"' \
+  -m glm-5.2
+```
+
+For the general Z.AI API, change the provider to `zai`. Users of the China
+service should use `zhipuai` or `zhipuai-coding-plan` with `ZHIPU_API_KEY`.
+
+The bundled providers use Z.AI's OpenAI-compatible Chat endpoint. With no
+explicit harness, they use Open Interpreter's generic Chat agent surface.
+
+## Use the ZCode Harness
+
+`zcode` reproduces the ZCode-shaped system prompt, Messages request format,
+tools, todos, plan controls, skills, session context, and subagent behavior in
+Open Interpreter's native Rust runtime. It requires an Anthropic
+Messages-compatible provider; selecting `zcode` on the built-in Chat provider
+does not activate that Messages route.
+
+Z.AI officially provides an Anthropic-compatible Coding Plan endpoint at
+`https://api.z.ai/api/anthropic`. To use it, add a Messages provider to
+`~/.openinterpreter/config.toml`:
+
+```toml
+model_provider = "zai-zcode"
+model = "glm-5.2"
+harness = "zcode"
+
+[model_providers.zai-zcode]
+name = "Z.AI ZCode"
+base_url = "https://api.z.ai/api/anthropic"
+env_key = "ZAI_API_KEY"
+wire_api = "messages"
+env_http_headers = { Authorization = "ZAI_AUTHORIZATION" }
+```
+
+Then expose the bearer header without writing the secret into the config file:
+
+```bash
+export ZAI_API_KEY="..."
+export ZAI_AUTHORIZATION="Bearer $ZAI_API_KEY"
+interpreter
+```
+
+Open Interpreter sends the ZCode Messages request to `/v1/messages`. The
+additional authorization environment variable matches Z.AI's documented
+bearer-token authentication while `ZAI_API_KEY` remains the provider's required
+secret source.
+
+See Z.AI's official [Coding Plan quickstart](https://docs.z.ai/devpack/quick-start)
+and [tool endpoint guide](https://docs.z.ai/devpack/tool/others) for current
+endpoint and plan-eligibility details.
+
+## Choose a GLM Model
+
+Use `/model` rather than maintaining a private list. The picker is generated
+from maintained provider sources and includes current GLM model IDs for the
+selected service. For example, the bundled Z.AI Coding Plan catalog currently
+includes `glm-5.2`, `glm-5.1`, `glm-5-turbo`, and lower-cost models.
+
+Z.AI may update server-side model mappings and plan eligibility independently
+of Open Interpreter. Check its [model-switching guide](https://docs.z.ai/devpack/using5.1)
+when a model is unavailable or consumes a different quota multiplier.
+
+## Chat or ZCode?
+
+| Goal | Configuration |
+| --- | --- |
+| Simplest setup with the built-in picker | `zai-coding-plan` or `zai`, generic Chat |
+| Provider-recommended OpenAI-compatible integration | Built-in provider, `wire_api = "chat"` |
+| ZCode-shaped coding-agent behavior | Custom Messages provider plus `harness = "zcode"` |
+
+Do not set `wire_api = "messages"` on the OpenAI-compatible `/paas/v4`
+endpoint, and do not point the Chat provider at `/api/anthropic`. The endpoint,
+wire API, and harness must agree.
+
+## Editors and SDKs
+
+Both configurations can be used through `interpreter acp` in
+[ACP-compatible editors](/docs/acp) and through Open Interpreter's
+[Codex SDK compatibility](/docs/sdk). The selected provider and harness remain
+part of the Open Interpreter configuration.
+
+## Troubleshooting
+
+- A 401 or 403 usually means the wrong key, endpoint, region, or authorization
+  header is in use.
+- If Coding Plan quota is not being used, confirm that the provider is
+  `zai-coding-plan` or that the ZCode setup points to `/api/anthropic`.
+- If `/harness` shows `zcode` but behavior looks generic, confirm the active
+  provider has `wire_api = "messages"`.
+- If a model is absent, open `/model` and choose one offered for that exact
+  provider instead of copying a model ID from another Z.AI region or plan.


### PR DESCRIPTION
Moves Kimi K3 out of Concepts into a provider-focused documentation section, adds dedicated DeepSeek and Z.AI/GLM/ZCode guides, corrects harness routing documentation, and updates README links.\n\nValidation:\n- docs.json parses\n- every navigation source page exists\n- every internal /docs link resolves\n- git diff --check passes