### PR TITLE
fix(rmcp-client): cap streamable HTTP response body size

### DIFF
--- a/codex-rs/rmcp-client/src/http_client_adapter.rs
+++ b/codex-rs/rmcp-client/src/http_client_adapter.rs
@@ -589,3 +589,41 @@ fn sse_stream_from_body(
     }))
     .boxed()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::within_body_limit;
+
+    #[test]
+    fn allows_chunk_that_exactly_reaches_limit() {
+        assert!(within_body_limit(90, 10, 100));
+    }
+
+    #[test]
+    fn allows_empty_chunk_at_limit() {
+        assert!(within_body_limit(100, 0, 100));
+    }
+
+    #[test]
+    fn rejects_chunk_that_exceeds_limit_by_one() {
+        assert!(!within_body_limit(90, 11, 100));
+    }
+
+    #[test]
+    fn rejects_first_chunk_larger_than_limit() {
+        assert!(!within_body_limit(0, 101, 100));
+    }
+
+    #[test]
+    fn rejects_any_chunk_once_body_is_at_limit() {
+        assert!(!within_body_limit(100, 1, 100));
+    }
+
+    #[test]
+    fn does_not_underflow_when_body_already_exceeds_limit() {
+        // A non-empty chunk is rejected rather than panicking on the internal
+        // subtraction; a zero-length chunk grows nothing and stays allowed.
+        assert!(!within_body_limit(200, 1, 100));
+        assert!(within_body_limit(200, 0, 100));
+    }
+}

--- a/codex-rs/rmcp-client/src/http_client_adapter.rs
+++ b/codex-rs/rmcp-client/src/http_client_adapter.rs
@@ -49,6 +49,11 @@ const EVENT_STREAM_MIME_TYPE: &str = "text/event-stream";
 const JSON_MIME_TYPE: &str = "application/json";
 const HEADER_SESSION_ID: &str = "Mcp-Session-Id";
 const NON_JSON_RESPONSE_BODY_PREVIEW_BYTES: usize = 8_192;
+/// Upper bound on a single buffered (non-SSE) HTTP response body. A malicious or
+/// broken MCP server could otherwise stream an unbounded body and exhaust memory
+/// before it is parsed. Mirrors `MAX_OAUTH_HTTP_RESPONSE_BODY_BYTES` in
+/// `oauth_http_client.rs`, with more headroom for large data-plane payloads.
+const MAX_STREAMABLE_HTTP_RESPONSE_BODY_BYTES: usize = 100 * 1024 * 1024;
 
 #[derive(Clone)]
 pub(crate) struct StreamableHttpClientAdapter {
@@ -65,6 +70,8 @@ pub(crate) enum StreamableHttpClientAdapterError {
     HttpRequest(#[from] ExecServerError),
     #[error("invalid HTTP header: {0}")]
     Header(String),
+    #[error("HTTP response body exceeds {limit} bytes")]
+    ResponseBodyTooLarge { limit: usize },
 }
 
 impl StreamableHttpClientAdapter {
@@ -537,6 +544,13 @@ fn parse_json_rpc_error(body: &[u8]) -> Option<ServerJsonRpcMessage> {
     }
 }
 
+/// Returns `true` if appending `chunk_len` bytes to a `current_len`-byte body
+/// keeps it within `limit`. Uses saturating subtraction so it never panics even
+/// if `current_len` somehow already exceeds `limit`.
+fn within_body_limit(current_len: usize, chunk_len: usize, limit: usize) -> bool {
+    chunk_len <= limit.saturating_sub(current_len)
+}
+
 async fn collect_body(
     body_stream: &mut HttpResponseBodyStream,
 ) -> std::result::Result<Vec<u8>, StreamableHttpError<StreamableHttpClientAdapterError>> {
@@ -547,6 +561,17 @@ async fn collect_body(
         .map_err(StreamableHttpClientAdapterError::from)
         .map_err(StreamableHttpError::Client)?
     {
+        if !within_body_limit(
+            body.len(),
+            chunk.len(),
+            MAX_STREAMABLE_HTTP_RESPONSE_BODY_BYTES,
+        ) {
+            return Err(StreamableHttpError::Client(
+                StreamableHttpClientAdapterError::ResponseBodyTooLarge {
+                    limit: MAX_STREAMABLE_HTTP_RESPONSE_BODY_BYTES,
+                },
+            ));
+        }
         body.extend_from_slice(&chunk);
     }
     Ok(body)

--- a/codex-rs/rmcp-client/src/streamable_http_retry.rs
+++ b/codex-rs/rmcp-client/src/streamable_http_retry.rs
@@ -159,7 +159,10 @@ impl RmcpClient {
             | StreamableHttpError::ServerDoesNotSupportSse
             | StreamableHttpError::Deserialize(_)
             | StreamableHttpError::Client(StreamableHttpClientAdapterError::SessionExpired404)
-            | StreamableHttpError::Client(StreamableHttpClientAdapterError::Header(_)) => false,
+            | StreamableHttpError::Client(StreamableHttpClientAdapterError::Header(_))
+            | StreamableHttpError::Client(
+                StreamableHttpClientAdapterError::ResponseBodyTooLarge { .. },
+            ) => false,
             _ => false,
         }
     }

--- a/codex-rs/rmcp-client/src/streamable_http_retry_tests.rs
+++ b/codex-rs/rmcp-client/src/streamable_http_retry_tests.rs
@@ -50,11 +50,14 @@ fn retryable_streamable_http_error_includes_remote_body_stream_failure() {
         )),
         StreamableHttpError::UnexpectedServerResponse("HTTP 502: upstream failure".into()),
         StreamableHttpError::UnexpectedServerResponse("HTTP 400: bad request".into()),
+        StreamableHttpError::Client(StreamableHttpClientAdapterError::ResponseBodyTooLarge {
+            limit: 100 * 1024 * 1024,
+        }),
     ];
 
     assert_eq!(
         errors.map(|error| RmcpClient::is_retryable_streamable_http_error(&error)),
-        [true, true, true, false, true, false],
+        [true, true, true, false, true, false, false],
     );
 }
 


### PR DESCRIPTION
### What I found

While auditing the MCP client transport, I noticed that `collect_body` in
`rmcp-client/src/http_client_adapter.rs` reads an HTTP response from an MCP
server into memory with **no upper bound**:

```rust
let mut body = Vec::new();
while let Some(chunk) = body_stream.recv().await... {
    body.extend_from_slice(&chunk);
}
```

Every chunk the server sends is appended to `body` until the stream ends. The
size is entirely controlled by the remote MCP server, and only *after* the whole
thing is buffered do we hand it to `serde_json::from_slice`.

What stood out is that the crate already knows this is a risk on a neighboring
code path: the OAuth client (`oauth_http_client.rs`) caps responses at 1 MiB via
`MAX_OAUTH_HTTP_RESPONSE_BODY_BYTES`. The main data path just never got the same
guard.

### What can happen if it's not fixed

Any MCP server the user connects to (including a compromised or buggy one) can
reply to a routine request like `tools/list` with a multi-gigabyte or
never-ending chunked body. The client dutifully buffers all of it, so memory
grows without limit until the process is killed by the OS — a denial-of-service
that takes the whole interpreter session down. The user doesn't have to do
anything unusual; a single normal request to a bad server is enough.

### How I fixed it

- Enforce a **100 MiB** ceiling while buffering in `collect_body`. If a response
  would exceed it, we stop and return a new `ResponseBodyTooLarge` error instead
  of continuing to allocate.
- The bounds check uses saturating subtraction (`chunk_len <=
  limit.saturating_sub(current_len)`) so it can never underflow/panic.
- `ResponseBodyTooLarge` is classified as **non-retryable**, since retrying would
  just pull the same oversized body again.
- I pulled the boundary logic into a tiny pure helper (`within_body_limit`) so it
  can be unit-tested directly.

I picked 100 MiB deliberately: it's generous enough to never reject a legitimate
large `resources/read` or `tools/list`, while still bounding what a malicious
server can force us to allocate.

### Why this only makes the interpreter better

The cap is a ceiling, not a preallocation — we still grow the buffer chunk by
chunk and only hold the bytes actually received. So for every normal response
(kilobytes to a few MB) behavior, speed, and memory are **identical** to before;
the only new behavior is that a pathological response is rejected instead of
crashing the process. Nothing that worked before stops working, and the streaming
(SSE) path isn't touched at all. It's purely a safety net that follows a pattern
the codebase already established for OAuth.

### Scope / known remaining vector

This PR caps the **buffered** response path (`collect_body`), which handles
`application/json` and error bodies. It intentionally does **not** cover the
**SSE** path (`Content-Type: text/event-stream` → `sse_stream_from_body`), so a
server could still stream an unbounded single event to grow memory. I scoped it
out on purpose: the SSE buffering lives inside the third-party `sse-stream` crate
(no size-limit option), and SSE is a legitimately long-lived, high-volume stream,
so a naive cumulative cap would risk disconnecting valid sessions. Bounding it
correctly needs a per-event limit (an upstream `max_event_size` in `sse-stream`
or a carefully-tested bounding adapter) and is best handled as a separate change.
Filing it as a follow-up rather than implying this closes the whole class.

### Tests I ran

Added unit tests for the boundary logic (exact fit at the limit, over-by-one,
empty chunk, body already at the limit, and the underflow-safety case), plus a
case asserting `ResponseBodyTooLarge` is non-retryable. Full crate suite,
lints, and formatting all pass on the pinned toolchain (1.95.0):

```
cargo test  -p codex-rmcp-client                                 # 75 passed, 0 failed
cargo clippy -p codex-rmcp-client --all-targets -- -D warnings   # clean
cargo fmt   -p codex-rmcp-client -- --check                      # no diffs
```
