### PR TITLE
fix(deps): bump gix to 0.83 to patch 5 security advisories (GHSA-f26g / GHSA-fr8x / GHSA-p3hw / GHSA-pg4w / GHSA-f89h)

### DIFF
--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -326,7 +326,7 @@ eventsource-stream = "0.2.3"
 flate2 = "1.1.8"
 futures = { version = "0.3", default-features = false }
 gethostname = "1.1.0"
-gix = { version = "0.81.0", default-features = false, features = ["sha1"] }
+gix = { version = "0.83", default-features = false, features = ["sha1"] }
 glob = "0.3"
 globset = "0.4"
 hmac = "0.12.1"


### PR DESCRIPTION
Automated dependency bump to address multiple publicly-disclosed security advisories in `gix 0.81.0` (direct workspace dep at `codex-rs/Cargo.toml`).

## Security advisories fixed

| Advisory | Severity | Summary |
|---|---|---|
| [GHSA-f26g-jm89-4g65](https://github.com/advisories/GHSA-f26g-jm89-4g65) | HIGH | CommandForbiddenInModulesConfiguration bypass in `gix_submodule` enables arbitrary command execution via crafted `.gitmodules` |
| [GHSA-fr8x-3vfx-f45h](https://github.com/advisories/GHSA-fr8x-3vfx-f45h) | HIGH | Unvalidated submodule name traverses out of `.git/modules`, allows worktree path escape |
| [GHSA-p3hw-mv63-rf9w](https://github.com/advisories/GHSA-p3hw-mv63-rf9w) | HIGH | Submodule name validation bypass + trust inheritance flaw enables path traversal and credential exfiltration |
| [GHSA-pg4w-g64p-qwhj](https://github.com/advisories/GHSA-pg4w-g64p-qwhj) | HIGH | Trust domain inheritance flaw in submodule handling |
| [GHSA-f89h-2fjh-2r9q](https://github.com/advisories/GHSA-f89h-2fjh-2r9q) | HIGH | `gix-fs`: Symlink prefix-reuse allows worktree escape during checkout (fixed via transitive `gix-fs` → `0.21.1`) |
| [GHSA-9857-6mw7-fq2m](https://github.com/advisories/GHSA-9857-6mw7-fq2m) | MEDIUM | `gix-transport`: HTTP credentials leaked to a redirected host in curl backend (fixed via transitive `gix-transport` → `0.56.0`) |

All six advisories are fixed in **gix 0.83.0**; the `gix-fs` and `gix-transport` transitive fixes are included when Cargo resolves the updated version.

## Change

- `codex-rs/Cargo.toml`: `gix = "0.81.0"` → `gix = "0.83"`

## After merging

Run:
```
cargo update -p gix --precise 0.83.0
```
to regenerate `Cargo.lock` with the patched versions.

## Additional note

`jsonwebtoken 9.3.1` (also a direct dep in `login`, `app-server-transport`, `agent-identity`) is affected by [GHSA-h395-gr6q-cpjc](https://github.com/advisories/GHSA-h395-gr6q-cpjc) — type confusion bypasses `exp`/`nbf` claim validation when those claims have wrong JSON types. Fixed in `10.3.0` (breaking API change), tracked separately.

---
Detected by [Aeon](https://github.com/aeonframework/aeon) · [osv-scanner](https://google.github.io/osv-scanner/) · No code changes outside `Cargo.toml`.