### PR TITLE
fix(config): support all provider wire APIs remotely

### DIFF
--- a/codex-rs/config/src/thread_config/proto/codex.thread_config.v1.proto
+++ b/codex-rs/config/src/thread_config/proto/codex.thread_config.v1.proto
@@ -65,4 +65,6 @@ message ModelProviderAuthInfo {
 enum WireApi {
   WIRE_API_UNSPECIFIED = 0;
   WIRE_API_RESPONSES = 1;
+  WIRE_API_CHAT = 2;
+  WIRE_API_MESSAGES = 3;
 }

--- a/codex-rs/config/src/thread_config/proto/codex.thread_config.v1.rs
+++ b/codex-rs/config/src/thread_config/proto/codex.thread_config.v1.rs
@@ -100,6 +100,8 @@ pub struct ModelProviderAuthInfo {
 pub enum WireApi {
     Unspecified = 0,
     Responses = 1,
+    Chat = 2,
+    Messages = 3,
 }
 impl WireApi {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -110,6 +112,8 @@ impl WireApi {
         match self {
             Self::Unspecified => "WIRE_API_UNSPECIFIED",
             Self::Responses => "WIRE_API_RESPONSES",
+            Self::Chat => "WIRE_API_CHAT",
+            Self::Messages => "WIRE_API_MESSAGES",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -117,6 +121,8 @@ impl WireApi {
         match value {
             "WIRE_API_UNSPECIFIED" => Some(Self::Unspecified),
             "WIRE_API_RESPONSES" => Some(Self::Responses),
+            "WIRE_API_CHAT" => Some(Self::Chat),
+            "WIRE_API_MESSAGES" => Some(Self::Messages),
             _ => None,
         }
     }

--- a/codex-rs/config/src/thread_config/remote.rs
+++ b/codex-rs/config/src/thread_config/remote.rs
@@ -159,6 +159,8 @@ fn model_provider_from_proto(
     let id = provider.id;
     let wire_api = match proto::WireApi::try_from(provider.wire_api) {
         Ok(proto::WireApi::Responses) => WireApi::Responses,
+        Ok(proto::WireApi::Chat) => WireApi::Chat,
+        Ok(proto::WireApi::Messages) => WireApi::Messages,
         Ok(proto::WireApi::Unspecified) => {
             return Err(parse_error("remote thread config omitted wire_api"));
         }
@@ -289,6 +291,8 @@ fn proto_string_map(values: HashMap<String, String>) -> proto::StringMap {
 fn proto_wire_api(wire_api: WireApi) -> proto::WireApi {
     match wire_api {
         WireApi::Responses => proto::WireApi::Responses,
+        WireApi::Chat => proto::WireApi::Chat,
+        WireApi::Messages => proto::WireApi::Messages,
     }
 }
 
@@ -419,12 +423,15 @@ mod tests {
 
     #[test]
     fn model_provider_proto_roundtrips_through_domain_type() {
-        let expected = expected_provider();
-        let proto = model_provider_to_proto("local", expected.clone());
-        let (id, actual) = model_provider_from_proto(proto).expect("model provider from proto");
+        for wire_api in [WireApi::Responses, WireApi::Chat, WireApi::Messages] {
+            let mut expected = expected_provider();
+            expected.wire_api = wire_api;
+            let proto = model_provider_to_proto("local", expected.clone());
+            let (id, actual) = model_provider_from_proto(proto).expect("model provider from proto");
 
-        assert_eq!(id, "local");
-        assert_eq!(actual, expected);
+            assert_eq!(id, "local");
+            assert_eq!(actual, expected);
+        }
     }
 
     fn proto_sources() -> Vec<proto::ThreadConfigSource> {


### PR DESCRIPTION
Extends the remote thread-config protocol to represent Responses, Chat, and Messages transports, and tests round-trip conversion for all three.\n\nLocal focused validation: cargo test -p codex-config (204 passed). Full validation is delegated to GitHub Actions.