### PR TITLE
Add native Kimi Code video reading

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app_test_support"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "codex-acp-server"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ansi-escape"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "ansi-to-tui",
  "ratatui",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-daemon"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-test-client"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "axum",
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "pretty_assertions",
  "tokio",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "serde",
  "serde_json",
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "codex-bwrap"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "cc",
  "libc",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chat-wire-compat"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bytes",
  "codex-api",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cli"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-config"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-client"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2633,7 +2633,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-mock-client"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "chrono",
  "codex-cloud-tasks-client",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-protocol",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-host"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-protocol",
  "pretty_assertions",
@@ -2686,11 +2686,11 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.0.33"
+version = "0.0.34"
 
 [[package]]
 name = "codex-config"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "codex-config",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors-extension"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-connectors",
  "codex-core-plugins",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-api"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-analytics",
  "codex-app-server-protocol",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy-legacy"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "allocative",
  "anyhow",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-utils-absolute-path",
  "pretty_assertions",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-hooks",
  "pretty_assertions",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -3275,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "notify",
  "pretty_assertions",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "codex-goal-extension"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "codex-home"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bytes",
  "codex-utils-cargo-bin",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-product-info",
  "codex-utils-absolute-path",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "keyring",
  "tracing",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "clap",
  "codex-core",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "codex-lmstudio"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-core",
  "codex-model-provider-info",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-extension"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-config",
  "codex-connectors-extension",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -3631,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "codex-message-history"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-config",
  "memchr",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-api",
  "codex-product-info",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3814,7 +3814,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ollama"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "assert_matches",
  "async-stream",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -3886,14 +3886,14 @@ dependencies = [
 
 [[package]]
 name = "codex-product-info"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "chardetng",
@@ -3949,7 +3949,7 @@ dependencies = [
 
 [[package]]
 name = "codex-realtime-webrtc"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "libwebrtc",
  "thiserror 2.0.18",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "codex-responses-api-proxy"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "axum",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -4068,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "codex-network-proxy",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "age",
  "anyhow",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-core-skills",
  "codex-exec-server",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "codex-stdio-to-uds"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "codex-uds",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "pretty_assertions",
  "tracing",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "codex-test-binary-support"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-arg0",
  "tempfile",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "codex-thread-manager-sample"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "codex-thread-store"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "chrono",
  "codex-git-utils",
@@ -4269,7 +4269,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-code-mode",
  "codex-connectors",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tui"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "async-io",
  "pretty_assertions",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "dirs",
  "dunce",
@@ -4431,14 +4431,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "lru 0.16.3",
  "sha1 0.10.6",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cargo-bin"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "assert_cmd",
  "runfiles",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -4468,15 +4468,15 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-elapsed"
-version = "0.0.33"
+version = "0.0.34"
 
 [[package]]
 name = "codex-utils-fuzzy-match"
-version = "0.0.33"
+version = "0.0.34"
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-product-info",
  "codex-utils-absolute-path",
@@ -4487,7 +4487,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4500,7 +4500,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-oss"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-core",
  "codex-lmstudio",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4528,7 +4528,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-exec-server",
  "codex-utils-absolute-path",
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "assert_matches",
  "thiserror 2.0.18",
@@ -4593,14 +4593,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-sandbox-summary"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-core",
  "codex-model-provider-info",
@@ -4611,7 +4611,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-sleep-inhibitor"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "core-foundation 0.9.4",
  "libc",
@@ -4621,14 +4621,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "pretty_assertions",
  "regex-lite",
@@ -4638,14 +4638,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "codex-v8-poc"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "pretty_assertions",
  "v8",
@@ -4653,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "codex-web-search-extension"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -4673,7 +4673,7 @@ dependencies = [
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "codex-http-client",
  "codex-utils-rustls-provider",
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "core_test_support"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9336,7 +9336,7 @@ dependencies = [
 
 [[package]]
 name = "mcp_test_support"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "codex-login",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -133,7 +133,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.33"
+version = "0.0.34"
 # Track the edition for all workspace crates in one place. Individual
 # crates can still override this value, but keeping it here means new
 # crates created with `cargo new -w ...` automatically inherit the 2024

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -220,7 +220,11 @@ impl ContextManager {
                 let mut replaced = false;
                 let placeholder = placeholder.to_string();
                 for item in content_items.iter_mut() {
-                    if matches!(item, FunctionCallOutputContentItem::InputImage { .. }) {
+                    if matches!(
+                        item,
+                        FunctionCallOutputContentItem::InputImage { .. }
+                            | FunctionCallOutputContentItem::InputVideo { .. }
+                    ) {
                         *item = FunctionCallOutputContentItem::InputText {
                             text: placeholder.clone(),
                         };

--- a/codex-rs/core/src/context_manager/normalize.rs
+++ b/codex-rs/core/src/context_manager/normalize.rs
@@ -345,7 +345,8 @@ pub(crate) fn strip_images_when_unsupported(
                     let mut normalized_content_items = Vec::with_capacity(content_items.len());
                     for content_item in content_items.iter() {
                         match content_item {
-                            FunctionCallOutputContentItem::InputImage { .. } => {
+                            FunctionCallOutputContentItem::InputImage { .. }
+                            | FunctionCallOutputContentItem::InputVideo { .. } => {
                                 normalized_content_items.push(
                                     FunctionCallOutputContentItem::InputText {
                                         text: IMAGE_CONTENT_OMITTED_PLACEHOLDER.to_string(),

--- a/codex-rs/core/src/harness/claude_code.rs
+++ b/codex-rs/core/src/harness/claude_code.rs
@@ -791,6 +791,7 @@ fn tool_result_body_stays_structured(body: &FunctionCallOutputBody) -> bool {
         matches!(
             item,
             FunctionCallOutputContentItem::InputImage { .. }
+                | FunctionCallOutputContentItem::InputVideo { .. }
                 | FunctionCallOutputContentItem::EncryptedContent { .. }
         )
     })
@@ -987,6 +988,10 @@ fn map_tool_result_content_item(
                 }
             })
         }
+        FunctionCallOutputContentItem::InputVideo { .. } => Some(AnthropicToolResultBlock::Text {
+            text: "[video omitted by claude-code harness]".to_string(),
+            cache_control: None,
+        }),
         FunctionCallOutputContentItem::EncryptedContent { .. } => None,
     }
 }

--- a/codex-rs/core/src/harness/kimi_cli.rs
+++ b/codex-rs/core/src/harness/kimi_cli.rs
@@ -884,6 +884,13 @@ fn kimi_output_content_item(item: &FunctionCallOutputContentItem) -> Value {
                 "id": null,
             }
         }),
+        FunctionCallOutputContentItem::InputVideo { video_url, id } => json!({
+            "type": "video_url",
+            "video_url": {
+                "url": video_url,
+                "id": id,
+            }
+        }),
         FunctionCallOutputContentItem::EncryptedContent { .. } => json!({
             "type": "text",
             "text": "<system>Tool returned encrypted content.</system>",

--- a/codex-rs/core/src/harness/kimi_code.rs
+++ b/codex-rs/core/src/harness/kimi_code.rs
@@ -269,6 +269,7 @@ mod tests {
     use super::build_request;
     use crate::client_common::Prompt;
     use codex_protocol::models::ContentItem;
+    use codex_protocol::models::FunctionCallOutputContentItem;
     use codex_protocol::models::FunctionCallOutputPayload;
     use codex_protocol::models::ResponseItem;
     use codex_protocol::openai_models::ModelInfo;
@@ -543,6 +544,84 @@ mod tests {
                         "url": "data:image/png;base64,AAAB",
                         "id": null
                     }
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn kimi_code_request_preserves_captured_video_tool_content() {
+        let prompt = Prompt {
+            input: vec![
+                ResponseItem::Message {
+                    id: Some("user".to_string()),
+                    role: "user".to_string(),
+                    content: vec![ContentItem::InputText {
+                        text: "Read the video.".to_string(),
+                    }],
+                    phase: None,
+                    internal_chat_message_metadata_passthrough: None,
+                },
+                ResponseItem::FunctionCall {
+                    id: None,
+                    name: "ReadMediaFile".to_string(),
+                    namespace: None,
+                    arguments: r#"{"path":"probe.mp4"}"#.to_string(),
+                    call_id: "ReadMediaFile:1".to_string(),
+                    internal_chat_message_metadata_passthrough: None,
+                },
+                ResponseItem::FunctionCallOutput {
+                    id: None,
+                    call_id: "ReadMediaFile:1".to_string(),
+                    output: FunctionCallOutputPayload::from_content_items(vec![
+                        FunctionCallOutputContentItem::InputText {
+                            text: "<video path=\"/workspace/probe.mp4\">".to_string(),
+                        },
+                        FunctionCallOutputContentItem::InputVideo {
+                            video_url: "ms://file-123".to_string(),
+                            id: Some("file-123".to_string()),
+                        },
+                        FunctionCallOutputContentItem::InputText {
+                            text: "</video>".to_string(),
+                        },
+                    ]),
+                    internal_chat_message_metadata_passthrough: None,
+                },
+            ],
+            cwd: Some(std::env::temp_dir()),
+            ..Prompt::default()
+        };
+
+        let (request, _) = build_request(
+            &prompt,
+            &test_model_info(),
+            "kimi-code-video-content-conversation",
+        )
+        .expect("build request");
+        let tool_message = request["messages"]
+            .as_array()
+            .expect("messages array")
+            .iter()
+            .find(|message| message["role"] == json!("tool"))
+            .expect("tool message");
+
+        assert_eq!(
+            tool_message["content"],
+            json!([
+                {
+                    "type": "text",
+                    "text": "<video path=\"/workspace/probe.mp4\">"
+                },
+                {
+                    "type": "video_url",
+                    "video_url": {
+                        "url": "ms://file-123",
+                        "id": "file-123"
+                    }
+                },
+                {
+                    "type": "text",
+                    "text": "</video>"
                 }
             ])
         );

--- a/codex-rs/core/src/harness/mini_swe_agent.rs
+++ b/codex-rs/core/src/harness/mini_swe_agent.rs
@@ -576,6 +576,7 @@ fn mini_swe_agent_tool_output_content(output: &FunctionCallOutputPayload) -> Str
             .filter_map(|item| match item {
                 FunctionCallOutputContentItem::InputText { text } => Some(text.as_str()),
                 FunctionCallOutputContentItem::InputImage { .. }
+                | FunctionCallOutputContentItem::InputVideo { .. }
                 | FunctionCallOutputContentItem::EncryptedContent { .. } => None,
             })
             .collect::<Vec<_>>()

--- a/codex-rs/core/src/harness/minimal.rs
+++ b/codex-rs/core/src/harness/minimal.rs
@@ -343,6 +343,10 @@ fn minimal_tool_output_content(output: &FunctionCallOutputPayload) -> Value {
                 FunctionCallOutputContentItem::InputImage { image_url, detail } => {
                     chat_image_content_part(image_url, *detail)
                 }
+                FunctionCallOutputContentItem::InputVideo { .. } => json!({
+                    "type": "text",
+                    "text": "[video content omitted]",
+                }),
                 FunctionCallOutputContentItem::EncryptedContent { .. } => json!({
                     "type": "text",
                     "text": "[encrypted content omitted]",

--- a/codex-rs/core/src/harness/zcode.rs
+++ b/codex-rs/core/src/harness/zcode.rs
@@ -1038,6 +1038,7 @@ fn map_tool_result_content_item(
                 }
             })
         }
+        FunctionCallOutputContentItem::InputVideo { .. } => None,
         FunctionCallOutputContentItem::EncryptedContent { .. } => None,
     }
 }

--- a/codex-rs/core/src/tools/handlers/kimi_code_media.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_media.rs
@@ -158,7 +158,7 @@ pub(super) async fn handle(
             },
             FunctionCallOutputContentItem::InputText { text: note },
         ],
-        Some(true),
+        /*success*/ Some(true),
     )))
 }
 

--- a/codex-rs/core/src/tools/handlers/kimi_code_media.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_media.rs
@@ -92,6 +92,16 @@ pub(super) async fn handle(
         )));
     }
 
+    if let Some(mime_type) = super::kimi_code_video::mime_type(&path, &data) {
+        let read_mode = if args.region.is_some() || args.full_resolution {
+            super::kimi_code_video::ReadMode::ImageOptionsRequested
+        } else {
+            super::kimi_code_video::ReadMode::Default
+        };
+        return super::kimi_code_video::handle(&invocation, &path, &data, mime_type, read_mode)
+            .await;
+    }
+
     let format = image::guess_format(&data).map_err(|_| {
         FunctionCallError::RespondToModel(format!(
             "\"{}\" is not a supported image or video file. Use Read for text files, or Bash or an MCP tool for other binary formats.",

--- a/codex-rs/core/src/tools/handlers/kimi_code_video.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_video.rs
@@ -147,8 +147,7 @@ fn multipart_body(boundary: &str, filename: &str, mime_type: &str, data: &[u8]) 
     let filename = filename
         .replace('\\', "\\\\")
         .replace('"', "\\\"")
-        .replace('\r', "_")
-        .replace('\n', "_");
+        .replace(['\r', '\n'], "_");
     let mut body = Vec::with_capacity(data.len() + 512);
     body.extend_from_slice(
         format!(

--- a/codex-rs/core/src/tools/handlers/kimi_code_video.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_video.rs
@@ -1,0 +1,234 @@
+use codex_http_client::build_reqwest_client_with_custom_ca;
+use codex_protocol::models::FunctionCallOutputContentItem;
+use serde::Deserialize;
+use std::path::Path;
+use std::time::Duration;
+use uuid::Uuid;
+
+use crate::function_tool::FunctionCallError;
+use crate::tools::context::FunctionToolOutput;
+use crate::tools::context::ToolInvocation;
+use crate::tools::context::ToolOutput;
+use crate::tools::context::boxed_tool_output;
+
+const MEDIA_UPLOAD_TIMEOUT: Duration = Duration::from_secs(60);
+const ASF_HEADER: [u8; 16] = [
+    0x30, 0x26, 0xb2, 0x75, 0x8e, 0x66, 0xcf, 0x11, 0xa6, 0xd9, 0x00, 0xaa, 0x00, 0x62, 0xce, 0x6c,
+];
+
+#[derive(Clone, Copy)]
+pub(super) enum ReadMode {
+    Default,
+    ImageOptionsRequested,
+}
+
+#[derive(Deserialize)]
+struct VideoUploadResponse {
+    id: String,
+}
+
+pub(super) async fn handle(
+    invocation: &ToolInvocation,
+    path: &Path,
+    data: &[u8],
+    mime_type: &'static str,
+    read_mode: ReadMode,
+) -> Result<Box<dyn ToolOutput>, FunctionCallError> {
+    if matches!(read_mode, ReadMode::ImageOptionsRequested) {
+        return Err(FunctionCallError::RespondToModel(
+            "region and full_resolution apply only to image files.".to_string(),
+        ));
+    }
+
+    let base_url = invocation
+        .turn
+        .provider
+        .runtime_base_url()
+        .await
+        .map_err(|error| {
+            FunctionCallError::RespondToModel(format!(
+                "Failed to resolve the video upload endpoint: {error}"
+            ))
+        })?
+        .ok_or_else(|| {
+            FunctionCallError::RespondToModel(
+                "The current provider does not expose a video upload endpoint.".to_string(),
+            )
+        })?;
+    let auth = invocation.turn.provider.api_auth().await.map_err(|error| {
+        FunctionCallError::RespondToModel(format!(
+            "Failed to resolve credentials for video upload: {error}"
+        ))
+    })?;
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("video");
+    let boundary = format!("----open-interpreter-kimi-video-{}", Uuid::new_v4());
+    let body = multipart_body(&boundary, filename, mime_type, data);
+    let client =
+        build_reqwest_client_with_custom_ca(reqwest::Client::builder()).unwrap_or_else(|error| {
+            tracing::warn!(error = %error, "failed to build Kimi video upload client");
+            reqwest::Client::new()
+        });
+    let request = client
+        .post(format!("{}/files", base_url.trim_end_matches('/')))
+        .timeout(MEDIA_UPLOAD_TIMEOUT)
+        .headers(auth.to_auth_headers())
+        .header(
+            reqwest::header::CONTENT_TYPE,
+            format!("multipart/form-data; boundary={boundary}"),
+        )
+        .body(body);
+    let response = tokio::select! {
+        _ = invocation.cancellation_token.cancelled() => {
+            return Err(FunctionCallError::RespondToModel(
+                "Video upload was cancelled.".to_string(),
+            ));
+        }
+        response = request.send() => response,
+    }
+    .map_err(|error| {
+        FunctionCallError::RespondToModel(format!("Failed to upload video: {error}"))
+    })?;
+    let status = response.status();
+    let response_body = response.bytes().await.map_err(|error| {
+        FunctionCallError::RespondToModel(format!(
+            "Failed to read the video upload response: {error}"
+        ))
+    })?;
+    if !status.is_success() {
+        let body = String::from_utf8_lossy(&response_body)
+            .chars()
+            .take(4_096)
+            .collect::<String>();
+        return Err(FunctionCallError::RespondToModel(format!(
+            "Video upload failed with status {status}: {body}"
+        )));
+    }
+    let uploaded: VideoUploadResponse =
+        serde_json::from_slice(&response_body).map_err(|error| {
+            FunctionCallError::RespondToModel(format!(
+                "Failed to decode the video upload response: {error}"
+            ))
+        })?;
+    if uploaded.id.is_empty() {
+        return Err(FunctionCallError::RespondToModel(
+            "The video upload response did not include a file id.".to_string(),
+        ));
+    }
+
+    let absolute_path = path.to_string_lossy();
+    let video_url = format!("ms://{}", uploaded.id);
+    let note = format!(
+        "<system>Read video file. Mime type: {mime_type}. Size: {} bytes. If you generate or edit images or videos via commands or scripts, read the result back immediately before continuing.</system>",
+        data.len()
+    );
+    Ok(boxed_tool_output(FunctionToolOutput::from_content(
+        vec![
+            FunctionCallOutputContentItem::InputText {
+                text: format!("<video path=\"{absolute_path}\">"),
+            },
+            FunctionCallOutputContentItem::InputVideo {
+                video_url,
+                id: Some(uploaded.id),
+            },
+            FunctionCallOutputContentItem::InputText {
+                text: "</video>".to_string(),
+            },
+            FunctionCallOutputContentItem::InputText { text: note },
+        ],
+        Some(true),
+    )))
+}
+
+fn multipart_body(boundary: &str, filename: &str, mime_type: &str, data: &[u8]) -> Vec<u8> {
+    let filename = filename
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\r', "_")
+        .replace('\n', "_");
+    let mut body = Vec::with_capacity(data.len() + 512);
+    body.extend_from_slice(
+        format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{filename}\"\r\nContent-Type: {mime_type}\r\n\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(data);
+    body.extend_from_slice(
+        format!(
+            "\r\n--{boundary}\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nvideo\r\n--{boundary}--\r\n"
+        )
+        .as_bytes(),
+    );
+    body
+}
+
+pub(super) fn mime_type(path: &Path, data: &[u8]) -> Option<&'static str> {
+    sniff_mime_type(data).or_else(|| {
+        let extension = path.extension()?.to_str()?.to_ascii_lowercase();
+        match extension.as_str() {
+            "mp4" => Some("video/mp4"),
+            "mpg" | "mpeg" => Some("video/mpeg"),
+            "mkv" => Some("video/x-matroska"),
+            "avi" => Some("video/x-msvideo"),
+            "mov" => Some("video/quicktime"),
+            "ogv" => Some("video/ogg"),
+            "wmv" => Some("video/x-ms-wmv"),
+            "webm" => Some("video/webm"),
+            "m4v" => Some("video/x-m4v"),
+            "flv" => Some("video/x-flv"),
+            "3gp" => Some("video/3gpp"),
+            "3g2" => Some("video/3gpp2"),
+            _ => None,
+        }
+    })
+}
+
+fn sniff_mime_type(data: &[u8]) -> Option<&'static str> {
+    let header = &data[..data.len().min(512)];
+    if header.starts_with(b"RIFF") && header.get(8..12) == Some(b"AVI ") {
+        return Some("video/x-msvideo");
+    }
+    if header.starts_with(b"FLV") {
+        return Some("video/x-flv");
+    }
+    if header.starts_with(&ASF_HEADER) {
+        return Some("video/x-ms-wmv");
+    }
+    if header.starts_with(&[0x1a, 0x45, 0xdf, 0xa3]) {
+        let lowered = String::from_utf8_lossy(header).to_ascii_lowercase();
+        if lowered.contains("webm") {
+            return Some("video/webm");
+        }
+        if lowered.contains("matroska") {
+            return Some("video/x-matroska");
+        }
+    }
+    if header.get(4..8) == Some(b"ftyp") {
+        let brand = header
+            .get(8..12)?
+            .iter()
+            .copied()
+            .take_while(|byte| !byte.is_ascii_whitespace() && *byte != 0)
+            .map(|byte| byte.to_ascii_lowercase())
+            .collect::<Vec<_>>();
+        return match brand.as_slice() {
+            b"isom" | b"iso2" | b"iso5" | b"mp41" | b"mp42" | b"avc1" | b"mp4v" => {
+                Some("video/mp4")
+            }
+            b"m4v" => Some("video/x-m4v"),
+            b"qt" => Some("video/quicktime"),
+            b"3gp4" | b"3gp5" | b"3gp6" | b"3gp7" => Some("video/3gpp"),
+            b"3g2" => Some("video/3gpp2"),
+            _ => None,
+        };
+    }
+    None
+}
+
+#[cfg(test)]
+#[path = "kimi_code_video_tests.rs"]
+mod tests;

--- a/codex-rs/core/src/tools/handlers/kimi_code_video.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_video.rs
@@ -139,7 +139,7 @@ pub(super) async fn handle(
             },
             FunctionCallOutputContentItem::InputText { text: note },
         ],
-        Some(true),
+        /*success*/ Some(true),
     )))
 }
 

--- a/codex-rs/core/src/tools/handlers/kimi_code_video_tests.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_video_tests.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+#[test]
+fn detection_accepts_every_kimi_code_video_suffix() {
+    for (filename, expected_mime) in [
+        ("sample.mp4", "video/mp4"),
+        ("sample.mpg", "video/mpeg"),
+        ("sample.mpeg", "video/mpeg"),
+        ("sample.mkv", "video/x-matroska"),
+        ("sample.avi", "video/x-msvideo"),
+        ("sample.mov", "video/quicktime"),
+        ("sample.ogv", "video/ogg"),
+        ("sample.wmv", "video/x-ms-wmv"),
+        ("sample.webm", "video/webm"),
+        ("sample.m4v", "video/x-m4v"),
+        ("sample.flv", "video/x-flv"),
+        ("sample.3gp", "video/3gpp"),
+        ("sample.3g2", "video/3gpp2"),
+    ] {
+        assert_eq!(
+            mime_type(Path::new(filename), b"no recognizable magic"),
+            Some(expected_mime),
+            "unexpected MIME for {filename}"
+        );
+    }
+}
+
+#[test]
+fn detection_prefers_captured_mp4_magic_over_the_suffix() {
+    let mut header = vec![0, 0, 0, 24];
+    header.extend_from_slice(b"ftypisom");
+
+    assert_eq!(
+        mime_type(Path::new("sample.bin"), &header),
+        Some("video/mp4")
+    );
+}
+
+#[test]
+fn multipart_body_matches_the_captured_file_and_purpose_parts() {
+    let body = multipart_body("boundary", "probe.mp4", "video/mp4", b"video-bytes");
+    let body = String::from_utf8(body).expect("multipart fixture is UTF-8");
+
+    assert_eq!(
+        body,
+        "--boundary\r\nContent-Disposition: form-data; name=\"file\"; filename=\"probe.mp4\"\r\nContent-Type: video/mp4\r\n\r\nvideo-bytes\r\n--boundary\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nvideo\r\n--boundary--\r\n"
+    );
+}

--- a/codex-rs/core/src/tools/handlers/mod.rs
+++ b/codex-rs/core/src/tools/handlers/mod.rs
@@ -15,6 +15,7 @@ mod kimi_code_extra;
 mod kimi_code_format;
 mod kimi_code_media;
 mod kimi_code_skill;
+mod kimi_code_video;
 mod list_available_plugins_to_install;
 pub(crate) mod list_available_plugins_to_install_spec;
 mod mcp;

--- a/codex-rs/ext/image-generation/src/tool.rs
+++ b/codex-rs/ext/image-generation/src/tool.rs
@@ -417,6 +417,7 @@ fn output_image_urls(output: &FunctionCallOutputPayload) -> impl Iterator<Item =
         .filter_map(|item| match item {
             FunctionCallOutputContentItem::InputImage { image_url, .. } => Some(image_url.clone()),
             FunctionCallOutputContentItem::InputText { .. }
+            | FunctionCallOutputContentItem::InputVideo { .. }
             | FunctionCallOutputContentItem::EncryptedContent { .. } => None,
         })
 }

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -1803,8 +1803,10 @@ pub struct ShellCommandToolCallParams {
     pub justification: Option<String>,
 }
 
-/// Responses API compatible content items that can be returned by a tool call.
-/// This is a subset of ContentItem with the types we support as function call outputs.
+/// Structured content items that can be returned by a tool call.
+///
+/// Most variants map directly to Responses API content. Harness adapters may
+/// translate additional media variants into their provider-specific wire shape.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema, TS)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum FunctionCallOutputContentItem {
@@ -1819,6 +1821,12 @@ pub enum FunctionCallOutputContentItem {
         #[ts(optional)]
         detail: Option<ImageDetail>,
     },
+    InputVideo {
+        video_url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        id: Option<String>,
+    },
     EncryptedContent {
         encrypted_content: String,
     },
@@ -1829,7 +1837,7 @@ pub enum FunctionCallOutputContentItem {
 ///
 /// This conversion is intentionally lossy:
 /// - only `input_text` items are included
-/// - image items are ignored
+/// - media items are ignored
 ///
 /// We use this helper where callers still need a string representation (for
 /// example telemetry previews or legacy string-only output paths) while keeping
@@ -1846,6 +1854,7 @@ pub fn function_call_output_content_items_to_text(
             }
             FunctionCallOutputContentItem::InputText { .. }
             | FunctionCallOutputContentItem::InputImage { .. }
+            | FunctionCallOutputContentItem::InputVideo { .. }
             | FunctionCallOutputContentItem::EncryptedContent { .. } => None,
         })
         .collect::<Vec<_>>();

--- a/codex-rs/tools/src/tool_output.rs
+++ b/codex-rs/tools/src/tool_output.rs
@@ -233,8 +233,14 @@ fn content_items_to_code_mode_result(items: &[FunctionCallOutputContentItem]) ->
                 {
                     Some(image_url.clone())
                 }
+                FunctionCallOutputContentItem::InputVideo { video_url, .. }
+                    if !video_url.trim().is_empty() =>
+                {
+                    Some(video_url.clone())
+                }
                 FunctionCallOutputContentItem::InputText { .. }
                 | FunctionCallOutputContentItem::InputImage { .. }
+                | FunctionCallOutputContentItem::InputVideo { .. }
                 | FunctionCallOutputContentItem::EncryptedContent { .. } => None,
             })
             .collect::<Vec<_>>()

--- a/codex-rs/utils/output-truncation/src/lib.rs
+++ b/codex-rs/utils/output-truncation/src/lib.rs
@@ -38,6 +38,7 @@ pub fn formatted_truncate_text_content_items_with_policy(
         .filter_map(|item| match item {
             FunctionCallOutputContentItem::InputText { text } => Some(text.as_str()),
             FunctionCallOutputContentItem::InputImage { .. }
+            | FunctionCallOutputContentItem::InputVideo { .. }
             | FunctionCallOutputContentItem::EncryptedContent { .. } => None,
         })
         .collect::<Vec<_>>();
@@ -67,6 +68,12 @@ pub fn formatted_truncate_text_content_items_with_policy(
             Some(FunctionCallOutputContentItem::InputImage {
                 image_url: image_url.clone(),
                 detail: *detail,
+            })
+        }
+        FunctionCallOutputContentItem::InputVideo { video_url, id } => {
+            Some(FunctionCallOutputContentItem::InputVideo {
+                video_url: video_url.clone(),
+                id: id.clone(),
             })
         }
         FunctionCallOutputContentItem::EncryptedContent { encrypted_content } => {
@@ -125,6 +132,12 @@ pub fn truncate_function_output_items_with_policy(
                 out.push(FunctionCallOutputContentItem::InputImage {
                     image_url: image_url.clone(),
                     detail: *detail,
+                });
+            }
+            FunctionCallOutputContentItem::InputVideo { video_url, id } => {
+                out.push(FunctionCallOutputContentItem::InputVideo {
+                    video_url: video_url.clone(),
+                    id: id.clone(),
                 });
             }
             FunctionCallOutputContentItem::EncryptedContent { encrypted_content } => {


### PR DESCRIPTION
## Summary

- add native Rust Kimi Code video upload and tool-result behavior
- support every video container exposed by the Kimi Code `ReadMediaFile` tool
- preserve structured video content through history, truncation, and harness adapters
- bump Open Interpreter to 0.0.34 for release

## Validation

- focused MIME, multipart, and request serialization tests included
- GitHub CI validates the branch