### PR TITLE
Fix portable, hermetic skill discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,23 @@ binary override:
 
 Open Interpreter speaks the same Codex exec protocol. See the [SDK guide](https://www.openinterpreter.com/docs/terminal/sdk) and run `scripts/test-codex-sdk-compat.sh` for a local, provider-free compatibility check.
 
+## Portable by default
+
+Open Interpreter should fit into your existing agent setup instead of trapping
+it in an Open Interpreter-only format. The product goal is to prefer shared,
+tool-neutral standards and directories, keep user-authored data in readable
+files, and make moving to or from another compatible agent straightforward.
+
+Today that includes repository `AGENTS.md`, shared `.agents/skills` directories,
+MCP, ACP, and the Codex exec protocol. Product-specific storage under
+`~/.openinterpreter` is reserved for configuration and runtime state that does
+not yet have a practical shared standard. Legacy product-specific skill
+directories remain readable for compatibility, but new skills belong in
+`.agents/skills` or `~/.agents/skills`.
+
+See the [portability guide](docs/portability.md) for the current boundary and
+the rules for evolving it.
+
 ## Computer Use
 
 Open Interpreter ships with a QA skill that lets any model operate and test interfaces. It can drive web apps in a real browser with [agent-browser](https://github.com/vercel-labs/agent-browser), or operate and test native apps with [trycua](https://github.com/trycua/cua).
@@ -90,7 +107,8 @@ Open Interpreter ships with a QA skill that lets any model operate and test inte
 - Inspects or switches Rust-native model harnesses with `/harness`.
 - Tests web and native apps through the built-in QA skill.
 - Runs as an [Agent Client Protocol](https://agentclientprotocol.com/) agent for editors with `interpreter acp`.
-- Keeps config and session state local under `~/.openinterpreter`.
+- Reuses shared `AGENTS.md` instructions and `.agents/skills` directories.
+- Keeps product-only config and session state local under `~/.openinterpreter`.
 - Supports `exec`, MCP, skills, hooks, permissions, and `AGENTS.md`.
 
 ## Documentation
@@ -107,6 +125,7 @@ Open Interpreter ships with a QA skill that lets any model operate and test inte
   - [Z.AI, GLM, and ZCode](https://www.openinterpreter.com/docs/terminal/zai-glm?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=zai_glm_docs)
 - [Agent Client Protocol](https://www.openinterpreter.com/docs/terminal/acp)
 - [Codex SDK](https://www.openinterpreter.com/docs/terminal/sdk)
+- [Portability](https://www.openinterpreter.com/docs/terminal/portability)
 - [Sandbox & approvals](https://www.openinterpreter.com/docs/terminal/sandbox?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=sandbox_approvals)
 
 Provider and model membership is generated, not maintained as Rust lists. From

--- a/codex-rs/core-skills/src/loader.rs
+++ b/codex-rs/core-skills/src/loader.rs
@@ -31,7 +31,6 @@ use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_absolute_path::AbsolutePathBufGuard;
 use codex_utils_path_uri::PathUri;
 use codex_utils_plugins::PluginSkillRoot;
-use dirs::home_dir;
 use discovery::DirectorySymlinkPolicy;
 use discovery::DiscoveredSkill;
 use discovery::HiddenDirectoryPolicy;
@@ -250,27 +249,7 @@ pub(crate) async fn load_skill_root(root: SkillRoot) -> SkillRootSnapshot {
     }
 }
 
-pub(crate) async fn skill_roots(
-    fs: Option<Arc<dyn ExecutorFileSystem>>,
-    config_layer_stack: &ConfigLayerStack,
-    cwd: &AbsolutePathBuf,
-    plugin_skill_roots: Vec<PluginSkillRoot>,
-    extra_skill_roots: Vec<AbsolutePathBuf>,
-) -> Vec<SkillRoot> {
-    let home_dir =
-        home_dir().and_then(|path| AbsolutePathBuf::from_absolute_path_checked(path).ok());
-    skill_roots_with_home_dir(
-        fs,
-        config_layer_stack,
-        cwd,
-        home_dir.as_ref(),
-        plugin_skill_roots,
-        extra_skill_roots,
-    )
-    .await
-}
-
-async fn skill_roots_with_home_dir(
+pub(crate) async fn skill_roots_with_home_dir(
     fs: Option<Arc<dyn ExecutorFileSystem>>,
     config_layer_stack: &ConfigLayerStack,
     cwd: &AbsolutePathBuf,
@@ -329,18 +308,8 @@ fn skill_roots_from_layer_stack_inner(
                 }
             }
             ConfigLayerSource::User { .. } => {
-                // Deprecated user skills location (`$CODEX_HOME/skills`), kept for backward
-                // compatibility.
-                roots.push(SkillRoot {
-                    path: config_folder.join(SKILLS_DIR_NAME),
-                    scope: SkillScope::User,
-                    file_system: Arc::clone(&LOCAL_FS),
-                    plugin_id: None,
-                    plugin_namespace: None,
-                    plugin_root: None,
-                });
-
-                // `$HOME/.agents/skills` (user-installed skills).
+                // Prefer the shared Agent Skills location so compatible tools can use the same
+                // user-authored skills without copying or importing them.
                 if let Some(home_dir) = home_dir {
                     roots.push(SkillRoot {
                         path: home_dir.join(AGENTS_DIR_NAME).join(SKILLS_DIR_NAME),
@@ -351,6 +320,17 @@ fn skill_roots_from_layer_stack_inner(
                         plugin_root: None,
                     });
                 }
+
+                // Deprecated product-specific user skills location (`$CODEX_HOME/skills`), kept
+                // as a compatibility fallback.
+                roots.push(SkillRoot {
+                    path: config_folder.join(SKILLS_DIR_NAME),
+                    scope: SkillScope::User,
+                    file_system: Arc::clone(&LOCAL_FS),
+                    plugin_id: None,
+                    plugin_namespace: None,
+                    plugin_root: None,
+                });
 
                 // Embedded system skills are cached under `$CODEX_HOME/skills/.system` and are a
                 // special case (not a config layer).

--- a/codex-rs/core-skills/src/loader_tests.rs
+++ b/codex-rs/core-skills/src/loader_tests.rs
@@ -360,11 +360,11 @@ async fn skill_roots_from_layer_stack_maps_user_to_user_and_system_cache_and_sys
     assert_eq!(
         got,
         vec![
-            (SkillScope::User, user_folder.join("skills")),
             (
                 SkillScope::User,
                 home_folder.join(AGENTS_DIR_NAME).join(SKILLS_DIR_NAME)
             ),
+            (SkillScope::User, user_folder.join("skills")),
             (
                 SkillScope::System,
                 user_folder.join("skills").join(".system")
@@ -430,11 +430,11 @@ async fn skill_roots_from_layer_stack_includes_disabled_project_layers() -> anyh
         got,
         vec![
             (SkillScope::Repo, dot_codex.join("skills")),
-            (SkillScope::User, user_folder.join("skills")),
             (
                 SkillScope::User,
                 home_folder.join(AGENTS_DIR_NAME).join(SKILLS_DIR_NAME)
             ),
+            (SkillScope::User, user_folder.join("skills")),
             (
                 SkillScope::System,
                 user_folder.join("skills").join(".system")
@@ -2816,11 +2816,13 @@ async fn loads_skills_from_system_cache_when_present() {
 async fn skill_roots_include_admin_with_lowest_priority() {
     let codex_home = tempfile::tempdir().expect("tempdir");
     let cfg = make_config(&codex_home).await;
+    let user_home = codex_home.path().abs();
 
-    let scopes: Vec<SkillScope> = super::skill_roots(
+    let scopes: Vec<SkillScope> = super::skill_roots_with_home_dir(
         Some(Arc::clone(&LOCAL_FS)),
         &cfg.config_layer_stack,
         &cfg.cwd,
+        Some(&user_home),
         Vec::new(),
         Vec::new(),
     )
@@ -2828,10 +2830,11 @@ async fn skill_roots_include_admin_with_lowest_priority() {
     .into_iter()
     .map(|root| root.scope)
     .collect();
-    let mut expected = vec![SkillScope::User, SkillScope::System];
-    if home_dir().is_some() {
-        expected.insert(1, SkillScope::User);
-    }
-    expected.push(SkillScope::Admin);
+    let expected = vec![
+        SkillScope::User,
+        SkillScope::User,
+        SkillScope::System,
+        SkillScope::Admin,
+    ];
     assert_eq!(scopes, expected);
 }

--- a/codex-rs/core-skills/src/service.rs
+++ b/codex-rs/core-skills/src/service.rs
@@ -24,10 +24,11 @@ use crate::config_rules::skill_config_rules_from_stack;
 use crate::loader::MAX_CONCURRENT_ROOT_SCANS;
 use crate::loader::SkillRoot;
 use crate::loader::load_skills_from_roots;
-use crate::loader::skill_roots;
+use crate::loader::skill_roots_with_home_dir;
 use crate::system::install_system_skills;
 use crate::system::uninstall_system_skills;
 use codex_config::SkillsConfig;
+use dirs::home_dir;
 
 #[derive(Debug, Clone)]
 pub struct SkillsLoadInput {
@@ -69,6 +70,7 @@ impl SkillsLoadInput {
 /// Source-specific model exposure remains the responsibility of the skills extension.
 pub struct SkillsService {
     codex_home: AbsolutePathBuf,
+    user_home: Option<AbsolutePathBuf>,
     restriction_product: Option<Product>,
     extra_roots: RwLock<Vec<AbsolutePathBuf>>,
     cache_by_cwd: RwLock<HashMap<AbsolutePathBuf, HostSkillsSnapshot>>,
@@ -87,8 +89,42 @@ impl SkillsService {
         bundled_skills_enabled: bool,
         restriction_product: Option<Product>,
     ) -> Self {
+        let user_home =
+            home_dir().and_then(|path| AbsolutePathBuf::from_absolute_path_checked(path).ok());
+        Self::new_inner(
+            codex_home,
+            bundled_skills_enabled,
+            restriction_product,
+            user_home,
+        )
+    }
+
+    /// Creates a skills service whose user-installed skills are resolved from an explicit home.
+    ///
+    /// This is useful for isolated runtimes and tests that must not inspect the host process home.
+    pub fn new_with_restriction_product_and_user_home(
+        codex_home: AbsolutePathBuf,
+        bundled_skills_enabled: bool,
+        restriction_product: Option<Product>,
+        user_home: AbsolutePathBuf,
+    ) -> Self {
+        Self::new_inner(
+            codex_home,
+            bundled_skills_enabled,
+            restriction_product,
+            Some(user_home),
+        )
+    }
+
+    fn new_inner(
+        codex_home: AbsolutePathBuf,
+        bundled_skills_enabled: bool,
+        restriction_product: Option<Product>,
+        user_home: Option<AbsolutePathBuf>,
+    ) -> Self {
         let service = Self {
             codex_home,
+            user_home,
             restriction_product,
             extra_roots: RwLock::new(Vec::new()),
             cache_by_cwd: RwLock::new(HashMap::new()),
@@ -157,10 +193,11 @@ impl SkillsService {
         input: &SkillsLoadInput,
         fs: Option<Arc<dyn ExecutorFileSystem>>,
     ) -> Vec<SkillRoot> {
-        let mut roots = skill_roots(
+        let mut roots = skill_roots_with_home_dir(
             fs,
             &input.config_layer_stack,
             &input.cwd,
+            self.user_home.as_ref(),
             input.effective_skill_roots.clone(),
             self.extra_roots(),
         )
@@ -185,10 +222,11 @@ impl SkillsService {
             return snapshot;
         }
 
-        let mut roots = skill_roots(
+        let mut roots = skill_roots_with_home_dir(
             fs.clone(),
             &input.config_layer_stack,
             &input.cwd,
+            self.user_home.as_ref(),
             input.effective_skill_roots.clone(),
             self.extra_roots(),
         )

--- a/codex-rs/core-skills/src/service_tests.rs
+++ b/codex-rs/core-skills/src/service_tests.rs
@@ -27,6 +27,13 @@ fn write_user_skill(codex_home: &TempDir, dir: &str, name: &str, description: &s
     fs::write(skill_dir.join("SKILL.md"), content).unwrap();
 }
 
+fn write_home_agents_skill(user_home: &TempDir, dir: &str, name: &str, description: &str) {
+    let skill_dir = user_home.path().join(".agents").join("skills").join(dir);
+    fs::create_dir_all(&skill_dir).unwrap();
+    let content = format!("---\nname: {name}\ndescription: {description}\n---\n\n# Body\n");
+    fs::write(skill_dir.join("SKILL.md"), content).unwrap();
+}
+
 fn write_plugin_skill(
     codex_home: &TempDir,
     marketplace: &str,
@@ -199,6 +206,33 @@ fn new_with_disabled_bundled_skills_removes_stale_cached_system_skills() {
         !codex_home.path().join("skills/.system").exists(),
         "expected disabling system skills to remove stale cached bundled skills"
     );
+}
+
+#[tokio::test]
+async fn explicit_user_home_isolates_user_installed_skill_discovery() {
+    let codex_home = tempfile::tempdir().expect("tempdir");
+    let user_home = tempfile::tempdir().expect("tempdir");
+    let other_home = tempfile::tempdir().expect("tempdir");
+    let cwd = tempfile::tempdir().expect("tempdir");
+    write_home_agents_skill(&user_home, "included", "included-skill", "included");
+    write_home_agents_skill(&other_home, "excluded", "excluded-skill", "excluded");
+    let config_layer_stack = config_stack(&codex_home, "");
+    let skills_service = SkillsService::new_with_restriction_product_and_user_home(
+        codex_home.path().abs(),
+        /*bundled_skills_enabled*/ false,
+        Some(Product::Codex),
+        user_home.path().abs(),
+    );
+
+    let outcome =
+        skills_for_config_with_stack(&skills_service, &cwd, &config_layer_stack, &[]).await;
+    let names = outcome
+        .skills
+        .iter()
+        .map(|skill| skill.name.as_str())
+        .collect::<HashSet<_>>();
+
+    assert_eq!(names, HashSet::from(["included-skill"]));
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -340,11 +340,20 @@ impl ThreadManager {
             Arc::clone(&extensions),
             codex_apps_tools_cache,
         ));
-        let skills_service = Arc::new(SkillsService::new_with_restriction_product(
-            codex_home,
-            config.bundled_skills_enabled(),
-            restriction_product,
-        ));
+        let skills_service = Arc::new(if should_use_test_thread_manager_behavior() {
+            SkillsService::new_with_restriction_product_and_user_home(
+                codex_home.clone(),
+                config.bundled_skills_enabled(),
+                restriction_product,
+                codex_home,
+            )
+        } else {
+            SkillsService::new_with_restriction_product(
+                codex_home,
+                config.bundled_skills_enabled(),
+                restriction_product,
+            )
+        });
         Self {
             state: Arc::new(ThreadManagerState {
                 threads: Arc::new(RwLock::new(HashMap::new())),
@@ -448,10 +457,11 @@ impl ThreadManager {
             auth_manager.get_api_auth_mode(),
         ));
         let mcp_manager = Arc::new(McpManager::new(Arc::clone(&plugins_manager)));
-        let skills_service = Arc::new(SkillsService::new_with_restriction_product(
-            skills_codex_home,
+        let skills_service = Arc::new(SkillsService::new_with_restriction_product_and_user_home(
+            skills_codex_home.clone(),
             /*bundled_skills_enabled*/ true,
             restriction_product,
+            skills_codex_home,
         ));
         // This test constructor has no Config input. Tests that need a non-local
         // process store should construct ThreadManager::new with an explicit store.

--- a/docs.json
+++ b/docs.json
@@ -33,6 +33,7 @@
           "docs/quickstart",
           "docs/use-cases",
           "docs/migrate",
+          "docs/portability",
           {
             "group": "Concepts",
             "pages": [

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -6,6 +6,10 @@ description: Bring Codex or other compatible agent setup into Open Interpreter.
 Open Interpreter can reuse much of the Codex-style local setup because the CLI
 surface and configuration model are closely related.
 
+The long-term goal is that standards-based agent setup does not need a
+migration at all: Open Interpreter should read shared files and directories in
+place whenever a practical cross-tool standard exists.
+
 ## What Usually Migrates
 
 | Source item | Open Interpreter destination |
@@ -19,6 +23,9 @@ surface and configuration model are closely related.
 | Subagents | `[agents]` config |
 | Recent sessions | Local session history where supported |
 
+Skills already stored under `.agents/skills/` or `~/.agents/skills/` do not
+need to be copied. Open Interpreter reads those shared locations directly.
+
 ## Review After Import
 
 Review migrated setup before relying on it:
@@ -31,8 +38,9 @@ Review migrated setup before relying on it:
 
 ## Codex Home
 
-Open Interpreter uses `~/.openinterpreter/` for its user state. If you previously
-used Codex, inspect both homes during migration:
+Open Interpreter uses `~/.openinterpreter/` for product-specific configuration
+and runtime state that does not yet have a practical shared home. If you
+previously used Codex, inspect both homes during migration:
 
 ```text
 ~/.codex/
@@ -40,4 +48,5 @@ used Codex, inspect both homes during migration:
 ```
 
 Do not copy secrets blindly. Prefer re-authenticating or using environment
-variables.
+variables. Keep portable, user-authored content such as skills in the shared
+locations above rather than either product home.

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -1,0 +1,64 @@
+---
+title: Portability
+description: How Open Interpreter uses shared agent standards and avoids product lock-in.
+---
+
+Open Interpreter's goal is to participate in a shared agent ecosystem, not
+create a private island of instructions, skills, and workflows. When a
+practical cross-tool standard exists, Open Interpreter should read it directly
+and preserve it in a form other compatible tools can use.
+
+This is a product direction and an engineering constraint. It is not a claim
+that every kind of runtime state already has a universal format.
+
+## Principles
+
+- Prefer established, tool-neutral protocols and directory conventions over
+  Open Interpreter-specific equivalents.
+- Keep user-authored instructions, skills, and configuration readable and
+  inspectable.
+- Read shared content in place instead of requiring an import or private copy.
+- Keep compatibility readers for legacy product paths during migrations.
+- Make export and migration possible when no shared live format exists.
+- Reserve product-specific storage for secrets, caches, indexes, logs, and
+  runtime state that cannot yet be represented safely by a shared standard.
+
+## Current Shared Surface
+
+| Capability | Shared surface |
+| ---------- | -------------- |
+| Project instructions | `AGENTS.md` |
+| Project skills | `.agents/skills/` |
+| Personal skills | `~/.agents/skills/` |
+| Tool integrations | Model Context Protocol (MCP) |
+| Editor and client integration | Agent Client Protocol (ACP) |
+| Programmatic execution | Codex-compatible exec protocol |
+
+These locations and protocols should work without converting the user's data
+into an Open Interpreter-only representation.
+
+## Product-Specific State
+
+Open Interpreter currently keeps configuration, credentials, session history,
+logs, caches, and daemon state under `~/.openinterpreter` or the operating
+system credential store. Some of that state is inherently product-specific;
+some may move to a shared standard when a safe and broadly adopted one exists.
+
+The legacy `~/.openinterpreter/skills/` directory remains readable so existing
+setups do not break. Shared `~/.agents/skills/` is the preferred home for new
+personal skills.
+
+## What This Means for Changes
+
+Before adding a new product-owned file format or directory, first check whether
+an established agent, editor, or operating-system standard can represent the
+same data. If a product-specific format is still necessary:
+
+1. Use plain, documented data where practical.
+2. Keep the boundary narrow.
+3. Provide a migration or export path for user-authored data.
+4. Avoid making the product-specific copy the only usable source of truth.
+
+The test for a portable feature is simple: a user should be able to understand
+where their data lives, reuse the standardized parts with another compatible
+tool, and leave Open Interpreter without losing user-authored work.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -47,6 +47,16 @@ The `description` controls when the skill is selected, so make it specific.
 
 Local skills take priority over personal and bundled skills when names collide.
 
+Use the `.agents/skills` locations for new skills. They are shared,
+tool-neutral directories, so another compatible agent can use the same skill
+without an Open Interpreter import or copy.
+
+Open Interpreter also reads `~/.openinterpreter/skills/` as a legacy
+compatibility fallback. Do not use that product-specific directory for new
+user-authored skills. Bundled internal skills may still be cached under the
+Open Interpreter home because they are product assets rather than portable
+user data.
+
 ## What to Put in a Skill
 
 Use skills for repeatable procedures:


### PR DESCRIPTION
## Summary
- isolate integration-test skill discovery from the host user's real skill directory
- prefer the shared ~/.agents/skills location over the legacy product-specific fallback
- document portability and standards-first storage as a product goal

## Validation
- cargo test -p codex-core-skills (119 unit + 6 integration passed)
- cargo test -p codex-core (2,237 unit passed)
- cargo test -p codex-core --test all (984 passed, 22 ignored)
- just fix -p codex-core-skills
- just fix -p codex-core
- just fmt