### PR TITLE
fix: prefer PowerShell over cmd.exe as ultimate fallback on Windows

### DIFF
--- a/codex-rs/shell-command/src/shell_detect.rs
+++ b/codex-rs/shell-command/src/shell_detect.rs
@@ -240,6 +240,17 @@ fn get_cmd_shell(path: Option<&PathBuf>) -> Option<DetectedShell> {
 
 pub fn ultimate_fallback_shell() -> DetectedShell {
     if cfg!(windows) {
+        // Prefer PowerShell over cmd.exe as the ultimate fallback on Windows.
+        // PowerShell is better supported (e.g., shell snapshotting works), and
+        // the model harnesses already steer toward PowerShell on Windows.
+        for path in ["pwsh", "powershell"] {
+            if let Ok(resolved) = which::which(path) {
+                return DetectedShell {
+                    shell_type: ShellType::PowerShell,
+                    shell_path: resolved,
+                };
+            }
+        }
         DetectedShell {
             shell_type: ShellType::Cmd,
             shell_path: PathBuf::from("cmd.exe"),


### PR DESCRIPTION
## Problem

On Windows, the ultimate fallback shell (ultimate_fallback_shell()) previously defaulted to cmd.exe. This causes problems because:

1. Shell snapshotting is unsupported for cmd.exe
2. The harnesses already steer toward PowerShell on Windows  
3. PowerShell is the recommended shell on Windows

## Solution

Modified ultimate_fallback_shell() on Windows to first look for pwsh and powershell via PATH lookup before falling back to cmd.exe. This matches the existing behavior of default_user_shell() which already prefers PowerShell on Windows.

The change preserves backward compatibility: if neither pwsh nor powershell is found on PATH, the function still falls back to cmd.exe.

## File changed

- codex-rs/shell-command/src/shell_detect.rs

Closes: #1023