### PR TITLE
docs: clarify the upstream contribution boundary

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,44 @@
-# External (non-OpenAI) Pull Request Requirements
+## Before opening this pull request
 
-External code contributions are by invitation only. Please read the dedicated "Contributing" markdown file for details:
-https://github.com/openai/codex/blob/main/docs/contributing.md
+Open Interpreter is built on [OpenAI Codex](https://github.com/openai/codex)
+and deliberately keeps its changes to Codex small. We generally do not accept
+changes to core Codex behavior in this repository.
 
-If your PR conforms to our contribution guidelines, replace this text with a detailed and high quality description of your changes.
+Before submitting, ask whether the change would also make sense in Codex
+without Open Interpreter. If it would, please contribute it to
+[`openai/codex`](https://github.com/openai/codex) instead. Once accepted there,
+it will reach Open Interpreter through an upstream sync.
 
-Include a link to a bug report or enhancement request.
+Changes belong here when they are specifically about an Open Interpreter-owned
+surface, such as its additional harnesses, provider/model support, branding,
+Open Interpreter endpoints, ACP support, compatibility/import behavior,
+standalone packaging and updates, or product documentation.
+
+- [ ] I considered whether this change belongs in `openai/codex`.
+- [ ] This change is specific to an Open Interpreter-owned surface, or I have
+      linked the upstream Codex contribution below.
+
+## Why this belongs in Open Interpreter
+
+<!--
+Required, especially if this changes code inherited from Codex.
+
+Explain what makes the change Open Interpreter-specific and which
+Open Interpreter-owned surface it supports. If the core change has been or
+will be proposed upstream, link that issue or pull request instead.
+
+Pull requests that change general Codex behavior without a clear
+Open Interpreter-specific reason will usually be redirected upstream.
+-->
+
+## Summary
+
+<!-- Describe the change and its user-visible effect. -->
+
+## Related issue
+
+<!-- Link the bug report, feature request, or upstream Codex contribution. -->
+
+## Test plan
+
+<!-- List the checks you ran and any platform-specific validation. -->


### PR DESCRIPTION
## Summary

- replace the inherited invitation-only Codex template with Open Interpreter’s actual contribution boundary
- ask contributors to send general Codex behavior changes to `openai/codex`
- require an Open Interpreter-specific rationale when a pull request changes inherited Codex code
- add focused summary, issue, and test-plan sections

## Upstream sync

Resolved the latest stable, non-prerelease Codex tag:

- tag: `rust-v0.145.0`
- peeled commit: `25af12f7e61572b0bc18ddb1008be543b91519b0`

That commit is already an ancestor of Open Interpreter `main`, so there is no newer stable upstream code to merge.

## Test plan

- `git diff --check`
- public GitHub checks
