### PR TITLE
fix(windows-sandbox): write deny-bin stub with real CRLF line breaks

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/env.rs
+++ b/codex-rs/windows-sandbox-rs/src/env.rs
@@ -175,3 +175,32 @@ pub fn apply_no_network_to_env(env_map: &mut HashMap<String, String>) -> Result<
     reorder_pathext_for_stubs(env_map);
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn denybin_stub_is_a_real_two_line_batch_file() {
+        let dir = tempdir().expect("tempdir");
+        ensure_denybin(&["ssh"], Some(dir.path())).expect("ensure_denybin");
+
+        for ext in [".bat", ".cmd"] {
+            let contents =
+                fs::read_to_string(dir.path().join(format!("ssh{ext}"))).expect("read stub");
+            // Must be two real CRLF-terminated lines, not one line containing
+            // the literal text `\r\n`, otherwise cmd.exe never runs `exit /b 1`
+            // and the network tool is not actually blocked.
+            assert_eq!(contents, "@echo off\r\nexit /b 1\r\n");
+            assert!(
+                !contents.contains("\\r\\n"),
+                "stub contains literal backslash-r-n: {contents:?}"
+            );
+            assert!(
+                contents.lines().any(|line| line == "exit /b 1"),
+                "stub is missing a standalone `exit /b 1` line: {contents:?}"
+            );
+        }
+    }
+}

--- a/codex-rs/windows-sandbox-rs/src/env.rs
+++ b/codex-rs/windows-sandbox-rs/src/env.rs
@@ -116,7 +116,7 @@ fn ensure_denybin(tools: &[&str], denybin_dir: Option<&Path>) -> Result<PathBuf>
             let path = base.join(format!("{tool}{ext}"));
             if !path.exists() {
                 let mut f = File::create(&path)?;
-                f.write_all(b"@echo off\\r\\nexit /b 1\\r\\n")?;
+                f.write_all(b"@echo off\r\nexit /b 1\r\n")?;
             }
         }
     }


### PR DESCRIPTION
### What I found

In offline mode, `apply_no_network_to_env` (used when a Windows sandboxed process
is spawned with network blocking — `spawn_prep.rs`) builds a `.sbx-denybin`
directory of stub `ssh`/`scp` scripts, puts it first on `PATH`, and reorders
`PATHEXT` so `.BAT`/`.CMD` win. A shell-invoked `ssh`/`scp` then resolves to the
stub, which is meant to exit 1. The stub is written in
`windows-sandbox-rs/src/env.rs`:

```rust
f.write_all(b"@echo off\\r\\nexit /b 1\\r\\n")?;
```

In a Rust byte-string literal `\\r` and `\\n` are a literal backslash followed by
`r`/`n`, **not** carriage-return/line-feed. So the file written is a single line
containing the literal text `@echo off\r\nexit /b 1\r\n`, not the intended
two-line batch file:

```
@echo off
exit /b 1
```

### What can happen if it's not fixed

When a stub is invoked in a shell, cmd.exe runs `@echo off\r\nexit /b 1\r\n` as a
*single* command: it echoes the stray text and the batch exits with code **0**. So
instead of reporting the tool as blocked (`exit /b 1`), the stub silently
"succeeds" and prints garbage.

To be precise about impact: the real `ssh`/`scp` are still shadowed by the stub on
`PATH`, so **this is not a network-exfiltration hole** — the tools don't run. What
breaks is the stub's signaling: a caller that relies on the non-zero exit code
sees success instead of a clean failure, and gets unexpected output. In short, the
stub doesn't do what its own code intends. This is a low-severity correctness bug
in the offline-mode block.

### How I fixed it

Write real CRLF bytes:

```rust
f.write_all(b"@echo off\r\nexit /b 1\r\n")?;
```

One-line change; the stub is now a proper two-line batch file that exits 1.

### Scope

This targets only the deny-bin stub. (There's a separate over-escaped literal in
`normalize_null_device_env` at `env.rs:17` — `"\\\\\\\\dev\\\\\\\\null"` — but its
intended match value is arguable, so I left it out of this no-debate fix and am
happy to raise it separately.)

### Tests I ran

Added a test asserting `ensure_denybin` writes exactly `"@echo off\r\nexit /b 1\r\n"`
(two real CRLF lines) and contains no literal `\r\n` text, so a regression is
caught. The `env` module is `#[cfg(target_os = "windows")]`, so the test runs on
Windows CI; I validated it locally by temporarily un-gating the (platform-
agnostic) module and running it:

```
cargo test -p codex-windows-sandbox --lib denybin_stub   # 1 passed
cargo fmt  -p codex-windows-sandbox -- --check            # no diffs
```
