### PR TITLE
fix(install): detect architecture without RuntimeInformation.OSArchitecture

### DIFF
--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -812,7 +812,30 @@ if (-not [Environment]::Is64BitOperatingSystem) {
     exit 1
 }
 
-$architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+$architecture = $null
+try {
+    $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+} catch {
+    # Older Windows PowerShell / .NET Framework (< 4.7.1) does not expose
+    # RuntimeInformation.OSArchitecture, which throws "The property
+    # 'OSArchitecture' cannot be found on this object." Fall back to the
+    # architecture environment variables, which are available everywhere.
+    $architecture = $null
+}
+if ([string]::IsNullOrWhiteSpace($architecture)) {
+    # PROCESSOR_ARCHITEW6432 holds the real architecture inside a 32-bit
+    # (WOW64) process; PROCESSOR_ARCHITECTURE is correct otherwise. A 64-bit
+    # OS is already required above.
+    $envArchitecture = $env:PROCESSOR_ARCHITEW6432
+    if ([string]::IsNullOrWhiteSpace($envArchitecture)) {
+        $envArchitecture = $env:PROCESSOR_ARCHITECTURE
+    }
+    switch ($envArchitecture) {
+        "AMD64" { $architecture = "X64" }
+        "ARM64" { $architecture = "Arm64" }
+        default { $architecture = $envArchitecture }
+    }
+}
 $target = $null
 $platformLabel = $null
 $npmTag = $null

--- a/scripts/install/test_install_ps1.ps1
+++ b/scripts/install/test_install_ps1.ps1
@@ -1,0 +1,105 @@
+#!/usr/bin/env pwsh
+# Tests for scripts/install/install.ps1.
+#
+# These run on any PowerShell (Windows PowerShell 5.1 or `pwsh` on
+# macOS/Linux/Windows):
+#
+#     pwsh -NoProfile -File scripts/install/test_install_ps1.ps1
+#
+# The architecture-detection cases exercise the *real* block extracted from
+# install.ps1 (not a copy), only swapping the RuntimeInformation.OSArchitecture
+# access for a probe we control, so we can simulate hosts where that property is
+# unavailable (older Windows PowerShell / .NET Framework < 4.7.1) without needing
+# such a host. See issue #1821.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$installPath = Join-Path $repoRoot 'scripts/install/install.ps1'
+$script:failures = 0
+
+function Assert-Equal {
+    param([string]$Name, $Actual, $Expected)
+    if ($Actual -eq $Expected) {
+        Write-Host "PASS: $Name -> $Actual"
+    } else {
+        Write-Host "FAIL: $Name -> got '$Actual', expected '$Expected'"
+        $script:failures++
+    }
+}
+
+# --- 1. The real installer parses without syntax errors -----------------------
+$parseErrors = $null
+[System.Management.Automation.Language.Parser]::ParseFile(
+    $installPath, [ref]$null, [ref]$parseErrors) | Out-Null
+if ($parseErrors -and $parseErrors.Count -gt 0) {
+    Write-Host "FAIL: install.ps1 has $($parseErrors.Count) parse error(s):"
+    $parseErrors | ForEach-Object { Write-Host "   $($_.Message)" }
+    $script:failures++
+} else {
+    Write-Host "PASS: install.ps1 parses cleanly"
+}
+
+# --- 2. Extract the real architecture-detection block -------------------------
+# Everything from `$architecture = $null` up to (but not including) the next
+# section (`$codexHome = ...`). This covers the OSArchitecture probe, the
+# environment-variable fallback, and the target `switch`.
+$installText = Get-Content -Raw -LiteralPath $installPath
+if ($installText -notmatch '(?s)(\$architecture = \$null.*?)\r?\n\$codexHome ') {
+    Write-Host 'FAIL: could not locate the architecture-detection block in install.ps1'
+    exit 1
+}
+$archBlock = $Matches[1]
+
+# Swap the real OSArchitecture access for a probe scriptblock we control, so we
+# can make it succeed (modern hosts) or throw (old .NET) at will.
+$probeMarker = '[System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture'
+if (-not $archBlock.Contains($probeMarker)) {
+    Write-Host 'FAIL: OSArchitecture access not found in the extracted block'
+    exit 1
+}
+$archBlock = $archBlock.Replace($probeMarker, '(& $script:OSArchitectureProbe)')
+
+function Resolve-InstallerArchitecture {
+    param(
+        [scriptblock]$OSArchitectureProbe,  # returns arch string, or throws
+        [string]$ArchEW6432 = '',           # $env:PROCESSOR_ARCHITEW6432
+        [string]$ArchProc = ''              # $env:PROCESSOR_ARCHITECTURE
+    )
+    $script:OSArchitectureProbe = $OSArchitectureProbe
+    $env:PROCESSOR_ARCHITEW6432 = $ArchEW6432
+    $env:PROCESSOR_ARCHITECTURE = $ArchProc
+    $architecture = $null
+    $target = $null
+    Invoke-Expression $archBlock
+    [pscustomobject]@{ Architecture = $architecture; Target = $target }
+}
+
+$throws = { throw "The property 'OSArchitecture' cannot be found on this object." }
+
+# --- 3. Modern hosts: OSArchitecture works -> behavior unchanged --------------
+$r = Resolve-InstallerArchitecture -OSArchitectureProbe { 'X64' }
+Assert-Equal 'modern x64 target' $r.Target 'x86_64-pc-windows-msvc'
+$r = Resolve-InstallerArchitecture -OSArchitectureProbe { 'Arm64' }
+Assert-Equal 'modern arm64 target' $r.Target 'aarch64-pc-windows-msvc'
+
+# --- 4. Old .NET (#1821): OSArchitecture throws -> env-var fallback -----------
+$r = Resolve-InstallerArchitecture -OSArchitectureProbe $throws -ArchProc 'AMD64'
+Assert-Equal 'old .NET amd64 target' $r.Target 'x86_64-pc-windows-msvc'
+$r = Resolve-InstallerArchitecture -OSArchitectureProbe $throws -ArchProc 'ARM64'
+Assert-Equal 'old .NET arm64 target' $r.Target 'aarch64-pc-windows-msvc'
+
+# --- 5. WOW64: 32-bit PowerShell on 64-bit OS -> real arch in ARCHITEW6432 ----
+$r = Resolve-InstallerArchitecture -OSArchitectureProbe $throws -ArchEW6432 'ARM64' -ArchProc 'x86'
+Assert-Equal 'old .NET WOW64 arm64 target' $r.Target 'aarch64-pc-windows-msvc'
+$r = Resolve-InstallerArchitecture -OSArchitectureProbe $throws -ArchEW6432 'AMD64' -ArchProc 'x86'
+Assert-Equal 'old .NET WOW64 amd64 target' $r.Target 'x86_64-pc-windows-msvc'
+
+if ($script:failures -eq 0) {
+    Write-Host "`nAll install.ps1 checks passed."
+    exit 0
+} else {
+    Write-Host "`n$($script:failures) install.ps1 check(s) failed."
+    exit 1
+}


### PR DESCRIPTION
Fixes #1821

### What I found

The Windows installer detects the CPU architecture with:

```powershell
$architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
```

`RuntimeInformation.OSArchitecture` was added in .NET Framework 4.7.1. On older
Windows PowerShell / .NET Framework hosts it isn't available, so this line throws
**"The property 'OSArchitecture' cannot be found on this object"** — the exact
error reported in #1821 — and the install aborts before doing anything.

### How I fixed it

Try `OSArchitecture` first, and if it isn't available fall back to the
architecture environment variables, which exist on every Windows version:

- `PROCESSOR_ARCHITEW6432` first (holds the real architecture inside a 32-bit
  WOW64 process),
- then `PROCESSOR_ARCHITECTURE`.

`AMD64` maps to `X64` and `ARM64` to `Arm64`, feeding the existing target `switch`
unchanged. A 64-bit OS is already required a few lines above, so no 32-bit case
needs handling.

### Why this fully resolves it

The failure is a single missing-property error, and the fallback is the standard,
universally-available way to read the architecture — so the reported install
failure simply no longer occurs, on both modern and old PowerShell. There's no
behavior change on hosts where `OSArchitecture` already works (that path is tried
first and unchanged).

### Testing

I added `scripts/install/test_install_ps1.ps1` (alongside the existing
`test_install_sh.py`). Rather than duplicate the logic, it **extracts the real
architecture-detection block from `install.ps1`** and runs it, only swapping the
`RuntimeInformation.OSArchitecture` access for a probe the test controls — so it
can simulate a host where that property is missing without needing an actual old
.NET box. It covers:

- **modern hosts** (`OSArchitecture` works) → `x64`/`arm64` resolve unchanged;
- **the #1821 case** (`OSArchitecture` throws) → falls back to
  `PROCESSOR_ARCHITECTURE` (`AMD64`→x64, `ARM64`→arm64);
- **32-bit WOW64 PowerShell** → resolves the real arch from
  `PROCESSOR_ARCHITEW6432`;

plus a parse check that the real `install.ps1` has no syntax errors.

Run it on any PowerShell (Windows PowerShell 5.1 or `pwsh` on macOS/Linux/Windows):

```
pwsh -NoProfile -File scripts/install/test_install_ps1.ps1
```

Output (run on `pwsh` 7 / macOS):

```
PASS: install.ps1 parses cleanly
PASS: modern x64 target -> x86_64-pc-windows-msvc
PASS: modern arm64 target -> aarch64-pc-windows-msvc
PASS: old .NET amd64 target -> x86_64-pc-windows-msvc
PASS: old .NET arm64 target -> aarch64-pc-windows-msvc
PASS: old .NET WOW64 arm64 target -> aarch64-pc-windows-msvc
PASS: old .NET WOW64 amd64 target -> x86_64-pc-windows-msvc

All install.ps1 checks passed.
```

The test is CI-friendly (exits non-zero on failure), so it can be wired into a
`pwsh`-based workflow if desired.

### Testing notes

The fix is defensive on both fronts: a missing-property access that raises a
*terminating* error is caught by `try`/`catch`, and a *non-terminating* one
leaves `$architecture` empty and is caught by the `IsNullOrWhiteSpace` fallback —
so it recovers regardless of how the missing property surfaces on a given host.
The committed test exercises this by making `OSArchitecture` throw against the
real installer block. (Old .NET Framework < 4.7.1 hosts are rare today, so I
validated via that simulation rather than a live legacy box.)
