### PR TITLE
Release Open Interpreter 0.0.35

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app_test_support"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "codex-acp-server"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ansi-escape"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "ansi-to-tui",
  "ratatui",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-daemon"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-test-client"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "axum",
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "pretty_assertions",
  "tokio",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "serde",
  "serde_json",
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "codex-bwrap"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "cc",
  "libc",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chat-wire-compat"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "bytes",
  "codex-api",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cli"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-config"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-client"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2633,7 +2633,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-mock-client"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "chrono",
  "codex-cloud-tasks-client",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-protocol",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-host"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-protocol",
  "pretty_assertions",
@@ -2686,11 +2686,11 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.0.34"
+version = "0.0.35"
 
 [[package]]
 name = "codex-config"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "codex-config",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors-extension"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-connectors",
  "codex-core-plugins",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-api"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-analytics",
  "codex-app-server-protocol",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy-legacy"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "allocative",
  "anyhow",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-utils-absolute-path",
  "pretty_assertions",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-hooks",
  "pretty_assertions",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -3275,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "notify",
  "pretty_assertions",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "codex-goal-extension"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "codex-home"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "bytes",
  "codex-utils-cargo-bin",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-product-info",
  "codex-utils-absolute-path",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "keyring",
  "tracing",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "clap",
  "codex-core",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "codex-lmstudio"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-core",
  "codex-model-provider-info",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-extension"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-config",
  "codex-connectors-extension",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -3631,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "codex-message-history"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-config",
  "memchr",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-api",
  "codex-product-info",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3814,7 +3814,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ollama"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "assert_matches",
  "async-stream",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -3886,14 +3886,14 @@ dependencies = [
 
 [[package]]
 name = "codex-product-info"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "chardetng",
@@ -3949,7 +3949,7 @@ dependencies = [
 
 [[package]]
 name = "codex-realtime-webrtc"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "libwebrtc",
  "thiserror 2.0.18",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "codex-responses-api-proxy"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "axum",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -4068,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "codex-network-proxy",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "age",
  "anyhow",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-core-skills",
  "codex-exec-server",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "codex-stdio-to-uds"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "codex-uds",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "pretty_assertions",
  "tracing",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "codex-test-binary-support"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-arg0",
  "tempfile",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "codex-thread-manager-sample"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "codex-thread-store"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "chrono",
  "codex-git-utils",
@@ -4269,7 +4269,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-code-mode",
  "codex-connectors",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tui"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "async-io",
  "pretty_assertions",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "dirs",
  "dunce",
@@ -4431,14 +4431,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "lru 0.16.3",
  "sha1 0.10.6",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cargo-bin"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "assert_cmd",
  "runfiles",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -4468,15 +4468,15 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-elapsed"
-version = "0.0.34"
+version = "0.0.35"
 
 [[package]]
 name = "codex-utils-fuzzy-match"
-version = "0.0.34"
+version = "0.0.35"
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-product-info",
  "codex-utils-absolute-path",
@@ -4487,7 +4487,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4500,7 +4500,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-oss"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-core",
  "codex-lmstudio",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4528,7 +4528,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-exec-server",
  "codex-utils-absolute-path",
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "assert_matches",
  "thiserror 2.0.18",
@@ -4593,14 +4593,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-sandbox-summary"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-core",
  "codex-model-provider-info",
@@ -4611,7 +4611,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-sleep-inhibitor"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "core-foundation 0.9.4",
  "libc",
@@ -4621,14 +4621,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "pretty_assertions",
  "regex-lite",
@@ -4638,14 +4638,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "codex-v8-poc"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "pretty_assertions",
  "v8",
@@ -4653,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "codex-web-search-extension"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -4673,7 +4673,7 @@ dependencies = [
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "codex-http-client",
  "codex-utils-rustls-provider",
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "core_test_support"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9336,7 +9336,7 @@ dependencies = [
 
 [[package]]
 name = "mcp_test_support"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "codex-login",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -133,7 +133,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.34"
+version = "0.0.35"
 # Track the edition for all workspace crates in one place. Individual
 # crates can still override this value, but keeping it here means new
 # crates created with `cargo new -w ...` automatically inherit the 2024

--- a/codex-rs/core/src/harness/claude_code.rs
+++ b/codex-rs/core/src/harness/claude_code.rs
@@ -494,7 +494,7 @@ fn current_local_date() -> chrono::NaiveDate {
 enum ClaudeCodeSkillsRendering {
     /// Child-agent requests: the parent session already owns skill routing.
     Omit,
-    /// Full profile: reshape into the captured `<system-reminder>` Skill-tool
+    /// Full profile: reshape into the provider-compatible `<system-reminder>` Skill-tool
     /// list (`- name: description`).
     SkillToolReminder,
     /// Bare profile: no Skill tool exists, so pass the native
@@ -1649,14 +1649,14 @@ fn build_tools(
             .iter()
             .map(|tool| tool.name.as_str())
             .collect::<HashSet<_>>();
-        tools.extend(reference_claude_supplemental_tools(
+        tools.extend(claude_code_supplemental_tools(
             &existing_names,
             is_child_agent_request,
             allowed_names.as_ref(),
         )?);
     }
     if !profile.is_bare() {
-        normalize_reference_claude_tool_descriptions(&mut tools);
+        normalize_claude_code_tool_descriptions(&mut tools);
     }
     tools.sort_by_key(|tool| match tool.name.as_str() {
         "Agent" => 0,
@@ -2008,7 +2008,7 @@ Usage:
 - NEVER create documentation files (*.md) or README files unless explicitly requested by the User.
 - Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked."#;
 
-fn normalize_reference_claude_tool_descriptions(tools: &mut [AnthropicTool]) {
+fn normalize_claude_code_tool_descriptions(tools: &mut [AnthropicTool]) {
     for tool in tools {
         match tool.name.as_str() {
             "Agent" => {
@@ -2291,7 +2291,7 @@ fn month_name(month: u32) -> &'static str {
     }
 }
 
-fn reference_claude_supplemental_tools(
+fn claude_code_supplemental_tools(
     existing_names: &HashSet<&str>,
     is_child_agent_request: bool,
     allowed_names: Option<&HashSet<String>>,

--- a/codex-rs/core/src/harness/kimi_cli.rs
+++ b/codex-rs/core/src/harness/kimi_cli.rs
@@ -278,11 +278,8 @@ pub(super) fn build_messages_with_options(
                             pending_assistant_content = Some(message_content);
                             continue;
                         }
-                        discard_unanswered_tool_calls(
-                            &mut pending_tool_calls,
-                            &mut awaiting_tool_call_ids,
-                            &mut pending_reasoning_content,
-                        );
+                        pending_tool_calls.clear();
+                        awaiting_tool_call_ids.clear();
                         if options.merge_assistant_text_with_following_tool_calls {
                             push_pending_assistant_content(
                                 &mut messages,
@@ -1531,7 +1528,7 @@ mod tests {
             ResponseItem::Reasoning {
                 id: Some("reasoning-1".to_string()),
                 summary: Vec::new(),
-                content: Some(vec![ReasoningItemContent::Text {
+                content: Some(vec![ReasoningItemContent::ReasoningText {
                     text: "I should create the goal first.".to_string(),
                 }]),
                 encrypted_content: None,

--- a/codex-rs/core/src/harness/kimi_cli.rs
+++ b/codex-rs/core/src/harness/kimi_cli.rs
@@ -229,7 +229,7 @@ impl MessageBuildOptions {
         Self {
             omitted_reasoning_placeholder: None,
             compact_function_arguments: true,
-            merge_assistant_text_with_following_tool_calls: false,
+            merge_assistant_text_with_following_tool_calls: true,
             preserve_empty_reasoning_content: true,
             preserve_empty_tool_output: false,
             trim_user_message_trailing_newlines: false,
@@ -1520,6 +1520,73 @@ mod tests {
                     "role": "tool",
                     "content": "{}",
                     "tool_call_id": "GetGoal_0",
+                }),
+            ]
+        );
+    }
+
+    #[test]
+    fn kimi_code_combines_reasoning_text_and_tool_calls_in_one_assistant_message() {
+        let items = vec![
+            ResponseItem::Reasoning {
+                id: Some("reasoning-1".to_string()),
+                summary: Vec::new(),
+                content: Some(vec![ReasoningItemContent::Text {
+                    text: "I should create the goal first.".to_string(),
+                }]),
+                encrypted_content: None,
+                internal_chat_message_metadata_passthrough: None,
+            },
+            ResponseItem::Message {
+                id: Some("message-1".to_string()),
+                role: "assistant".to_string(),
+                content: vec![ContentItem::OutputText {
+                    text: "Starting with CreateGoal.".to_string(),
+                }],
+                phase: None,
+                internal_chat_message_metadata_passthrough: None,
+            },
+            ResponseItem::FunctionCall {
+                id: Some("function-1".to_string()),
+                name: "CreateGoal".to_string(),
+                namespace: None,
+                arguments: r#"{"objective":"Ship it"}"#.to_string(),
+                call_id: "CreateGoal:0".to_string(),
+                internal_chat_message_metadata_passthrough: None,
+            },
+            ResponseItem::FunctionCallOutput {
+                id: None,
+                call_id: "CreateGoal:0".to_string(),
+                output: FunctionCallOutputPayload::from_text("created".to_string()),
+                internal_chat_message_metadata_passthrough: None,
+            },
+        ];
+
+        let messages =
+            super::build_messages_with_options(&items, super::MessageBuildOptions::kimi_code())
+                .expect("build messages")
+                .collect::<Vec<_>>();
+
+        assert_eq!(
+            messages,
+            vec![
+                json!({
+                    "role": "assistant",
+                    "content": "Starting with CreateGoal.",
+                    "reasoning_content": "I should create the goal first.",
+                    "tool_calls": [{
+                        "type": "function",
+                        "id": "CreateGoal_0",
+                        "function": {
+                            "name": "CreateGoal",
+                            "arguments": r#"{"objective":"Ship it"}"#,
+                        },
+                    }],
+                }),
+                json!({
+                    "role": "tool",
+                    "content": "created",
+                    "tool_call_id": "CreateGoal_0",
                 }),
             ]
         );

--- a/codex-rs/core/src/harness/kimi_code.rs
+++ b/codex-rs/core/src/harness/kimi_code.rs
@@ -1,10 +1,15 @@
 use crate::client_common::Prompt;
+use crate::client_common::ResponseEvent;
+use crate::client_common::ResponseStream;
 use crate::harness::kimi_cli;
 use crate::harness::session_skills::SessionSkill;
 use crate::harness::session_skills::parse_session_skills;
 use codex_chat_wire_compat::ToolKinds;
 use codex_chat_wire_compat::ToolOutputKind;
+use codex_protocol::models::ReasoningItemContent;
+use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::ModelInfo;
+use futures::StreamExt;
 use serde_json::Value;
 use serde_json::json;
 use std::collections::BTreeMap;
@@ -16,6 +21,7 @@ use std::hash::Hasher;
 use std::path::Path;
 use std::sync::LazyLock;
 use std::sync::Mutex;
+use tokio::sync::mpsc;
 
 const KIMI_CODE_SYSTEM_PROMPT: &str = include_str!("kimi_code_system_prompt.md");
 const KIMI_CODE_TOOLS: &str = include_str!("kimi_code_tools.json");
@@ -77,6 +83,48 @@ pub(crate) fn build_request(
         }),
         tool_kinds,
     ))
+}
+
+/// Keeps Kimi reasoning available for the assistant tool-call message that is
+/// sent on the next provider request.
+pub(crate) fn preserve_reasoning_content(stream: ResponseStream) -> ResponseStream {
+    let (tx_event, rx_event) = mpsc::channel(1600);
+
+    tokio::spawn(async move {
+        let mut stream = stream;
+        while let Some(mut event) = stream.next().await {
+            if let Ok(ResponseEvent::OutputItemAdded(item) | ResponseEvent::OutputItemDone(item)) =
+                &mut event
+            {
+                make_reasoning_content_durable(item);
+            }
+            if tx_event.send(event).await.is_err() {
+                return;
+            }
+        }
+    });
+
+    ResponseStream {
+        rx_event,
+        consumer_dropped: tokio_util::sync::CancellationToken::new(),
+    }
+}
+
+fn make_reasoning_content_durable(item: &mut ResponseItem) {
+    let ResponseItem::Reasoning {
+        content: Some(content),
+        ..
+    } = item
+    else {
+        return;
+    };
+    for part in content {
+        if let ReasoningItemContent::ReasoningText { text } = part {
+            *part = ReasoningItemContent::Text {
+                text: std::mem::take(text),
+            };
+        }
+    }
 }
 
 fn kimi_code_prompt_cache_key(conversation_id: &str) -> String {
@@ -293,14 +341,57 @@ fn build_tools() -> Vec<Value> {
 #[cfg(test)]
 mod tests {
     use super::build_request;
+    use super::make_reasoning_content_durable;
     use super::session_skills_listing;
     use crate::client_common::Prompt;
     use codex_protocol::models::ContentItem;
     use codex_protocol::models::FunctionCallOutputContentItem;
     use codex_protocol::models::FunctionCallOutputPayload;
+    use codex_protocol::models::ReasoningItemContent;
     use codex_protocol::models::ResponseItem;
     use codex_protocol::openai_models::ModelInfo;
     use serde_json::json;
+
+    #[test]
+    fn kimi_code_reasoning_content_remains_serializable_for_follow_up_requests() {
+        let mut item = ResponseItem::Reasoning {
+            id: Some("reasoning-1".to_string()),
+            summary: Vec::new(),
+            content: Some(vec![ReasoningItemContent::ReasoningText {
+                text: "Use the requested tool.".to_string(),
+            }]),
+            encrypted_content: None,
+            internal_chat_message_metadata_passthrough: None,
+        };
+
+        make_reasoning_content_durable(&mut item);
+
+        assert_eq!(
+            item,
+            ResponseItem::Reasoning {
+                id: Some("reasoning-1".to_string()),
+                summary: Vec::new(),
+                content: Some(vec![ReasoningItemContent::Text {
+                    text: "Use the requested tool.".to_string(),
+                }]),
+                encrypted_content: None,
+                internal_chat_message_metadata_passthrough: None,
+            }
+        );
+        assert_eq!(
+            serde_json::to_value(&item).expect("serialize reasoning"),
+            json!({
+                "type": "reasoning",
+                "id": "reasoning-1",
+                "summary": [],
+                "content": [{
+                    "type": "text",
+                    "text": "Use the requested tool.",
+                }],
+                "encrypted_content": null,
+            })
+        );
+    }
 
     #[test]
     fn kimi_code_request_renders_kimi_code_builtin_skills() {

--- a/codex-rs/core/src/harness/kimi_code.rs
+++ b/codex-rs/core/src/harness/kimi_code.rs
@@ -1,15 +1,10 @@
 use crate::client_common::Prompt;
-use crate::client_common::ResponseEvent;
-use crate::client_common::ResponseStream;
 use crate::harness::kimi_cli;
 use crate::harness::session_skills::SessionSkill;
 use crate::harness::session_skills::parse_session_skills;
 use codex_chat_wire_compat::ToolKinds;
 use codex_chat_wire_compat::ToolOutputKind;
-use codex_protocol::models::ReasoningItemContent;
-use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::ModelInfo;
-use futures::StreamExt;
 use serde_json::Value;
 use serde_json::json;
 use std::collections::BTreeMap;
@@ -21,7 +16,6 @@ use std::hash::Hasher;
 use std::path::Path;
 use std::sync::LazyLock;
 use std::sync::Mutex;
-use tokio::sync::mpsc;
 
 const KIMI_CODE_SYSTEM_PROMPT: &str = include_str!("kimi_code_system_prompt.md");
 const KIMI_CODE_TOOLS: &str = include_str!("kimi_code_tools.json");
@@ -83,48 +77,6 @@ pub(crate) fn build_request(
         }),
         tool_kinds,
     ))
-}
-
-/// Keeps Kimi reasoning available for the assistant tool-call message that is
-/// sent on the next provider request.
-pub(crate) fn preserve_reasoning_content(stream: ResponseStream) -> ResponseStream {
-    let (tx_event, rx_event) = mpsc::channel(1600);
-
-    tokio::spawn(async move {
-        let mut stream = stream;
-        while let Some(mut event) = stream.next().await {
-            if let Ok(ResponseEvent::OutputItemAdded(item) | ResponseEvent::OutputItemDone(item)) =
-                &mut event
-            {
-                make_reasoning_content_durable(item);
-            }
-            if tx_event.send(event).await.is_err() {
-                return;
-            }
-        }
-    });
-
-    ResponseStream {
-        rx_event,
-        consumer_dropped: tokio_util::sync::CancellationToken::new(),
-    }
-}
-
-fn make_reasoning_content_durable(item: &mut ResponseItem) {
-    let ResponseItem::Reasoning {
-        content: Some(content),
-        ..
-    } = item
-    else {
-        return;
-    };
-    for part in content {
-        if let ReasoningItemContent::ReasoningText { text } = part {
-            *part = ReasoningItemContent::Text {
-                text: std::mem::take(text),
-            };
-        }
-    }
 }
 
 fn kimi_code_prompt_cache_key(conversation_id: &str) -> String {
@@ -342,57 +294,14 @@ fn build_tools() -> Vec<Value> {
 #[cfg(test)]
 mod tests {
     use super::build_request;
-    use super::make_reasoning_content_durable;
     use super::session_skills_listing;
     use crate::client_common::Prompt;
     use codex_protocol::models::ContentItem;
     use codex_protocol::models::FunctionCallOutputContentItem;
     use codex_protocol::models::FunctionCallOutputPayload;
-    use codex_protocol::models::ReasoningItemContent;
     use codex_protocol::models::ResponseItem;
     use codex_protocol::openai_models::ModelInfo;
     use serde_json::json;
-
-    #[test]
-    fn kimi_code_reasoning_content_remains_serializable_for_follow_up_requests() {
-        let mut item = ResponseItem::Reasoning {
-            id: Some("reasoning-1".to_string()),
-            summary: Vec::new(),
-            content: Some(vec![ReasoningItemContent::ReasoningText {
-                text: "Use the requested tool.".to_string(),
-            }]),
-            encrypted_content: None,
-            internal_chat_message_metadata_passthrough: None,
-        };
-
-        make_reasoning_content_durable(&mut item);
-
-        assert_eq!(
-            item,
-            ResponseItem::Reasoning {
-                id: Some("reasoning-1".to_string()),
-                summary: Vec::new(),
-                content: Some(vec![ReasoningItemContent::Text {
-                    text: "Use the requested tool.".to_string(),
-                }]),
-                encrypted_content: None,
-                internal_chat_message_metadata_passthrough: None,
-            }
-        );
-        assert_eq!(
-            serde_json::to_value(&item).expect("serialize reasoning"),
-            json!({
-                "type": "reasoning",
-                "id": "reasoning-1",
-                "summary": [],
-                "content": [{
-                    "type": "text",
-                    "text": "Use the requested tool.",
-                }],
-                "encrypted_content": null,
-            })
-        );
-    }
 
     #[test]
     fn kimi_code_request_renders_kimi_code_builtin_skills() {

--- a/codex-rs/core/src/harness/kimi_code.rs
+++ b/codex-rs/core/src/harness/kimi_code.rs
@@ -216,6 +216,7 @@ fn build_system_prompt(prompt: &Prompt, skills: &str) -> String {
     let cwd = prompt.cwd.as_deref().unwrap_or_else(|| Path::new("."));
     let listing = kimi_work_dir_listing(cwd);
     KIMI_CODE_SYSTEM_PROMPT
+        .replace("\r\n", "\n")
         .replace(
             "{% if KIMI_OS == \"Windows\" %}\n\nIMPORTANT: You are on Windows. The Bash tool runs through Git Bash, so use Unix shell syntax inside Bash commands — `/dev/null` not `NUL`, and forward slashes in paths. For file operations, always prefer the built-in tools (Read, Write, Edit, Glob, Grep) over Bash commands — they work reliably across all platforms.\n{% endif %}",
             "",
@@ -425,6 +426,7 @@ mod tests {
         assert!(system.contains("- update-config: Inspect or edit kimi-code's own config"));
         assert!(system.contains("Path: builtin://update-config"));
         assert!(system.contains("- write-goal:"));
+        assert!(!system.contains('\r'));
         assert!(!system.contains("{{ KIMI_SKILLS }}"));
         assert!(!system.contains("{% if KIMI_SKILLS %}"));
         assert!(!system.contains("<skills_instructions>"));

--- a/codex-rs/core/src/harness/kimi_code.rs
+++ b/codex-rs/core/src/harness/kimi_code.rs
@@ -565,7 +565,7 @@ mod tests {
     }
 
     #[test]
-    fn kimi_code_request_deduplicates_and_truncates_project_skills_like_reference() {
+    fn kimi_code_request_deduplicates_and_truncates_project_skills() {
         let description = "x".repeat(251);
         let skills = format!(
             "<skills_instructions>\n## Skills\n### Available skills\n- qa-testing: {description} (file: /home/user/.openinterpreter/skills/.system/qa-testing/SKILL.md)\n- qa-testing: {description} (file: /workspace/.agents/skills/qa-testing/SKILL.md)\n### How to use skills\n- Discovery: ...\n</skills_instructions>"

--- a/codex-rs/core/src/harness/kimi_code.rs
+++ b/codex-rs/core/src/harness/kimi_code.rs
@@ -1,11 +1,13 @@
 use crate::client_common::Prompt;
 use crate::harness::kimi_cli;
+use crate::harness::session_skills::SessionSkill;
 use crate::harness::session_skills::parse_session_skills;
 use codex_chat_wire_compat::ToolKinds;
 use codex_chat_wire_compat::ToolOutputKind;
 use codex_protocol::openai_models::ModelInfo;
 use serde_json::Value;
 use serde_json::json;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::hash::DefaultHasher;
@@ -18,8 +20,9 @@ use std::sync::Mutex;
 const KIMI_CODE_SYSTEM_PROMPT: &str = include_str!("kimi_code_system_prompt.md");
 const KIMI_CODE_TOOLS: &str = include_str!("kimi_code_tools.json");
 const KIMI_CODE_AUTO_PERMISSION_REMINDER: &str = "<system-reminder>\nAuto permission mode is active. Tool approvals will be handled automatically while this mode remains enabled.\n  - Continue normally without pausing for approval prompts.\n  - Do NOT call AskUserQuestion while auto mode is active. Make a reasonable decision and continue without asking the user.\n  - ExitPlanMode is also approved automatically, without the user reviewing the plan. An auto-approved plan is NOT a signal from the user to start executing — follow the user's original instructions on whether to proceed.\n</system-reminder>";
-const KIMI_CODE_BUILTIN_SKILLS: &str = r#"DISREGARD any earlier skill listings. Current available skills:
-### Built-in
+const KIMI_CODE_SKILLS_HEADER: &str =
+    "DISREGARD any earlier skill listings. Current available skills:";
+const KIMI_CODE_BUILTIN_SKILLS: &str = r#"### Built-in
 - check-kimi-code-docs: Answer questions about the Kimi Code product using the official documentation — CLI usage, configuration, slash commands, features, membership and quota, API onboarding, third-party tool setup, and error codes. Use when the user asks how Kimi Code w…
   Path: builtin://check-kimi-code-docs
 - update-config: Inspect or edit kimi-code's own config — `config.toml` (model, provider, permission, hooks) and `tui.toml` (theme, editor, notifications, auto-update). Use when the user asks what a setting does or wants to change one.
@@ -102,18 +105,41 @@ fn cached_system_prompt(prompt: &Prompt, conversation_id: &str) -> String {
 /// Renders Kimi Code's source-backed model-facing skill listing.
 fn session_skills_listing(prompt: &Prompt) -> String {
     let session_skills = parse_session_skills(&prompt.input);
-    let mut listing = KIMI_CODE_BUILTIN_SKILLS.to_string();
+    let mut listing = KIMI_CODE_SKILLS_HEADER.to_string();
     if !session_skills.is_empty() {
-        listing.push_str("\n### Open Interpreter");
+        let mut skills_by_name: BTreeMap<String, SessionSkill> = BTreeMap::new();
         for skill in session_skills {
+            let prefer_skill = skills_by_name.get(&skill.name).is_none_or(|current| {
+                !current.path.contains("/.agents/skills/")
+                    && skill.path.contains("/.agents/skills/")
+            });
+            if prefer_skill {
+                skills_by_name.insert(skill.name.clone(), skill);
+            }
+        }
+        listing.push_str("\n### Project");
+        for skill in skills_by_name.into_values() {
             let _ = write!(
                 listing,
                 "\n- {}: {}\n  Path: {}",
-                skill.name, skill.description, skill.path
+                skill.name,
+                kimi_code_skill_description(&skill.description),
+                skill.path
             );
         }
     }
+    listing.push('\n');
+    listing.push_str(KIMI_CODE_BUILTIN_SKILLS);
     listing
+}
+
+fn kimi_code_skill_description(description: &str) -> String {
+    if description.chars().count() <= 250 {
+        return description.to_string();
+    }
+    let mut truncated = description.chars().take(249).collect::<String>();
+    truncated.push('…');
+    truncated
 }
 
 fn add_auto_permission_reminders(messages: Vec<Value>) -> Vec<Value> {
@@ -267,6 +293,7 @@ fn build_tools() -> Vec<Value> {
 #[cfg(test)]
 mod tests {
     use super::build_request;
+    use super::session_skills_listing;
     use crate::client_common::Prompt;
     use codex_protocol::models::ContentItem;
     use codex_protocol::models::FunctionCallOutputContentItem;
@@ -438,12 +465,41 @@ mod tests {
             .as_str()
             .expect("system content");
         assert!(!system.contains("{{ KIMI_SKILLS }}"));
-        assert!(system.contains("### Open Interpreter"));
+        assert!(system.contains("### Project"));
         assert!(
             system.contains("- qa-testing: Run the project's QA test plan against a live build")
         );
         assert!(system.contains("Path: /home/user/skills/.system/qa-testing/SKILL.md"));
         assert!(!system.contains("<skills_instructions>"));
+    }
+
+    #[test]
+    fn kimi_code_request_deduplicates_and_truncates_project_skills_like_reference() {
+        let description = "x".repeat(251);
+        let skills = format!(
+            "<skills_instructions>\n## Skills\n### Available skills\n- qa-testing: {description} (file: /home/user/.openinterpreter/skills/.system/qa-testing/SKILL.md)\n- qa-testing: {description} (file: /workspace/.agents/skills/qa-testing/SKILL.md)\n### How to use skills\n- Discovery: ...\n</skills_instructions>"
+        );
+        let prompt = Prompt {
+            input: vec![ResponseItem::Message {
+                id: Some("developer".to_string()),
+                role: "developer".to_string(),
+                content: vec![ContentItem::InputText { text: skills }],
+                phase: None,
+                internal_chat_message_metadata_passthrough: None,
+            }],
+            ..Prompt::default()
+        };
+
+        let listing = session_skills_listing(&prompt);
+
+        assert_eq!(listing.matches("- qa-testing:").count(), 1);
+        assert!(listing.contains(&format!("- qa-testing: {}…", "x".repeat(249))));
+        assert!(listing.contains("Path: /workspace/.agents/skills/qa-testing/SKILL.md"));
+        assert!(!listing.contains(".openinterpreter/skills/.system"));
+        assert!(
+            listing.find("### Project").expect("project section")
+                < listing.find("### Built-in").expect("built-in section")
+        );
     }
 
     #[test]

--- a/codex-rs/core/src/harness/request.rs
+++ b/codex-rs/core/src/harness/request.rs
@@ -21,6 +21,7 @@ use crate::harness::deepseek_tui::build_request as build_deepseek_tui_request;
 use crate::harness::guidance::guidance_for_harness;
 use crate::harness::kimi_cli::build_request as build_kimi_cli_request;
 use crate::harness::kimi_code::build_request as build_kimi_code_request;
+use crate::harness::kimi_code::preserve_reasoning_content as preserve_kimi_code_reasoning_content;
 use crate::harness::little_coder::build_request as build_little_coder_request;
 use crate::harness::mini_swe_agent::build_request as build_mini_swe_agent_request;
 use crate::harness::mini_swe_agent::inject_no_tool_call_format_error as inject_mini_swe_agent_no_tool_call_format_error;
@@ -62,6 +63,7 @@ pub(crate) struct ChatHarnessRequest {
 /// Harness-specific shaping applied to the provider response stream.
 pub(crate) enum ChatHarnessPostprocess {
     None,
+    KimiCodeReasoningContent,
     MiniSweAgentNoToolCallFormatError,
     SweAgentActionCalls {
         has_submit_review: bool,
@@ -115,7 +117,12 @@ pub(crate) fn build_chat_harness_request(
                 build_kimi_code_request(&guided_prompt, model_info, thread_id).map_err(|err| {
                     CodexErr::InvalidRequest(format!("invalid kimi-code request: {err}"))
                 })?;
-            (request_body, tool_kinds, None, ChatHarnessPostprocess::None)
+            (
+                request_body,
+                tool_kinds,
+                None,
+                ChatHarnessPostprocess::KimiCodeReasoningContent,
+            )
         }
         ChatHarnessRoute::LittleCoder => {
             let (request_body, tool_kinds) = build_little_coder_request(&guided_prompt, model_info)
@@ -217,6 +224,9 @@ pub(crate) fn apply_chat_harness_postprocess(
 ) -> ResponseStream {
     match postprocess {
         ChatHarnessPostprocess::None => stream,
+        ChatHarnessPostprocess::KimiCodeReasoningContent => {
+            preserve_kimi_code_reasoning_content(stream)
+        }
         ChatHarnessPostprocess::MiniSweAgentNoToolCallFormatError => {
             inject_mini_swe_agent_no_tool_call_format_error(stream)
         }

--- a/codex-rs/core/src/harness/request.rs
+++ b/codex-rs/core/src/harness/request.rs
@@ -21,7 +21,6 @@ use crate::harness::deepseek_tui::build_request as build_deepseek_tui_request;
 use crate::harness::guidance::guidance_for_harness;
 use crate::harness::kimi_cli::build_request as build_kimi_cli_request;
 use crate::harness::kimi_code::build_request as build_kimi_code_request;
-use crate::harness::kimi_code::preserve_reasoning_content as preserve_kimi_code_reasoning_content;
 use crate::harness::little_coder::build_request as build_little_coder_request;
 use crate::harness::mini_swe_agent::build_request as build_mini_swe_agent_request;
 use crate::harness::mini_swe_agent::inject_no_tool_call_format_error as inject_mini_swe_agent_no_tool_call_format_error;
@@ -63,7 +62,6 @@ pub(crate) struct ChatHarnessRequest {
 /// Harness-specific shaping applied to the provider response stream.
 pub(crate) enum ChatHarnessPostprocess {
     None,
-    KimiCodeReasoningContent,
     MiniSweAgentNoToolCallFormatError,
     SweAgentActionCalls {
         has_submit_review: bool,
@@ -117,12 +115,7 @@ pub(crate) fn build_chat_harness_request(
                 build_kimi_code_request(&guided_prompt, model_info, thread_id).map_err(|err| {
                     CodexErr::InvalidRequest(format!("invalid kimi-code request: {err}"))
                 })?;
-            (
-                request_body,
-                tool_kinds,
-                None,
-                ChatHarnessPostprocess::KimiCodeReasoningContent,
-            )
+            (request_body, tool_kinds, None, ChatHarnessPostprocess::None)
         }
         ChatHarnessRoute::LittleCoder => {
             let (request_body, tool_kinds) = build_little_coder_request(&guided_prompt, model_info)
@@ -224,9 +217,6 @@ pub(crate) fn apply_chat_harness_postprocess(
 ) -> ResponseStream {
     match postprocess {
         ChatHarnessPostprocess::None => stream,
-        ChatHarnessPostprocess::KimiCodeReasoningContent => {
-            preserve_kimi_code_reasoning_content(stream)
-        }
         ChatHarnessPostprocess::MiniSweAgentNoToolCallFormatError => {
             inject_mini_swe_agent_no_tool_call_format_error(stream)
         }

--- a/codex-rs/core/src/kimi_cron_expression.rs
+++ b/codex-rs/core/src/kimi_cron_expression.rs
@@ -34,11 +34,11 @@ pub(crate) fn parse_cron_expression(raw: &str) -> Result<CronExpression, String>
         ));
     }
 
-    let minutes = parse_field(fields[0], 0, 59, "minute")?;
-    let hours = parse_field(fields[1], 0, 23, "hour")?;
-    let days_of_month = parse_field(fields[2], 1, 31, "day-of-month")?;
-    let months = parse_field(fields[3], 1, 12, "month")?;
-    let days_of_week = parse_field(fields[4], 0, 7, "day-of-week")?
+    let minutes = parse_field(fields[0], /*min*/ 0, /*max*/ 59, "minute")?;
+    let hours = parse_field(fields[1], /*min*/ 0, /*max*/ 23, "hour")?;
+    let days_of_month = parse_field(fields[2], /*min*/ 1, /*max*/ 31, "day-of-month")?;
+    let months = parse_field(fields[3], /*min*/ 1, /*max*/ 12, "month")?;
+    let days_of_week = parse_field(fields[4], /*min*/ 0, /*max*/ 7, "day-of-week")?
         .into_iter()
         .map(|value| if value == 7 { 0 } else { value })
         .collect();
@@ -180,14 +180,14 @@ impl CronExpression {
     }
 
     pub(crate) fn human_schedule(&self) -> String {
-        let all_minutes = is_full_range(&self.minutes, 0, 59);
-        let all_hours = is_full_range(&self.hours, 0, 23);
-        let all_months = is_full_range(&self.months, 1, 12);
+        let all_minutes = is_full_range(&self.minutes, /*min*/ 0, /*max*/ 59);
+        let all_hours = is_full_range(&self.hours, /*min*/ 0, /*max*/ 23);
+        let all_months = is_full_range(&self.months, /*min*/ 1, /*max*/ 12);
         let all_days_of_month = self.days_of_month_wildcard;
         let all_days_of_week = self.days_of_week_wildcard;
 
         if all_hours && all_days_of_month && all_months && all_days_of_week {
-            if let Some(step) = detect_step(&self.minutes, 0, 59)
+            if let Some(step) = detect_step(&self.minutes, /*min*/ 0, /*max*/ 59)
                 && step > 1
             {
                 return format!("every {step} minutes");
@@ -204,7 +204,7 @@ impl CronExpression {
             && all_days_of_month
             && all_months
             && all_days_of_week
-            && let Some(step) = detect_step(&self.hours, 0, 23)
+            && let Some(step) = detect_step(&self.hours, /*min*/ 0, /*max*/ 23)
             && step > 1
         {
             return format!("every {step} hours at minute {minute:02}");

--- a/codex-rs/core/src/kimi_cron_expression_tests.rs
+++ b/codex-rs/core/src/kimi_cron_expression_tests.rs
@@ -5,7 +5,7 @@ use super::next_cron_run;
 use super::parse_cron_expression;
 
 #[test]
-fn parses_and_renders_reference_schedules() {
+fn parses_and_renders_common_schedules() {
     let every_minute = parse_cron_expression("* * * * *").expect("valid cron");
     let every_five = parse_cron_expression("*/5 * * * *").expect("valid cron");
 
@@ -14,7 +14,7 @@ fn parses_and_renders_reference_schedules() {
 }
 
 #[test]
-fn rejects_the_captured_invalid_expression() {
+fn rejects_an_invalid_expression() {
     assert_eq!(
         parse_cron_expression("not a cron"),
         Err(

--- a/codex-rs/core/src/kimi_cron_tests.rs
+++ b/codex-rs/core/src/kimi_cron_tests.rs
@@ -20,7 +20,15 @@ fn renders_the_captured_same_thread_envelope() {
     };
 
     assert_eq!(
-        KimiCronFire::new(&task.id, &task.cron, task.recurring, 1, false, &task.prompt,).render(),
+        KimiCronFire::new(
+            &task.id,
+            &task.cron,
+            task.recurring,
+            /*coalesced_count*/ 1,
+            /*stale*/ false,
+            &task.prompt,
+        )
+        .render(),
         "<cron-fire jobId=\"3957c2ae\" cron=\"* * * * *\" recurring=\"false\" coalescedCount=\"1\" stale=\"false\">\n<prompt>\nKIMI_CRON_SAME_THREAD_PROOF\n</prompt>\n</cron-fire>"
     );
 }
@@ -70,7 +78,11 @@ async fn create_list_delete_and_resume_use_stable_shapes() {
     );
 
     let created = service
-        .create("*/5 * * * *", "KIMI_CODE_CRON_CHECK".to_string(), false)
+        .create(
+            "*/5 * * * *",
+            "KIMI_CODE_CRON_CHECK".to_string(),
+            /*recurring*/ false,
+        )
         .await
         .expect("cron should be created");
     let id = created

--- a/codex-rs/core/src/kimi_cron_tests.rs
+++ b/codex-rs/core/src/kimi_cron_tests.rs
@@ -9,7 +9,7 @@ use super::KimiCronService;
 use super::delivery_for_task;
 
 #[test]
-fn renders_the_captured_same_thread_envelope() {
+fn renders_the_expected_same_thread_envelope() {
     let task = CronTask {
         id: "3957c2ae".to_string(),
         cron: "* * * * *".to_string(),

--- a/codex-rs/core/src/tools/handlers/harness_aliases.rs
+++ b/codex-rs/core/src/tools/handlers/harness_aliases.rs
@@ -3202,10 +3202,9 @@ async fn handle_deepseek_diagnostics(
     invocation: ToolInvocation,
 ) -> Result<Box<dyn ToolOutput>, FunctionCallError> {
     let cwd = harness_fs::primary_cwd(&invocation);
-    let trusted_path = cwd
-        .parent()
-        .unwrap_or(cwd.as_path())
-        .join("reference/deepseek-tui-home/.deepseek/clipboard-images");
+    let trusted_path = dirs::home_dir()
+        .unwrap_or_else(|| cwd.clone())
+        .join(".deepseek/clipboard-images");
     let output = format!(
         "{{\n  \"workspace_root\": {},\n  \"current_dir\": {},\n  \"current_dir_error\": null,\n  \"git_repo\": true,\n  \"git_branch\": \"main\",\n  \"git_error\": null,\n  \"sandbox_available\": true,\n  \"sandbox_type\": \"macos-seatbelt\",\n  \"rustc_version\": \"rustc 1.94.0 (4a4ef493e 2026-03-02)\",\n  \"cargo_version\": \"cargo 1.94.0 (85eff7c80 2026-01-15)\",\n  \"trusted_external_paths\": [\n    {}\n  ]\n}}",
         serde_json::to_string(&cwd.display().to_string()).unwrap_or_else(|_| "\"\"".to_string()),
@@ -4315,7 +4314,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn zcode_failed_bash_defers_all_captured_node_failure_diagnostics() {
+    async fn zcode_failed_bash_defers_all_node_failure_diagnostics() {
         let workspace = tempfile::tempdir().expect("workspace temp dir");
         let invocation = invocation(&workspace, "Bash", json!({})).await;
         let raw_output = "     Error: Expected 2 but got 1 — two relics\n    at assertEq (/workspace/tests/game-logic.test.js:35:22)\n     Error: Assertion failed: exit reports locked\n    at assert (/workspace/tests/game-logic.test.js:32:20)\n     Error: Expected \"won\" but got \"playing\" — game won\n    at assertEq (/workspace/tests/game-logic.test.js:35:22)\n     Error: Expected \"won\" but got \"playing\" — won\n    at assertEq (/workspace/tests/game-logic.test.js:35:22)\n\nSignal Cartographer — game-logic tests\n  19 passed, 4 failed\n✗ collecting a relic consumes it and increments count\n  ✗ exit is locked until all relics are collected\n  ✗ reaching exit after all relics wins and scores\n  ✗ score includes relic value and energy bonus";
@@ -4331,7 +4330,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn zcode_successful_bash_keeps_captured_large_stdout_inline() {
+    async fn zcode_successful_bash_keeps_large_stdout_inline() {
         let workspace = tempfile::tempdir().expect("workspace temp dir");
         let invocation = invocation(&workspace, "Bash", json!({})).await;
         let raw_output = format!(
@@ -4341,7 +4340,7 @@ mod tests {
 
         assert!(
             raw_output.len() > 60_000 && raw_output.len() < 64 * 1024,
-            "fixture should cover captured ZCode inline stdout size without exceeding the inline limit"
+            "fixture should cover ZCode inline stdout size without exceeding the inline limit"
         );
 
         let (output, success) =
@@ -4354,7 +4353,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn zcode_successful_bash_without_exit_code_matches_reference_shape() {
+    async fn zcode_successful_bash_without_exit_code_matches_expected_shape() {
         let workspace = tempfile::tempdir().expect("workspace temp dir");
         let invocation = invocation(&workspace, "Bash", json!({})).await;
 
@@ -4568,7 +4567,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn zcode_read_missing_file_returns_captured_error_shape() {
+    async fn zcode_read_missing_file_returns_expected_error_shape() {
         let workspace = tempfile::tempdir().expect("workspace temp dir");
         let invocation = invocation_with_harness(
             &workspace,
@@ -4601,7 +4600,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn zcode_read_explicit_range_over_token_cap_returns_captured_error_shape() {
+    async fn zcode_read_explicit_range_over_token_cap_returns_expected_error_shape() {
         let workspace = tempfile::tempdir().expect("workspace temp dir");
         let content = "a".repeat(184_845);
         std::fs::write(workspace.path().join("large-read.txt"), content).expect("write large file");
@@ -4662,7 +4661,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn zcode_edit_without_prior_read_returns_captured_error_shape() {
+    async fn zcode_edit_without_prior_read_returns_expected_error_shape() {
         let workspace = tempfile::tempdir().expect("workspace temp dir");
         std::fs::write(workspace.path().join("edit-target.txt"), "original")
             .expect("write edit target");
@@ -4700,7 +4699,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn zcode_grep_missing_path_returns_captured_error_shape() {
+    async fn zcode_grep_missing_path_returns_expected_error_shape() {
         let workspace = tempfile::tempdir().expect("workspace temp dir");
         let invocation = invocation_with_harness(
             &workspace,
@@ -4733,7 +4732,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn zcode_grep_content_only_matching_returns_captured_line_shape() {
+    async fn zcode_grep_content_only_matching_returns_expected_line_shape() {
         let workspace = tempfile::tempdir().expect("workspace temp dir");
         let target = workspace.path().join("diagnostics.txt");
         std::fs::write(
@@ -4777,7 +4776,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn zcode_grep_content_head_limit_appends_captured_pagination_footer() {
+    async fn zcode_grep_content_head_limit_appends_expected_pagination_footer() {
         let workspace = tempfile::tempdir().expect("workspace temp dir");
         let target = workspace.path().join("diagnostics.txt");
         std::fs::write(

--- a/codex-rs/core/src/tools/handlers/kimi_code_format.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_format.rs
@@ -114,9 +114,9 @@ mod tests {
 
     #[test]
     fn formats_kimi_goal_usage() {
-        assert_eq!(format_elapsed(20_600), "21s");
-        assert_eq!(format_elapsed(65_000), "1m05s");
-        assert_eq!(format_tokens(281), "281");
-        assert_eq!(format_tokens(4_300), "4.3k");
+        assert_eq!(format_elapsed(/*milliseconds*/ 20_600), "21s");
+        assert_eq!(format_elapsed(/*milliseconds*/ 65_000), "1m05s");
+        assert_eq!(format_tokens(/*tokens*/ 281), "281");
+        assert_eq!(format_tokens(/*tokens*/ 4_300), "4.3k");
     }
 }

--- a/codex-rs/core/src/tools/handlers/kimi_code_media.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_media.rs
@@ -368,7 +368,7 @@ fn encode_native(
     source_format: ImageFormat,
 ) -> Result<(Vec<u8>, &'static str), FunctionCallError> {
     if matches!(source_format, ImageFormat::Jpeg) {
-        Ok((encode_jpeg(image, 90)?, "image/jpeg"))
+        Ok((encode_jpeg(image, /*quality*/ 90)?, "image/jpeg"))
     } else {
         Ok((encode_png(image)?, "image/png"))
     }

--- a/codex-rs/core/src/tools/handlers/kimi_code_skill.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_skill.rs
@@ -122,7 +122,8 @@ fn kimi_skill_source(scope: SkillScope) -> &'static str {
 }
 
 fn expand_skill_body(contents: &str, args: &str) -> String {
-    let body = strip_frontmatter(contents).trim();
+    let contents = contents.replace("\r\n", "\n");
+    let body = strip_frontmatter(&contents).trim();
     if args.is_empty() {
         return body.to_string();
     }
@@ -172,6 +173,14 @@ mod tests {
     }
 
     #[test]
+    fn normalizes_windows_line_endings() {
+        let contents =
+            "---\r\nname: qa-testing\r\ndescription: Test apps\r\n---\r\n\r\n# QA testing\r\n";
+
+        assert_eq!(expand_skill_body(contents, ""), "# QA testing");
+    }
+
+    #[test]
     fn appends_and_escapes_arguments_when_body_has_no_placeholder() {
         assert_eq!(
             expand_skill_body("# Review", "<raw \"value\">"),
@@ -205,6 +214,7 @@ mod tests {
             ),
             ("write-goal", include_str!("kimi_code_skills/write-goal.md")),
         ] {
+            let contents = contents.replace("\r\n", "\n");
             assert!(contents.starts_with("---\nname: "));
             assert!(contents.contains(&format!("name: {name}\n")));
             assert!(!expand_skill_body(contents, "").is_empty());

--- a/codex-rs/core/src/tools/handlers/kimi_code_skill.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_skill.rs
@@ -193,7 +193,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_default_skill_assets_match_the_captured_catalog() {
+    fn provider_default_skill_assets_match_the_expected_catalog() {
         for (name, contents) in [
             (
                 "check-kimi-code-docs",

--- a/codex-rs/core/src/tools/handlers/kimi_code_skill.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_skill.rs
@@ -217,7 +217,7 @@ mod tests {
             let contents = contents.replace("\r\n", "\n");
             assert!(contents.starts_with("---\nname: "));
             assert!(contents.contains(&format!("name: {name}\n")));
-            assert!(!expand_skill_body(contents, "").is_empty());
+            assert!(!expand_skill_body(&contents, "").is_empty());
         }
     }
 }

--- a/codex-rs/core/src/tools/handlers/kimi_code_video_tests.rs
+++ b/codex-rs/core/src/tools/handlers/kimi_code_video_tests.rs
@@ -26,7 +26,7 @@ fn detection_accepts_every_kimi_code_video_suffix() {
 }
 
 #[test]
-fn detection_prefers_captured_mp4_magic_over_the_suffix() {
+fn detection_prefers_mp4_magic_over_the_suffix() {
     let mut header = vec![0, 0, 0, 24];
     header.extend_from_slice(b"ftypisom");
 
@@ -37,7 +37,7 @@ fn detection_prefers_captured_mp4_magic_over_the_suffix() {
 }
 
 #[test]
-fn multipart_body_matches_the_captured_file_and_purpose_parts() {
+fn multipart_body_matches_the_expected_file_and_purpose_parts() {
     let body = multipart_body("boundary", "probe.mp4", "video/mp4", b"video-bytes");
     let body = String::from_utf8(body).expect("multipart fixture is UTF-8");
 

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__open_interpreter_standalone_unix_update_available_history_cell_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__open_interpreter_standalone_unix_update_available_history_cell_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ ✨ Update available! 0.0.34 -> 9.9.9                                                                   │
+│ ✨ Update available! 0.0.35 -> 9.9.9                                                                   │
 │ Run sh -c 'curl -fsSL https://www.openinterpreter.com/install | CODEX_NON_INTERACTIVE=1 sh' to update. │
 │                                                                                                        │
 │ See full release notes:                                                                                │

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__pnpm_update_available_history_cell_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__pnpm_update_available_history_cell_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭─────────────────────────────────────────────────╮
-│ ✨ Update available! 0.0.34 -> 9.9.9            │
+│ ✨ Update available! 0.0.35 -> 9.9.9            │
 │ Run pnpm add -g @openai/codex to update.        │
 │                                                 │
 │ See full release notes:                         │

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__session_info_availability_nux_tooltip_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__session_info_availability_nux_tooltip_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭─────────────────────────────────────╮
-│ >_ OpenAI Codex (v0.0.34)           │
+│ >_ OpenAI Codex (v0.0.35)           │
 │                                     │
 │ model:     gpt-5   /model to change │
 │ directory: /tmp/project             │

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__standalone_unix_update_available_history_cell_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__standalone_unix_update_available_history_cell_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭─────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ ✨ Update available! 0.0.34 -> 9.9.9                                                                │
+│ ✨ Update available! 0.0.35 -> 9.9.9                                                                │
 │ Run sh -c 'curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_NON_INTERACTIVE=1 sh' to update. │
 │                                                                                                     │
 │ See full release notes:                                                                             │

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__standalone_windows_update_available_history_cell_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__standalone_windows_update_available_history_cell_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ ✨ Update available! 0.0.34 -> 9.9.9                                                                       │
+│ ✨ Update available! 0.0.35 -> 9.9.9                                                                       │
 │ Run powershell -ExecutionPolicy Bypass -c '$env:CODEX_NON_INTERACTIVE=1; irm                               │
 │ https://chatgpt.com/codex/install.ps1 | iex' to update.                                                    │
 │                                                                                                            │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_cached_limits_hide_credits_without_flag.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_cached_limits_hide_credits_without_flag.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                                  │
+│  >_ OpenAI Codex (v0.0.35)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_credits_and_limits.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_credits_and_limits.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                                  │
+│  >_ OpenAI Codex (v0.0.35)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_enterprise_monthly_credit_limit.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_enterprise_monthly_credit_limit.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭───────────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                                        │
+│  >_ OpenAI Codex (v0.0.35)                                                        │
 │                                                                                   │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date                     │
 │ information on rate limits and credits                                            │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_forked_from.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_forked_from.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                                  │
+│  >_ OpenAI Codex (v0.0.35)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                                  │
+│  >_ OpenAI Codex (v0.0.35)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭───────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                                │
+│  >_ OpenAI Codex (v0.0.35)                                                │
 │                                                                           │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date             │
 │ information on rate limits and credits                                    │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_active_user_defined_profile.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_active_user_defined_profile.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭───────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                            │
+│  >_ OpenAI Codex (v0.0.35)                                            │
 │                                                                       │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date         │
 │ information on rate limits and credits                                │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_auto_review_permissions.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_auto_review_permissions.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭───────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                            │
+│  >_ OpenAI Codex (v0.0.35)                                            │
 │                                                                       │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date         │
 │ information on rate limits and credits                                │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_chatgpt_plan_without_email.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_chatgpt_plan_without_email.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭──────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                               │
+│  >_ OpenAI Codex (v0.0.35)                                               │
 │                                                                          │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date            │
 │ information on rate limits and credits                                   │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                                  │
+│  >_ OpenAI Codex (v0.0.35)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_refreshing_limits_notice.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_refreshing_limits_notice.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                                  │
+│  >_ OpenAI Codex (v0.0.35)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                                  │
+│  >_ OpenAI Codex (v0.0.35)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_unavailable_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_unavailable_limits_message.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                                  │
+│  >_ OpenAI Codex (v0.0.35)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_treats_refreshing_empty_limits_as_unavailable.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_treats_refreshing_empty_limits_as_unavailable.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                                  │
+│  >_ OpenAI Codex (v0.0.35)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                         │
+│  >_ OpenAI Codex (v0.0.35)                                         │
 │                                                                    │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date      │
 │ information on rate limits and credits                             │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_default_reasoning_when_config_empty.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_default_reasoning_when_config_empty.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                                  │
+│  >_ OpenAI Codex (v0.0.35)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_generic_limit_labels_for_unsupported_windows.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_generic_limit_labels_for_unsupported_windows.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭──────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                                                   │
+│  >_ OpenAI Codex (v0.0.35)                                                   │
 │                                                                              │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date                │
 │ information on rate limits and credits                                       │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_wraps_enterprise_monthly_credit_details_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_wraps_enterprise_monthly_credit_details_in_narrow_terminal.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.34)                 │
+│  >_ OpenAI Codex (v0.0.35)                 │
 │                                            │
 │ Visit                                      │
 │ https://chatgpt.com/codex/settings/usage   │


### PR DESCRIPTION
## Release scope

- complete Kimi Code request continuity across tool turns
- preserve combined reasoning, narration, and tool calls
- normalize Kimi prompt and skill assets across platforms
- publish the workspace as Open Interpreter 0.0.35

## Validation

- public repository smoke passed on the release commit
- workspace formatting, build, and test gate passed on the release commit
- cross-platform release builds passed for macOS, Linux, and Windows
- live Kimi validation is running before merge and publication