### PR TITLE
Scope model cache by configured provider

### DIFF
--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -38,6 +38,7 @@ use codex_login::CodexAuth;
 use codex_login::default_client::CODEX_INTERNAL_ORIGINATOR_OVERRIDE_ENV_VAR;
 use codex_login::default_client::originator;
 use codex_model_provider::create_model_provider;
+use codex_model_provider::create_model_provider_with_cache_id;
 use codex_model_provider_info::ModelProviderInfo;
 use codex_model_provider_info::OPENAI_PROVIDER_ID;
 use codex_models_manager::manager::RefreshStrategy;
@@ -272,7 +273,11 @@ pub fn build_models_manager(
     config: &Config,
     auth_manager: Arc<AuthManager>,
 ) -> SharedModelsManager {
-    let provider = create_model_provider(config.model_provider.clone(), Some(auth_manager));
+    let provider = create_model_provider_with_cache_id(
+        config.model_provider_id.clone(),
+        config.model_provider.clone(),
+        Some(auth_manager),
+    );
     provider.models_manager(
         config.codex_home.to_path_buf(),
         config.model_catalog.clone(),

--- a/codex-rs/core/tests/suite/models_cache_ttl.rs
+++ b/codex-rs/core/tests/suite/models_cache_ttl.rs
@@ -38,6 +38,7 @@ use wiremock::MockServer;
 
 const ETAG: &str = "\"models-etag-ttl\"";
 const CACHE_FILE: &str = "models_cache.json";
+const PROVIDER_ID: &str = "openai";
 const REMOTE_MODEL: &str = "codex-test-ttl";
 const VERSIONED_MODEL: &str = "codex-test-versioned";
 const MISSING_VERSION_MODEL: &str = "codex-test-missing-version";
@@ -171,6 +172,7 @@ async fn uses_cache_when_version_matches() -> Result<()> {
             let cache = ModelsCache {
                 fetched_at: Utc::now(),
                 etag: None,
+                provider_id: Some(PROVIDER_ID.to_string()),
                 client_version: Some(client_version_to_whole()),
                 models: vec![cached_model],
             };
@@ -221,6 +223,7 @@ async fn refreshes_when_cache_version_missing() -> Result<()> {
             let cache = ModelsCache {
                 fetched_at: Utc::now(),
                 etag: None,
+                provider_id: Some(PROVIDER_ID.to_string()),
                 client_version: None,
                 models: vec![cached_model],
             };
@@ -272,6 +275,7 @@ async fn refreshes_when_cache_version_differs() -> Result<()> {
             let cache = ModelsCache {
                 fetched_at: Utc::now(),
                 etag: None,
+                provider_id: Some(PROVIDER_ID.to_string()),
                 client_version: Some(format!("{client_version}-diff")),
                 models: vec![cached_model],
             };
@@ -301,6 +305,117 @@ async fn refreshes_when_cache_version_differs() -> Result<()> {
     assert!(
         models_request_count >= 1,
         "/models should be called when cache version differs"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn refreshes_when_cache_provider_differs() -> Result<()> {
+    let server = MockServer::start().await;
+    let cached_model = test_remote_model("cached-other-provider", /*priority*/ 1);
+    let models_mock = responses::mount_models_once(
+        &server,
+        ModelsResponse {
+            models: vec![test_remote_model(
+                "remote-current-provider",
+                /*priority*/ 2,
+            )],
+        },
+    )
+    .await;
+
+    let mut builder = test_codex().with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing());
+    builder = builder
+        .with_pre_build_hook(move |home| {
+            let cache = ModelsCache {
+                fetched_at: Utc::now(),
+                etag: None,
+                provider_id: Some("different-provider".to_string()),
+                client_version: Some(client_version_to_whole()),
+                models: vec![cached_model],
+            };
+            let cache_path = home.join(CACHE_FILE);
+            write_cache_sync(&cache_path, &cache).expect("write cache");
+        })
+        .with_config(|config| {
+            config.model_provider.request_max_retries = Some(0);
+        });
+
+    let test = builder.build(&server).await?;
+    let models = test
+        .thread_manager
+        .get_models_manager()
+        .list_models(
+            RefreshStrategy::OnlineIfUncached,
+            codex_core::test_support::default_http_client_factory(),
+        )
+        .await;
+
+    assert!(
+        models
+            .iter()
+            .any(|preset| preset.model == "remote-current-provider"),
+        "expected models for the active provider"
+    );
+    assert_eq!(
+        models_mock.requests().len(),
+        1,
+        "/models should be called when the cache provider differs"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn refreshes_when_cache_provider_missing() -> Result<()> {
+    let server = MockServer::start().await;
+    let cached_model = test_remote_model("cached-legacy-provider", /*priority*/ 1);
+    let models_mock = responses::mount_models_once(
+        &server,
+        ModelsResponse {
+            models: vec![test_remote_model("remote-provider", /*priority*/ 2)],
+        },
+    )
+    .await;
+
+    let mut builder = test_codex().with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing());
+    builder = builder
+        .with_pre_build_hook(move |home| {
+            let cache = ModelsCache {
+                fetched_at: Utc::now(),
+                etag: None,
+                provider_id: None,
+                client_version: Some(client_version_to_whole()),
+                models: vec![cached_model],
+            };
+            let cache_path = home.join(CACHE_FILE);
+            write_cache_sync(&cache_path, &cache).expect("write cache");
+        })
+        .with_config(|config| {
+            config.model_provider.request_max_retries = Some(0);
+        });
+
+    let test = builder.build(&server).await?;
+    let models = test
+        .thread_manager
+        .get_models_manager()
+        .list_models(
+            RefreshStrategy::OnlineIfUncached,
+            codex_core::test_support::default_http_client_factory(),
+        )
+        .await;
+
+    assert!(
+        models
+            .iter()
+            .any(|preset| preset.model == "remote-provider"),
+        "expected refreshed models"
+    );
+    assert_eq!(
+        models_mock.requests().len(),
+        1,
+        "/models should be called when the cache provider is missing"
     );
 
     Ok(())
@@ -336,6 +451,8 @@ struct ModelsCache {
     fetched_at: DateTime<Utc>,
     #[serde(default)]
     etag: Option<String>,
+    #[serde(default)]
+    provider_id: Option<String>,
     #[serde(default)]
     client_version: Option<String>,
     models: Vec<ModelInfo>,

--- a/codex-rs/model-provider/src/lib.rs
+++ b/codex-rs/model-provider/src/lib.rs
@@ -24,3 +24,4 @@ pub use provider::ProviderAccountState;
 pub use provider::ProviderCapabilities;
 pub use provider::SharedModelProvider;
 pub use provider::create_model_provider;
+pub use provider::create_model_provider_with_cache_id;

--- a/codex-rs/model-provider/src/provider.rs
+++ b/codex-rs/model-provider/src/provider.rs
@@ -240,24 +240,45 @@ pub fn create_model_provider(
     provider_info: ModelProviderInfo,
     auth_manager: Option<Arc<AuthManager>>,
 ) -> SharedModelProvider {
+    let cache_provider_id = provider_info.name.clone();
+    create_model_provider_with_cache_id(cache_provider_id, provider_info, auth_manager)
+}
+
+/// Creates the default runtime model provider with the exact configured ID
+/// used to scope provider-specific disk caches.
+pub fn create_model_provider_with_cache_id(
+    cache_provider_id: String,
+    provider_info: ModelProviderInfo,
+    auth_manager: Option<Arc<AuthManager>>,
+) -> SharedModelProvider {
     if provider_info.is_amazon_bedrock() {
         Arc::new(AmazonBedrockModelProvider::new(provider_info, auth_manager))
     } else {
-        Arc::new(ConfiguredModelProvider::new(provider_info, auth_manager))
+        Arc::new(ConfiguredModelProvider::new(
+            cache_provider_id,
+            provider_info,
+            auth_manager,
+        ))
     }
 }
 
 /// Runtime model provider backed by configured `ModelProviderInfo`.
 #[derive(Clone, Debug)]
 struct ConfiguredModelProvider {
+    cache_provider_id: String,
     info: ModelProviderInfo,
     auth_manager: Option<Arc<AuthManager>>,
 }
 
 impl ConfiguredModelProvider {
-    fn new(provider_info: ModelProviderInfo, auth_manager: Option<Arc<AuthManager>>) -> Self {
+    fn new(
+        cache_provider_id: String,
+        provider_info: ModelProviderInfo,
+        auth_manager: Option<Arc<AuthManager>>,
+    ) -> Self {
         let auth_manager = auth_manager_for_provider(auth_manager, &provider_info);
         Self {
+            cache_provider_id,
             info: provider_info,
             auth_manager,
         }
@@ -347,8 +368,9 @@ impl ModelProvider for ConfiguredModelProvider {
                     self.info.clone(),
                     self.auth_manager.clone(),
                 ));
-                Arc::new(OpenAiModelsManager::new_with_base_models(
+                Arc::new(OpenAiModelsManager::new_with_base_models_for_provider(
                     codex_home,
+                    self.cache_provider_id.clone(),
                     endpoint,
                     self.auth_manager.clone(),
                     bundled_provider_model_infos(&self.info),

--- a/codex-rs/models-manager/src/cache.rs
+++ b/codex-rs/models-manager/src/cache.rs
@@ -16,14 +16,16 @@ use tracing::info;
 pub(crate) struct ModelsCacheManager {
     cache_path: PathBuf,
     cache_ttl: Duration,
+    provider_id: String,
 }
 
 impl ModelsCacheManager {
-    /// Create a new cache manager with the given path and TTL.
-    pub(crate) fn new(cache_path: PathBuf, cache_ttl: Duration) -> Self {
+    /// Create a new cache manager with the given path, TTL, and provider identity.
+    pub(crate) fn new(cache_path: PathBuf, cache_ttl: Duration, provider_id: String) -> Self {
         Self {
             cache_path,
             cache_ttl,
+            provider_id,
         }
     }
 
@@ -31,6 +33,7 @@ impl ModelsCacheManager {
     pub(crate) async fn load_fresh(&self, expected_version: &str) -> Option<ModelsCache> {
         info!(
             cache_path = %self.cache_path.display(),
+            expected_provider_id = %self.provider_id,
             expected_version,
             "models cache: attempting load_fresh"
         );
@@ -43,10 +46,20 @@ impl ModelsCacheManager {
         };
         info!(
             cache_path = %self.cache_path.display(),
+            cached_provider_id = ?cache.provider_id,
             cached_version = ?cache.client_version,
             fetched_at = %cache.fetched_at,
             "models cache: loaded cache file"
         );
+        if cache.provider_id.as_deref() != Some(self.provider_id.as_str()) {
+            info!(
+                cache_path = %self.cache_path.display(),
+                expected_provider_id = %self.provider_id,
+                cached_provider_id = ?cache.provider_id,
+                "models cache: provider mismatch"
+            );
+            return None;
+        }
         if cache.client_version.as_deref() != Some(expected_version) {
             info!(
                 cache_path = %self.cache_path.display(),
@@ -83,6 +96,7 @@ impl ModelsCacheManager {
         let cache = ModelsCache {
             fetched_at: Utc::now(),
             etag,
+            provider_id: Some(self.provider_id.clone()),
             client_version: Some(client_version),
             models: models.to_vec(),
         };
@@ -92,11 +106,19 @@ impl ModelsCacheManager {
     }
 
     /// Renew the cache TTL by updating the fetched_at timestamp to now.
-    pub(crate) async fn renew_cache_ttl(&self) -> io::Result<()> {
+    pub(crate) async fn renew_cache_ttl(&self, expected_version: &str) -> io::Result<()> {
         let mut cache = match self.load().await? {
             Some(cache) => cache,
             None => return Err(io::Error::new(ErrorKind::NotFound, "cache not found")),
         };
+        if cache.provider_id.as_deref() != Some(self.provider_id.as_str())
+            || cache.client_version.as_deref() != Some(expected_version)
+        {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                "cache identity changed before TTL renewal",
+            ));
+        }
         cache.fetched_at = Utc::now();
         self.save_internal(&cache).await
     }
@@ -163,6 +185,8 @@ pub(crate) struct ModelsCache {
     pub(crate) fetched_at: DateTime<Utc>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) etag: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) provider_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) client_version: Option<String>,
     pub(crate) models: Vec<ModelInfo>,

--- a/codex-rs/models-manager/src/manager.rs
+++ b/codex-rs/models-manager/src/manager.rs
@@ -26,6 +26,7 @@ use tracing::info;
 
 const MODEL_CACHE_FILE: &str = "models_cache.json";
 const DEFAULT_MODEL_CACHE_TTL: Duration = Duration::from_secs(300);
+const DEFAULT_PROVIDER_CACHE_ID: &str = "openai";
 
 /// Remote endpoint used by the OpenAI-compatible model manager.
 ///
@@ -239,7 +240,29 @@ impl OpenAiModelsManager {
         endpoint_client: Arc<dyn ModelsEndpointClient>,
         auth_manager: Option<Arc<AuthManager>>,
     ) -> Self {
-        Self::new_with_base_models(codex_home, endpoint_client, auth_manager, Vec::new())
+        Self::new_for_provider(
+            codex_home,
+            DEFAULT_PROVIDER_CACHE_ID.to_string(),
+            endpoint_client,
+            auth_manager,
+        )
+    }
+
+    /// Construct an OpenAI-compatible remote model manager whose disk cache is
+    /// scoped to the configured provider identity.
+    pub fn new_for_provider(
+        codex_home: PathBuf,
+        provider_id: String,
+        endpoint_client: Arc<dyn ModelsEndpointClient>,
+        auth_manager: Option<Arc<AuthManager>>,
+    ) -> Self {
+        Self::new_with_base_models_for_provider(
+            codex_home,
+            provider_id,
+            endpoint_client,
+            auth_manager,
+            Vec::new(),
+        )
     }
 
     /// Construct an OpenAI-compatible model manager seeded with provider-local
@@ -250,9 +273,31 @@ impl OpenAiModelsManager {
         auth_manager: Option<Arc<AuthManager>>,
         base_models: Vec<ModelInfo>,
     ) -> Self {
+        Self::new_with_base_models_for_provider(
+            codex_home,
+            DEFAULT_PROVIDER_CACHE_ID.to_string(),
+            endpoint_client,
+            auth_manager,
+            base_models,
+        )
+    }
+
+    /// Construct an OpenAI-compatible model manager with provider-local models
+    /// and a disk cache scoped to the configured provider identity.
+    pub fn new_with_base_models_for_provider(
+        codex_home: PathBuf,
+        provider_id: String,
+        endpoint_client: Arc<dyn ModelsEndpointClient>,
+        auth_manager: Option<Arc<AuthManager>>,
+        base_models: Vec<ModelInfo>,
+    ) -> Self {
         let cache_path = codex_home.join(MODEL_CACHE_FILE);
         Self::new_with_cache_manager(
-            Some(ModelsCacheManager::new(cache_path, DEFAULT_MODEL_CACHE_TTL)),
+            Some(ModelsCacheManager::new(
+                cache_path,
+                DEFAULT_MODEL_CACHE_TTL,
+                provider_id,
+            )),
             endpoint_client,
             auth_manager,
             base_models,
@@ -381,7 +426,9 @@ impl OpenAiModelsManager {
         let current_etag = self.get_etag().await;
         if current_etag.clone().is_some() && current_etag.as_deref() == Some(etag.as_str()) {
             if let Some(cache_manager) = self.cache_manager.as_ref()
-                && let Err(err) = cache_manager.renew_cache_ttl().await
+                && let Err(err) = cache_manager
+                    .renew_cache_ttl(&crate::client_version_to_whole())
+                    .await
             {
                 error!("failed to renew cache TTL: {err}");
             }
@@ -511,8 +558,6 @@ impl OpenAiModelsManager {
             codex_otel::start_global_timer("codex.remote_models.load_cache.duration_ms", &[]);
         let client_version = crate::client_version_to_whole();
         info!(client_version, "models cache: evaluating cache eligibility");
-        // TODO(celia-oai): Include provider identity in cache eligibility so switching
-        // providers does not reuse a fresh models_cache.json entry from another provider.
         let cache = match cache_manager.load_fresh(&client_version).await {
             Some(cache) => cache,
             None => {


### PR DESCRIPTION
Fixes #1812.

## What changed
- persist the exact configured provider ID with `models_cache.json`
- reject legacy or mismatched provider cache entries before loading them
- revalidate provider and client identities before renewing an ETag-matched cache TTL
- cover matching, mismatched, and missing provider identities in regression tests

## Validation
- `just fmt`
- GitHub CI