### PR TITLE
Add Kimi Code image viewing

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app_test_support"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "codex-acp-server"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ansi-escape"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "ansi-to-tui",
  "ratatui",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-daemon"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-test-client"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "axum",
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "pretty_assertions",
  "tokio",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "serde",
  "serde_json",
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "codex-bwrap"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "cc",
  "libc",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chat-wire-compat"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bytes",
  "codex-api",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cli"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-config"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-client"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2633,7 +2633,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-mock-client"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "chrono",
  "codex-cloud-tasks-client",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-protocol",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-host"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-protocol",
  "pretty_assertions",
@@ -2686,11 +2686,11 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.0.29"
+version = "0.0.30"
 
 [[package]]
 name = "codex-config"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "codex-config",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors-extension"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-connectors",
  "codex-core-plugins",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-api"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-analytics",
  "codex-app-server-protocol",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy-legacy"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "allocative",
  "anyhow",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-utils-absolute-path",
  "pretty_assertions",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-hooks",
  "pretty_assertions",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -3275,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "notify",
  "pretty_assertions",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "codex-goal-extension"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "codex-home"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bytes",
  "codex-utils-cargo-bin",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-product-info",
  "codex-utils-absolute-path",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "keyring",
  "tracing",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "clap",
  "codex-core",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "codex-lmstudio"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-core",
  "codex-model-provider-info",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-extension"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-config",
  "codex-connectors-extension",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -3631,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "codex-message-history"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-config",
  "memchr",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-api",
  "codex-product-info",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3814,7 +3814,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ollama"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "assert_matches",
  "async-stream",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -3886,14 +3886,14 @@ dependencies = [
 
 [[package]]
 name = "codex-product-info"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "chardetng",
@@ -3949,7 +3949,7 @@ dependencies = [
 
 [[package]]
 name = "codex-realtime-webrtc"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "libwebrtc",
  "thiserror 2.0.18",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "codex-responses-api-proxy"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "axum",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -4068,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "codex-network-proxy",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "age",
  "anyhow",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-core-skills",
  "codex-exec-server",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "codex-stdio-to-uds"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "codex-uds",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "pretty_assertions",
  "tracing",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "codex-test-binary-support"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-arg0",
  "tempfile",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "codex-thread-manager-sample"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "codex-thread-store"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "chrono",
  "codex-git-utils",
@@ -4269,7 +4269,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-code-mode",
  "codex-connectors",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tui"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "async-io",
  "pretty_assertions",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "dirs",
  "dunce",
@@ -4431,14 +4431,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "lru 0.16.3",
  "sha1 0.10.6",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cargo-bin"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "assert_cmd",
  "runfiles",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -4468,15 +4468,15 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-elapsed"
-version = "0.0.29"
+version = "0.0.30"
 
 [[package]]
 name = "codex-utils-fuzzy-match"
-version = "0.0.29"
+version = "0.0.30"
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-product-info",
  "codex-utils-absolute-path",
@@ -4487,7 +4487,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4500,7 +4500,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-oss"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-core",
  "codex-lmstudio",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4528,7 +4528,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-exec-server",
  "codex-utils-absolute-path",
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "assert_matches",
  "thiserror 2.0.18",
@@ -4593,14 +4593,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-sandbox-summary"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-core",
  "codex-model-provider-info",
@@ -4611,7 +4611,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-sleep-inhibitor"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "core-foundation 0.9.4",
  "libc",
@@ -4621,14 +4621,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "pretty_assertions",
  "regex-lite",
@@ -4638,14 +4638,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "codex-v8-poc"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "pretty_assertions",
  "v8",
@@ -4653,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "codex-web-search-extension"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -4673,7 +4673,7 @@ dependencies = [
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "codex-http-client",
  "codex-utils-rustls-provider",
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "core_test_support"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9336,7 +9336,7 @@ dependencies = [
 
 [[package]]
 name = "mcp_test_support"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "codex-login",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -133,7 +133,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.29"
+version = "0.0.30"
 # Track the edition for all workspace crates in one place. Individual
 # crates can still override this value, but keeping it here means new
 # crates created with `cargo new -w ...` automatically inherit the 2024

--- a/codex-rs/core/src/tools/handlers/harness_aliases.rs
+++ b/codex-rs/core/src/tools/handlers/harness_aliases.rs
@@ -1346,33 +1346,7 @@ async fn handle_read(invocation: ToolInvocation) -> Result<Box<dyn ToolOutput>, 
 async fn handle_read_media_file(
     invocation: ToolInvocation,
 ) -> Result<Box<dyn ToolOutput>, FunctionCallError> {
-    let arguments = function_arguments(&invocation.payload)?;
-    let args: ReadArgs = parse_arguments(arguments)?;
-    let path = harness_fs::checked_read_path(&invocation, &args.path, "ReadMediaFile")?;
-    let Some(mime_type) = image_mime_type(&path) else {
-        return Err(FunctionCallError::RespondToModel(format!(
-            "ReadMediaFile failed: `{}` is not a supported image file",
-            display_model_path(&invocation, &path)
-        )));
-    };
-    let data = std::fs::read(&path)
-        .map_err(|err| FunctionCallError::RespondToModel(format!("ReadMediaFile failed: {err}")))?;
-    let image_url = format!("data:{mime_type};base64,{}", BASE64_STANDARD.encode(data));
-    Ok(boxed_tool_output(FunctionToolOutput::from_content(
-        vec![
-            FunctionCallOutputContentItem::InputText {
-                text: format!(
-                    "<system>Read media file `{}` as {mime_type}.</system>",
-                    display_model_path(&invocation, &path)
-                ),
-            },
-            FunctionCallOutputContentItem::InputImage {
-                image_url,
-                detail: None,
-            },
-        ],
-        Some(true),
-    )))
+    super::kimi_code_media::handle(invocation).await
 }
 
 async fn poll_claude_task_output(
@@ -4848,13 +4822,20 @@ mod tests {
     #[tokio::test]
     async fn kimi_read_media_file_alias_returns_image_payload() {
         let workspace = tempfile::tempdir().expect("workspace temp dir");
-        std::fs::write(workspace.path().join("red.png"), b"png-bytes").expect("write image file");
+        let image_path = workspace.path().join("red.png");
+        image::DynamicImage::new_rgb8(1, 1)
+            .save(&image_path)
+            .expect("write image file");
 
         let response_item = handle_response_item(
             &workspace,
             HarnessAliasHandler::ReadMediaFile,
             "ReadMediaFile",
-            json!({ "path": "red.png" }),
+            json!({
+                "path": "red.png",
+                "region": { "x": 0, "y": 0, "width": 1, "height": 1 },
+                "full_resolution": true,
+            }),
         )
         .await
         .expect("read media file succeeds");
@@ -4872,14 +4853,82 @@ mod tests {
         assert_eq!(
             items[0],
             FunctionCallOutputContentItem::InputText {
-                text: "<system>Read media file `red.png` as image/png.</system>".to_string(),
+                text: format!(
+                    "<image path=\"{}\">",
+                    dunce::canonicalize(&image_path)
+                        .expect("canonical image path")
+                        .display()
+                ),
             }
         );
         let FunctionCallOutputContentItem::InputImage { image_url, detail } = &items[1] else {
             panic!("expected image item");
         };
         assert!(image_url.starts_with("data:image/png;base64,"));
-        assert_eq!(*detail, None);
+        assert_eq!(*detail, Some(codex_protocol::models::ImageDetail::Original));
+        assert_eq!(
+            items[2],
+            FunctionCallOutputContentItem::InputText {
+                text: "</image>".to_string(),
+            }
+        );
+        let FunctionCallOutputContentItem::InputText { text } = &items[3] else {
+            panic!("expected media note");
+        };
+        assert!(text.contains("Original dimensions: 1x1 pixels."));
+        assert!(text.contains("Showing region (x=0, y=0, width=1, height=1)"));
+    }
+
+    #[tokio::test]
+    async fn kimi_read_media_file_accepts_all_provider_image_formats() {
+        let workspace = tempfile::tempdir().expect("workspace temp dir");
+        let image = image::DynamicImage::new_rgb8(2, 2);
+        for (filename, format) in [
+            ("sample.png", image::ImageFormat::Png),
+            ("sample.jpg", image::ImageFormat::Jpeg),
+            ("sample.webp", image::ImageFormat::WebP),
+        ] {
+            image
+                .save_with_format(workspace.path().join(filename), format)
+                .expect("write image fixture");
+        }
+        std::fs::write(
+            workspace.path().join("sample.gif"),
+            b"GIF89a\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\xff\xff\xff\x21\xf9\x04\x01\x00\x00\x00\x00\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3b",
+        )
+        .expect("write GIF fixture");
+
+        for (filename, mime_type) in [
+            ("sample.png", "image/png"),
+            ("sample.jpg", "image/jpeg"),
+            ("sample.gif", "image/gif"),
+            ("sample.webp", "image/webp"),
+        ] {
+            let response_item = handle_response_item(
+                &workspace,
+                HarnessAliasHandler::ReadMediaFile,
+                "ReadMediaFile",
+                json!({ "path": filename }),
+            )
+            .await
+            .expect("read media file succeeds");
+            let codex_protocol::models::ResponseInputItem::FunctionCallOutput { output, .. } =
+                response_item
+            else {
+                panic!("expected function call output");
+            };
+            let codex_protocol::models::FunctionCallOutputBody::ContentItems(items) = output.body
+            else {
+                panic!("expected content items");
+            };
+            let FunctionCallOutputContentItem::InputImage { image_url, .. } = &items[1] else {
+                panic!("expected image item");
+            };
+            assert!(
+                image_url.starts_with(format!("data:{mime_type};base64,").as_str()),
+                "unexpected image URL for {filename}: {image_url}"
+            );
+        }
     }
 
     #[test]

--- a/codex-rs/core/src/tools/handlers/kimi_code_media.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_media.rs
@@ -1,0 +1,445 @@
+use codex_protocol::models::FunctionCallOutputContentItem;
+use codex_protocol::models::ImageDetail;
+use codex_utils_image::data_url_from_bytes;
+use image::DynamicImage;
+use image::GenericImageView;
+use image::ImageEncoder;
+use image::ImageFormat;
+use image::codecs::jpeg::JpegEncoder;
+use image::codecs::png::PngEncoder;
+use image::imageops::FilterType;
+use serde::Deserialize;
+
+use crate::function_tool::FunctionCallError;
+use crate::tools::context::FunctionToolOutput;
+use crate::tools::context::ToolInvocation;
+use crate::tools::context::ToolOutput;
+use crate::tools::context::ToolPayload;
+use crate::tools::context::boxed_tool_output;
+use crate::tools::handlers::parse_arguments;
+
+const MAX_MEDIA_BYTES: usize = 100 * 1024 * 1024;
+const MAX_IMAGE_DECODE_BYTES: usize = 64 * 1024 * 1024;
+const FULL_IMAGE_BYTE_BUDGET: usize = 15 * 1024 * 1024 / 4;
+const READ_IMAGE_BYTE_BUDGET: usize = 256 * 1024;
+const MAX_IMAGE_EDGE: u32 = 2_000;
+const FALLBACK_EDGES: [u32; 5] = [1_000, 768, 512, 384, 256];
+const JPEG_QUALITY_STEPS: [u8; 4] = [80, 60, 40, 20];
+
+#[derive(Deserialize)]
+struct ReadMediaArgs {
+    path: String,
+    #[serde(default)]
+    region: Option<ImageRegion>,
+    #[serde(default)]
+    full_resolution: bool,
+}
+
+#[derive(Clone, Copy, Deserialize)]
+struct ImageRegion {
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+}
+
+struct PreparedImage {
+    bytes: Vec<u8>,
+    mime_type: &'static str,
+    width: u32,
+    height: u32,
+    delivery: ImageDelivery,
+}
+
+#[derive(Clone, Copy)]
+enum ImageDelivery {
+    Untouched,
+    Downsampled,
+    Full,
+    Crop { region: ImageRegion, resized: bool },
+}
+
+pub(super) async fn handle(
+    invocation: ToolInvocation,
+) -> Result<Box<dyn ToolOutput>, FunctionCallError> {
+    let ToolPayload::Function { arguments } = &invocation.payload else {
+        return Err(FunctionCallError::RespondToModel(
+            "ReadMediaFile received unsupported tool payload".to_string(),
+        ));
+    };
+    let args: ReadMediaArgs = parse_arguments(arguments)?;
+    if args.path.is_empty() {
+        return Err(FunctionCallError::RespondToModel(
+            "File path cannot be empty.".to_string(),
+        ));
+    }
+    let path = super::harness_fs::checked_read_path(&invocation, &args.path, "ReadMediaFile")?;
+    let data = std::fs::read(&path).map_err(|error| {
+        FunctionCallError::RespondToModel(format!("Failed to read {}: {error}", args.path))
+    })?;
+    let original_size = data.len();
+    if data.is_empty() {
+        return Err(FunctionCallError::RespondToModel(format!(
+            "\"{}\" is empty.",
+            args.path
+        )));
+    }
+    if data.len() > MAX_MEDIA_BYTES {
+        return Err(FunctionCallError::RespondToModel(format!(
+            "\"{}\" is {} bytes, which exceeds the maximum 100MB for media files.",
+            args.path,
+            data.len()
+        )));
+    }
+
+    let format = image::guess_format(&data).map_err(|_| {
+        FunctionCallError::RespondToModel(format!(
+            "\"{}\" is not a supported image or video file. Use Read for text files, or Bash or an MCP tool for other binary formats.",
+            args.path
+        ))
+    })?;
+    let mime_type = supported_mime_type(format).ok_or_else(|| {
+        FunctionCallError::RespondToModel(format!(
+            "\"{}\" is not a provider-supported PNG, JPEG, GIF, or WebP image. Convert it with Bash, then call ReadMediaFile on the converted file.",
+            args.path
+        ))
+    })?;
+    let (original_width, original_height, prepared) = if matches!(format, ImageFormat::Gif) {
+        let (width, height) = gif_dimensions(&data).ok_or_else(|| {
+            FunctionCallError::RespondToModel(format!(
+                "Failed to read {}: failed to decode GIF dimensions",
+                args.path
+            ))
+        })?;
+        let prepared = prepare_gif(&args, data, width, height)?;
+        (width, height, prepared)
+    } else {
+        let decoded = image::load_from_memory_with_format(&data, format).map_err(|error| {
+            FunctionCallError::RespondToModel(format!(
+                "Failed to read {}: failed to decode image: {error}",
+                args.path
+            ))
+        })?;
+        let (width, height) = decoded.dimensions();
+        let prepared = prepare_image(&args, data, decoded, format, mime_type)?;
+        (width, height, prepared)
+    };
+    let absolute_path = path.to_string_lossy();
+    let note = media_note(
+        mime_type,
+        original_size,
+        original_width,
+        original_height,
+        &prepared,
+    );
+    let image_url = data_url_from_bytes(prepared.mime_type, &prepared.bytes);
+
+    Ok(boxed_tool_output(FunctionToolOutput::from_content(
+        vec![
+            FunctionCallOutputContentItem::InputText {
+                text: format!("<image path=\"{absolute_path}\">"),
+            },
+            FunctionCallOutputContentItem::InputImage {
+                image_url,
+                detail: Some(ImageDetail::Original),
+            },
+            FunctionCallOutputContentItem::InputText {
+                text: "</image>".to_string(),
+            },
+            FunctionCallOutputContentItem::InputText { text: note },
+        ],
+        Some(true),
+    )))
+}
+
+fn prepare_gif(
+    args: &ReadMediaArgs,
+    data: Vec<u8>,
+    width: u32,
+    height: u32,
+) -> Result<PreparedImage, FunctionCallError> {
+    if args.region.is_some() {
+        return Err(FunctionCallError::RespondToModel(format!(
+            "Cannot read region from \"{}\": Cropping is only supported for PNG, JPEG, and WebP images; got image/gif.",
+            args.path
+        )));
+    }
+    if args.full_resolution {
+        if data.len() > FULL_IMAGE_BYTE_BUDGET {
+            return Err(FunctionCallError::RespondToModel(format!(
+                "\"{}\" is {} bytes, over the {}-byte per-image limit, so full_resolution cannot be honored. Use region to view a crop at full fidelity instead.",
+                args.path,
+                data.len(),
+                FULL_IMAGE_BYTE_BUDGET
+            )));
+        }
+        return Ok(PreparedImage {
+            bytes: data,
+            mime_type: "image/gif",
+            width,
+            height,
+            delivery: ImageDelivery::Full,
+        });
+    }
+    if data.len() > READ_IMAGE_BYTE_BUDGET || width > MAX_IMAGE_EDGE || height > MAX_IMAGE_EDGE {
+        return Err(FunctionCallError::RespondToModel(format!(
+            "Image is too large to send safely after compression ({} bytes; limit {READ_IMAGE_BYTE_BUDGET} bytes and {MAX_IMAGE_EDGE}px on the longest edge). The original image was not sent to the model. Do not retry the same file unchanged.",
+            data.len()
+        )));
+    }
+    Ok(PreparedImage {
+        bytes: data,
+        mime_type: "image/gif",
+        width,
+        height,
+        delivery: ImageDelivery::Untouched,
+    })
+}
+
+fn gif_dimensions(data: &[u8]) -> Option<(u32, u32)> {
+    let header = data.get(..10)?;
+    let signature = &header[..6];
+    if signature != b"GIF87a" && signature != b"GIF89a" {
+        return None;
+    }
+    let width = u16::from_le_bytes([header[6], header[7]]).into();
+    let height = u16::from_le_bytes([header[8], header[9]]).into();
+    Some((width, height))
+}
+
+fn prepare_image(
+    args: &ReadMediaArgs,
+    data: Vec<u8>,
+    decoded: DynamicImage,
+    format: ImageFormat,
+    mime_type: &'static str,
+) -> Result<PreparedImage, FunctionCallError> {
+    let (original_width, original_height) = decoded.dimensions();
+    if let Some(requested) = args.region {
+        if data.len() > MAX_IMAGE_DECODE_BYTES {
+            return Err(FunctionCallError::RespondToModel(format!(
+                "Image is too large to process safely for region or full_resolution ({} bytes; safe decode limit {} bytes). The original image was not sent to the model.",
+                data.len(),
+                MAX_IMAGE_DECODE_BYTES
+            )));
+        }
+        if requested.width == 0
+            || requested.height == 0
+            || requested.x >= original_width
+            || requested.y >= original_height
+        {
+            return Err(FunctionCallError::RespondToModel(format!(
+                "Cannot read region from \"{}\": Region (x={}, y={}, width={}, height={}) lies outside the {}x{} image.",
+                args.path,
+                requested.x,
+                requested.y,
+                requested.width,
+                requested.height,
+                original_width,
+                original_height
+            )));
+        }
+        let region = ImageRegion {
+            x: requested.x,
+            y: requested.y,
+            width: requested.width.min(original_width - requested.x),
+            height: requested.height.min(original_height - requested.y),
+        };
+        let crop = decoded.crop_imm(region.x, region.y, region.width, region.height);
+        let (crop, resized) = if args.full_resolution
+            || crop.width() <= MAX_IMAGE_EDGE && crop.height() <= MAX_IMAGE_EDGE
+        {
+            (crop, false)
+        } else {
+            (
+                crop.resize(MAX_IMAGE_EDGE, MAX_IMAGE_EDGE, FilterType::Triangle),
+                true,
+            )
+        };
+        let (bytes, output_mime) = encode_native(&crop, format)?;
+        if bytes.len() > FULL_IMAGE_BYTE_BUDGET {
+            return Err(FunctionCallError::RespondToModel(format!(
+                "Cannot read region from \"{}\": The cropped region encodes to {} bytes, over the {}-byte per-image limit. Choose a smaller region, or allow downscaling.",
+                args.path,
+                bytes.len(),
+                FULL_IMAGE_BYTE_BUDGET
+            )));
+        }
+        return Ok(PreparedImage {
+            width: crop.width(),
+            height: crop.height(),
+            bytes,
+            mime_type: output_mime,
+            delivery: ImageDelivery::Crop { region, resized },
+        });
+    }
+
+    if args.full_resolution {
+        if data.len() > FULL_IMAGE_BYTE_BUDGET {
+            return Err(FunctionCallError::RespondToModel(format!(
+                "\"{}\" is {} bytes, over the {}-byte per-image limit, so full_resolution cannot be honored. Use region to view a crop at full fidelity instead.",
+                args.path,
+                data.len(),
+                FULL_IMAGE_BYTE_BUDGET
+            )));
+        }
+        return Ok(PreparedImage {
+            bytes: data,
+            mime_type,
+            width: original_width,
+            height: original_height,
+            delivery: ImageDelivery::Full,
+        });
+    }
+
+    if data.len() <= READ_IMAGE_BYTE_BUDGET
+        && original_width <= MAX_IMAGE_EDGE
+        && original_height <= MAX_IMAGE_EDGE
+    {
+        return Ok(PreparedImage {
+            bytes: data,
+            mime_type,
+            width: original_width,
+            height: original_height,
+            delivery: ImageDelivery::Untouched,
+        });
+    }
+
+    let resized = decoded.resize(MAX_IMAGE_EDGE, MAX_IMAGE_EDGE, FilterType::Triangle);
+    let (bytes, output_mime, width, height) = encode_with_read_budget(resized, format)?;
+    Ok(PreparedImage {
+        bytes,
+        mime_type: output_mime,
+        width,
+        height,
+        delivery: ImageDelivery::Downsampled,
+    })
+}
+
+fn encode_with_read_budget(
+    image: DynamicImage,
+    source_format: ImageFormat,
+) -> Result<(Vec<u8>, &'static str, u32, u32), FunctionCallError> {
+    let mut candidate = image;
+    let mut fallback_edges = FALLBACK_EDGES.into_iter();
+    loop {
+        if !matches!(source_format, ImageFormat::Jpeg)
+            && (candidate.width() >= 1_000 || candidate.height() >= 1_000)
+        {
+            let png = encode_png(&candidate)?;
+            if png.len() <= READ_IMAGE_BYTE_BUDGET {
+                return Ok((png, "image/png", candidate.width(), candidate.height()));
+            }
+        }
+        for quality in JPEG_QUALITY_STEPS {
+            let jpeg = encode_jpeg(&candidate, quality)?;
+            if jpeg.len() <= READ_IMAGE_BYTE_BUDGET {
+                return Ok((jpeg, "image/jpeg", candidate.width(), candidate.height()));
+            }
+        }
+        let Some(edge) = fallback_edges.next() else {
+            break;
+        };
+        if candidate.width() > edge || candidate.height() > edge {
+            candidate = candidate.resize(edge, edge, FilterType::Triangle);
+        }
+    }
+    Err(FunctionCallError::RespondToModel(format!(
+        "Image is too large to send safely after compression (limit {READ_IMAGE_BYTE_BUDGET} bytes and {MAX_IMAGE_EDGE}px on the longest edge). The original image was not sent to the model. Do not retry the same file unchanged."
+    )))
+}
+
+fn encode_native(
+    image: &DynamicImage,
+    source_format: ImageFormat,
+) -> Result<(Vec<u8>, &'static str), FunctionCallError> {
+    if matches!(source_format, ImageFormat::Jpeg) {
+        Ok((encode_jpeg(image, 90)?, "image/jpeg"))
+    } else {
+        Ok((encode_png(image)?, "image/png"))
+    }
+}
+
+fn encode_png(image: &DynamicImage) -> Result<Vec<u8>, FunctionCallError> {
+    let rgba = image.to_rgba8();
+    let mut bytes = Vec::new();
+    PngEncoder::new(&mut bytes)
+        .write_image(
+            rgba.as_raw(),
+            image.width(),
+            image.height(),
+            image::ExtendedColorType::Rgba8,
+        )
+        .map_err(|error| {
+            FunctionCallError::RespondToModel(format!("Failed to encode image: {error}"))
+        })?;
+    Ok(bytes)
+}
+
+fn encode_jpeg(image: &DynamicImage, quality: u8) -> Result<Vec<u8>, FunctionCallError> {
+    let mut bytes = Vec::new();
+    JpegEncoder::new_with_quality(&mut bytes, quality)
+        .encode_image(image)
+        .map_err(|error| {
+            FunctionCallError::RespondToModel(format!("Failed to encode image: {error}"))
+        })?;
+    Ok(bytes)
+}
+
+fn supported_mime_type(format: ImageFormat) -> Option<&'static str> {
+    match format {
+        ImageFormat::Png => Some("image/png"),
+        ImageFormat::Jpeg => Some("image/jpeg"),
+        ImageFormat::Gif => Some("image/gif"),
+        ImageFormat::WebP => Some("image/webp"),
+        _ => None,
+    }
+}
+
+fn media_note(
+    original_mime: &str,
+    original_size: usize,
+    original_width: u32,
+    original_height: u32,
+    prepared: &PreparedImage,
+) -> String {
+    let mut parts = vec![
+        "Read image file.".to_string(),
+        format!("Mime type: {original_mime}."),
+        format!("Size: {original_size} bytes."),
+        format!("Original dimensions: {original_width}x{original_height} pixels."),
+    ];
+    match prepared.delivery {
+        ImageDelivery::Untouched => {}
+        ImageDelivery::Downsampled => parts.push(format!(
+            "The attached image was downsampled to {}x{} pixels ({}, {} bytes) to fit model limits; fine detail may be lost. To inspect fine detail, call ReadMediaFile again with the region parameter (original-image pixel coordinates) to view a crop at full fidelity.",
+            prepared.width, prepared.height, prepared.mime_type, prepared.bytes.len()
+        )),
+        ImageDelivery::Full => {
+            parts.push("Shown at native resolution; no downscaling applied.".to_string());
+        }
+        ImageDelivery::Crop { region, resized } => {
+            let resolution = if resized {
+                format!(
+                    ", downsampled to {}x{} pixels",
+                    prepared.width, prepared.height
+                )
+            } else {
+                " at native resolution".to_string()
+            };
+            parts.push(format!(
+                "Showing region (x={}, y={}, width={}, height={}) of the original image{resolution}. To output coordinates in original-image pixels, locate them within this crop and add the region offset (x={}, y={}).",
+                region.x, region.y, region.width, region.height, region.x, region.y
+            ));
+        }
+    }
+    if !matches!(prepared.delivery, ImageDelivery::Crop { .. }) {
+        parts.push(
+            "If you need to output coordinates, output relative coordinates first and compute absolute coordinates using the original image size.".to_string(),
+        );
+    }
+    parts.push(
+        "If you generate or edit images or videos via commands or scripts, read the result back immediately before continuing.".to_string(),
+    );
+    format!("<system>{}</system>", parts.join(" "))
+}

--- a/codex-rs/core/src/tools/handlers/mod.rs
+++ b/codex-rs/core/src/tools/handlers/mod.rs
@@ -12,6 +12,7 @@ mod harness_fs;
 mod kimi_code_aliases;
 mod kimi_code_extra;
 mod kimi_code_format;
+mod kimi_code_media;
 mod kimi_code_skill;
 mod list_available_plugins_to_install;
 pub(crate) mod list_available_plugins_to_install_spec;


### PR DESCRIPTION
Fixes Kimi K3 screenshot and image consumption by returning native multimodal ReadMediaFile output. Supports the same provider-safe image set as Kimi Code: PNG, JPEG, GIF, and WebP; adds region and full-resolution reads; applies Kimi-compatible limits and compression fallbacks; rejects unsupported formats before session history is poisoned; and prepares Open Interpreter 0.0.30. Focused core tests, scoped Clippy, and formatting passed locally. GitHub CI is the release gate.