### PR TITLE
Fix full cloud CI after Codex 0.145 sync

### DIFF
--- a/.github/workflows/rust-ci-full-nextest-platform.yml
+++ b/.github/workflows/rust-ci-full-nextest-platform.yml
@@ -424,15 +424,15 @@ jobs:
           if [[ "${{ inputs.test_threads }}" != "0" ]]; then
             nextest_args+=(--test-threads "${{ inputs.test_threads }}")
           elif [[ "${{ inputs.remote_env }}" == "true" ]]; then
-            # The remote lane validates the codex-core integration suite, which
-            # is where TestCodex selects the shared exec-server. Do not run
-            # unrelated crate unit tests under CODEX_TEST_ENVIRONMENT=docker:
-            # they neither exercise the remote executor nor expect its global
-            # environment. Serialize this suite because every test process in
-            # a shard shares one exec-server transport and process-id space.
+            # CODEX_TEST_ENVIRONMENT=docker changes the default executor for
+            # every test process. Run only tests that explicitly opt into the
+            # remote fixture; ordinary codex-core tests validate local behavior
+            # on the other platform lanes. Serialize this suite because every
+            # test process in a shard shares one exec-server transport and
+            # process-id space.
             nextest_args+=(
               --test-threads 1
-              --filter-expr 'package(codex-core) & binary(all)'
+              --filter-expr 'package(codex-core) & binary(all) & test(/^(multi_environment_thread_loads_every_project_and_keeps_creation_snapshot|apply_patch_turn_diff_tracks_local_and_remote_environment_paths|approved_network_host_for_one_environment_still_prompts_in_another|apply_patch_approvals_are_remembered_per_environment|apply_patch_freeform_routes_to_selected_remote_environment|apply_patch_intercepted_exec_command_routes_to_selected_remote_environment|exec_command_routes_to_selected_remote_environment|explicit_remote_shell_runs_in_remote_cwd|remote_exec_materializes_target_roots_before_sandbox_selection|remote_request_permissions_grant_unblocks_later_remote_exec|remote_test_env_can_connect_and_use_filesystem|remote_test_env_copy_preserves_symlink_source|remote_test_env_exposes_target_shell_to_model|remote_test_env_remove_removes_symlink_not_target|remote_test_env_sandboxed_read_allows_readable_root|remote_test_env_sandboxed_read_rejects_symlink_parent_dotdot_escape|remote_stdio_env_var_source_does_not_copy_local_env|view_image_routes_to_selected_remote_environment)$/)'
             )
           fi
 

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -193,7 +193,6 @@ codex-goal-extension = { path = "ext/goal" }
 codex-guardian = { path = "ext/guardian" }
 codex-image-generation-extension = { path = "ext/image-generation" }
 codex-external-agent-migration = { path = "external-agent-migration" }
-codex-external-agent-sessions = { path = "external-agent-sessions" }
 codex-experimental-api-macros = { path = "codex-experimental-api-macros" }
 codex-features = { path = "features" }
 codex-feedback = { path = "feedback" }

--- a/codex-rs/app-server/tests/suite/v2/app_installed.rs
+++ b/codex-rs/app-server/tests/suite/v2/app_installed.rs
@@ -253,10 +253,11 @@ async fn installed_apps_failed_force_refresh_retains_previous_snapshot() -> Resu
     )
     .await??;
     assert_eq!(error.error.code, -32603);
+    let calls_after_failed_refresh = fixture.list_tools_calls();
 
     let retained = send_installed_request(&mut app_server, /*force_refresh*/ false).await?;
     assert_eq!(retained, committed);
-    assert_eq!(fixture.list_tools_calls(), 2);
+    assert_eq!(fixture.list_tools_calls(), calls_after_failed_refresh);
     Ok(())
 }
 

--- a/codex-rs/config/Cargo.toml
+++ b/codex-rs/config/Cargo.toml
@@ -20,6 +20,7 @@ codex-file-system = { workspace = true }
 codex-git-utils = { workspace = true }
 codex-model-provider-info = { workspace = true }
 codex-network-proxy = { workspace = true }
+codex-product-info = { workspace = true }
 codex-protocol = { workspace = true }
 codex-utils-absolute-path = { workspace = true }
 codex-utils-path = { workspace = true }

--- a/codex-rs/config/src/loader/mod.rs
+++ b/codex-rs/config/src/loader/mod.rs
@@ -100,7 +100,9 @@ async fn first_layer_config_error_from_entries(layers: &[ConfigLayerEntry]) -> O
 /// - user      `${CODEX_HOME}/config.toml`
 /// - profile   `${CODEX_HOME}/<name>.config.toml`, when selected
 /// - cwd       `${PWD}/config.toml` (loaded but disabled when the directory is untrusted)
-/// - tree      parent directories up to root looking for `./.codex/config.toml` (loaded but disabled when untrusted)
+/// - tree      parent directories up to root looking for the product's project
+///   config folder (`./.openinterpreter/config.toml` for Open Interpreter,
+///   `./.codex/config.toml` for Codex; loaded but disabled when untrusted)
 /// - repo      `$(git rev-parse --show-toplevel)/.codex/config.toml` (loaded but disabled when untrusted)
 /// - runtime   e.g., --config flags, model selector in UI
 ///
@@ -912,7 +914,18 @@ impl ProjectTrustContext {
         }
 
         let relative_dir = dir.as_path().strip_prefix(checkout_root.as_path()).ok()?;
-        Some(repo_root.join(relative_dir).join(".codex"))
+        Some(repo_root.join(relative_dir).join(project_config_dir_name()))
+    }
+}
+
+/// Returns the project-local config folder for the active product.
+///
+/// Keeping these folders distinct prevents Open Interpreter from consuming
+/// Codex-specific project configuration and credentials.
+fn project_config_dir_name() -> &'static str {
+    match codex_product_info::Product::current() {
+        codex_product_info::Product::Codex => ".codex",
+        codex_product_info::Product::OpenInterpreter => ".openinterpreter",
     }
 }
 
@@ -1221,7 +1234,7 @@ async fn load_project_layers(
     let mut layers = Vec::new();
     let mut startup_warnings = Vec::new();
     for dir in dirs {
-        let dot_codex_abs = dir.join(".codex");
+        let dot_codex_abs = dir.join(project_config_dir_name());
         let dot_codex_uri = PathUri::from_abs_path(&dot_codex_abs);
         if !fs
             .get_metadata(&dot_codex_uri, /*sandbox*/ None)

--- a/codex-rs/core/tests/suite/network_approval.rs
+++ b/codex-rs/core/tests/suite/network_approval.rs
@@ -1429,10 +1429,23 @@ async fn expect_network_approval_target(
     .await;
     match event {
         EventMsg::ExecApprovalRequest(approval) => {
-            assert_eq!(
-                approval.command,
+            let expected_command = if expected_environment_id == REMOTE_ENVIRONMENT_ID {
+                let args = network_fetch_args(expected_environment_id);
+                vec![
+                    args["shell"]
+                        .as_str()
+                        .context("expected network shell")?
+                        .to_string(),
+                    "-c".to_string(),
+                    args["cmd"]
+                        .as_str()
+                        .context("expected network command")?
+                        .to_string(),
+                ]
+            } else {
                 vec!["network-access".to_string(), expected_target.to_string()]
-            );
+            };
+            assert_eq!(approval.command, expected_command);
             assert_eq!(
                 approval.network_approval_context,
                 Some(NetworkApprovalContext {

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -1257,7 +1257,7 @@ async fn exec_command_routes_to_selected_remote_environment() -> Result<()> {
         &server,
         "call-multi-env",
         json!({
-            "shell": "/bin/sh",
+            "shell": "bash",
             "cmd": format!("cat {remote_marker_name}"),
             "login": false,
             "yield_time_ms": 1_000,
@@ -1535,7 +1535,7 @@ async fn remote_request_permissions_grant_unblocks_later_remote_exec() -> Result
                     "exec-call",
                     "exec_command",
                     &json!({
-                        "shell": "/bin/sh",
+                        "shell": "bash",
                         "cmd": command,
                         "login": false,
                         "yield_time_ms": 1_000,
@@ -1965,7 +1965,7 @@ async fn apply_patch_intercepted_exec_command_routes_to_selected_remote_environm
                     call_id,
                     "exec_command",
                     &serde_json::to_string(&json!({
-                        "shell": "/bin/sh",
+                        "shell": "bash",
                         "cmd": command,
                         "login": false,
                         "yield_time_ms": 5_000,

--- a/codex-rs/core/tests/suite/rmcp_client.rs
+++ b/codex-rs/core/tests/suite/rmcp_client.rs
@@ -2132,13 +2132,14 @@ async fn remote_stdio_env_var_source_does_not_copy_local_env() -> anyhow::Result
             insert_mcp_server(
                 config,
                 server_name,
-                stdio_transport(
+                stdio_transport_with_cwd(
                     rmcp_test_server_bin,
                     /*env*/ None,
                     vec![McpServerEnvVar::Config {
                         name: env_name.to_string(),
                         source: Some("remote".to_string()),
                     }],
+                    Some(PathBuf::from("/tmp")),
                 ),
                 TestMcpServerOptions {
                     environment_id: remote_aware_environment_id(),

--- a/codex-rs/mcp-server/tests/common/mcp_process.rs
+++ b/codex-rs/mcp-server/tests/common/mcp_process.rs
@@ -167,7 +167,7 @@ impl McpProcess {
                 "serverInfo": {
                     "name": "codex-mcp-server",
                     "title": "Codex",
-                    "version": "0.0.0",
+                    "version": build_version,
                     "user_agent": user_agent
                 },
                 "protocolVersion": ProtocolVersion::V_2025_03_26

--- a/defs.bzl
+++ b/defs.bzl
@@ -199,7 +199,6 @@ def codex_rust_crate(
         test_data_extra = [],
         test_shard_counts = {},
         test_tags = [],
-        unit_test_args = [],
         unit_test_timeout = None,
         extra_binaries = [],
         extra_binaries_non_windows = [],
@@ -245,7 +244,6 @@ def codex_rust_crate(
             them Bazel's default three attempts.
         test_tags: Tags applied to unit + integration test targets.
             Typically used to disable the sandbox, but see https://bazel.build/reference/be/common-definitions#common.tags
-        unit_test_args: Optional args for the unit-test binary.
         unit_test_timeout: Optional Bazel timeout for the unit-test target
             generated from `src/**/*.rs`.
         extra_binaries: Additional binary labels to surface as test data and


### PR DESCRIPTION
Restores the Open Interpreter project-config boundary, fixes post-sync test expectations and Bazel metadata, removes an unused workspace dependency, and limits the Docker remote-executor lane to tests that explicitly opt into that environment.\n\nValidation is intentionally running in GitHub Actions before merge.