### PR TITLE
fix(secrets): redact current-generation OpenAI API keys

### DIFF
--- a/codex-rs/secrets/src/sanitizer.rs
+++ b/codex-rs/secrets/src/sanitizer.rs
@@ -1,7 +1,12 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-static OPENAI_KEY_REGEX: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"sk-[A-Za-z0-9]{20,}"));
+// Matches the legacy `sk-...` key form (unchanged) plus the current prefixed
+// variants `sk-proj-...`, `sk-svcacct-...`, and `sk-admin-...`, whose random
+// tail can contain `-` and `_` and so was previously cut short.
+static OPENAI_KEY_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    compile_regex(r"sk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{16,}|sk-[A-Za-z0-9]{20,}")
+});
 static AWS_ACCESS_KEY_ID_REGEX: LazyLock<Regex> =
     LazyLock::new(|| compile_regex(r"\bAKIA[0-9A-Z]{16}\b"));
 static BEARER_TOKEN_REGEX: LazyLock<Regex> =

--- a/codex-rs/secrets/src/sanitizer.rs
+++ b/codex-rs/secrets/src/sanitizer.rs
@@ -43,4 +43,49 @@ mod tests {
         // The goal of this test is just to compile all the regex to prevent the panic
         let _ = redact_secrets("secret".to_string());
     }
+
+    fn assert_redacted(secret: &str) {
+        let input = format!("prefix {secret} suffix");
+        let redacted = redact_secrets(input);
+        assert!(
+            !redacted.contains(secret),
+            "expected secret to be redacted, got: {redacted}"
+        );
+        assert!(redacted.contains("[REDACTED_SECRET]"), "got: {redacted}");
+    }
+
+    #[test]
+    fn redacts_legacy_openai_key() {
+        assert_redacted("sk-abcdEFGH1234ijklMNOP5678");
+    }
+
+    #[test]
+    fn redacts_prefixed_openai_keys() {
+        assert_redacted("sk-proj-abcdEFGH1234ijklMNOP5678_qrst-uvwx");
+        assert_redacted("sk-svcacct-ABCdef123456GHIjkl789012");
+        assert_redacted("sk-admin-ABCdef123456GHIjkl789012");
+    }
+
+    #[test]
+    fn still_redacts_aws_access_key_id() {
+        assert_redacted("AKIAIOSFODNN7EXAMPLE");
+    }
+
+    #[test]
+    fn still_redacts_bearer_and_assignment() {
+        let redacted = redact_secrets("Authorization: Bearer sometokenvalue1234567890".to_string());
+        assert!(
+            redacted.contains("Bearer [REDACTED_SECRET]"),
+            "got: {redacted}"
+        );
+
+        let redacted = redact_secrets("password=supersecretvalue".to_string());
+        assert!(!redacted.contains("supersecretvalue"), "got: {redacted}");
+    }
+
+    #[test]
+    fn leaves_ordinary_text_untouched() {
+        let input = "The quick brown fox jumps over the lazy dog.".to_string();
+        assert_eq!(redact_secrets(input.clone()), input);
+    }
 }


### PR DESCRIPTION
### What I found

The secret redaction in `codex-secrets` (`sanitizer.rs`) is used during **memory
extraction** (`memories/write/src/phase1.rs:319-321` and `:425`), so whatever it
misses can be written into long-term memory and re-sent to the model on later
turns. It has an OpenAI-key pattern — but that pattern only matches the **legacy**
`sk-<alphanumeric>` form:

```rust
sk-[A-Za-z0-9]{20,}
```

Current OpenAI keys are prefixed — `sk-proj-...`, `sk-svcacct-...`,
`sk-admin-...` — and their random tail contains `-` and `_`. The old
`[A-Za-z0-9]` class stops at the first `-`, so **a current-generation OpenAI API
key is not redacted at all.** For a redactor that specifically targets OpenAI
keys, that's a plain blind spot.

### What can happen if it's not fixed

A user pastes (or a tool prints) an `sk-proj-…` key into the session. During
memory extraction the redactor runs but leaves the key intact, so it's persisted
into a memory file and re-sent to the model on subsequent turns. It's the user's
own key and the provider already saw it once, so this is hygiene / defense in
depth rather than a containment boundary — but a redactor that quietly skips the
most common key format it's meant to catch is worth fixing.

### How I fixed it

Added the prefixed forms via an alternation:

```rust
sk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{16,}|sk-[A-Za-z0-9]{20,}
```

The legacy branch is left **byte-for-byte unchanged**, so no input that
redacted before behaves differently — the change only *adds* matches for the
prefixed keys.

### What I deliberately left out, and why

I scoped this down to the one unambiguous defect. I initially also added GitHub
token and bare-JWT patterns, but dropped both:

- **JWT (`eyJ….eyJ….sig`)** — highest false-positive risk (it also matches
  non-secret base64 that happens to split that way), and low marginal value since
  JWTs prefixed with `Bearer` are already covered. In persisted memory, a false
  positive silently replaces real context with `[REDACTED_SECRET]`, which
  degrades the thing memory exists to preserve.
- **GitHub tokens (`ghp_`, `github_pat_`, …)** — low false-positive risk and
  reasonable, but adding new secret *types* opens a "why these and not Slack /
  Stripe / GCP / SSH keys?" scope discussion. This redactor is explicitly
  best-effort; expanding the catalog is a separate conversation. Happy to add
  GitHub tokens in a follow-up if maintainers want them.

This keeps the PR to a tight, obviously-correct fix (make the existing OpenAI
pattern actually match OpenAI keys) with no behavior change for anything already
handled.

### Tests I ran

Added tests asserting `sk-proj-`, `sk-svcacct-`, and `sk-admin-` keys are
redacted, plus regression coverage for legacy `sk-` keys, AWS ids, `Bearer`
tokens, and `key=value` assignments, and a check that ordinary text is untouched.

```
cargo test  -p codex-secrets --lib sanitizer                 # 6 passed, 0 failed
cargo clippy -p codex-secrets --all-targets -- -D warnings   # clean
cargo fmt   -p codex-secrets -- --check                      # no diffs
```
