### PR TITLE
Fix Chat Completions tool result adjacency

### DIFF
--- a/codex-rs/chat-wire-compat/src/request.rs
+++ b/codex-rs/chat-wire-compat/src/request.rs
@@ -120,6 +120,11 @@ pub(crate) fn convert_request(
     let mut pending_reasoning_content: Option<String> = None;
     let mut pending_assistant_content: Option<Value> = None;
     let mut pending_tool_calls: Vec<ChatToolCall> = Vec::new();
+    // Responses histories can contain local context updates while tools are running. Chat
+    // Completions requires every result for an assistant tool-call group to appear before the
+    // next user message, so retain those context updates until the whole group is complete.
+    let mut pending_tool_call_ids: Vec<String> = Vec::new();
+    let mut deferred_messages: Vec<ChatMessage> = Vec::new();
     for item in &request.input {
         match item {
             ResponseItem::Message { role, content, .. } => {
@@ -135,19 +140,24 @@ pub(crate) fn convert_request(
                     );
                     continue;
                 }
-                flush_pending_assistant(
-                    &mut messages,
-                    &mut pending_reasoning_content,
-                    &mut pending_assistant_content,
-                    &mut pending_tool_calls,
-                );
-                messages.push(ChatMessage {
+                let message = ChatMessage {
                     role: chat_message_role(role).to_string(),
                     content: converted_content,
                     reasoning_content: None,
                     tool_calls: None,
                     tool_call_id: None,
-                });
+                };
+                if pending_tool_call_ids.is_empty() {
+                    flush_pending_assistant(
+                        &mut messages,
+                        &mut pending_reasoning_content,
+                        &mut pending_assistant_content,
+                        &mut pending_tool_calls,
+                    );
+                    messages.push(message);
+                } else {
+                    deferred_messages.push(message);
+                }
             }
             ResponseItem::FunctionCall {
                 name,
@@ -156,6 +166,7 @@ pub(crate) fn convert_request(
                 call_id,
                 ..
             } => {
+                pending_tool_call_ids.push(call_id.clone());
                 pending_tool_calls.push(ChatToolCall {
                     id: call_id.clone(),
                     type_: "function".to_string(),
@@ -175,6 +186,7 @@ pub(crate) fn convert_request(
                 input,
                 ..
             } => {
+                pending_tool_call_ids.push(call_id.clone());
                 pending_tool_calls.push(ChatToolCall {
                     id: call_id.clone(),
                     type_: "function".to_string(),
@@ -204,6 +216,7 @@ pub(crate) fn convert_request(
                     })
                     .to_string(),
                 };
+                pending_tool_call_ids.push(call_id.clone());
                 pending_tool_calls.push(ChatToolCall {
                     id: call_id,
                     type_: "function".to_string(),
@@ -219,8 +232,10 @@ pub(crate) fn convert_request(
                 arguments,
                 ..
             } => {
+                let call_id = call_id.clone().unwrap_or_else(|| "tool_search".to_string());
+                pending_tool_call_ids.push(call_id.clone());
                 pending_tool_calls.push(ChatToolCall {
-                    id: call_id.clone().unwrap_or_else(|| "tool_search".to_string()),
+                    id: call_id,
                     type_: "function".to_string(),
                     function: ChatFunctionCall {
                         name: "tool_search".to_string(),
@@ -241,13 +256,13 @@ pub(crate) fn convert_request(
                     &mut pending_assistant_content,
                     &mut pending_tool_calls,
                 );
-                messages.push(ChatMessage {
-                    role: "tool".to_string(),
-                    content: Some(json!(tool_output_text(output))),
-                    reasoning_content: None,
-                    tool_calls: None,
-                    tool_call_id: Some(call_id.clone()),
-                });
+                push_tool_output(
+                    &mut messages,
+                    &mut deferred_messages,
+                    &mut pending_tool_call_ids,
+                    call_id,
+                    tool_output_text(output),
+                );
             }
             ResponseItem::CustomToolCallOutput {
                 call_id, output, ..
@@ -258,13 +273,13 @@ pub(crate) fn convert_request(
                     &mut pending_assistant_content,
                     &mut pending_tool_calls,
                 );
-                messages.push(ChatMessage {
-                    role: "tool".to_string(),
-                    content: Some(json!(tool_output_text(output))),
-                    reasoning_content: None,
-                    tool_calls: None,
-                    tool_call_id: Some(call_id.clone()),
-                });
+                push_tool_output(
+                    &mut messages,
+                    &mut deferred_messages,
+                    &mut pending_tool_call_ids,
+                    call_id,
+                    tool_output_text(output),
+                );
             }
             ResponseItem::ToolSearchOutput {
                 call_id,
@@ -279,15 +294,14 @@ pub(crate) fn convert_request(
                     &mut pending_assistant_content,
                     &mut pending_tool_calls,
                 );
-                messages.push(ChatMessage {
-                    role: "tool".to_string(),
-                    content: Some(json!(tool_search_output_text(status, execution, tools))),
-                    reasoning_content: None,
-                    tool_calls: None,
-                    tool_call_id: Some(
-                        call_id.clone().unwrap_or_else(|| "tool_search".to_string()),
-                    ),
-                });
+                let call_id = call_id.clone().unwrap_or_else(|| "tool_search".to_string());
+                push_tool_output(
+                    &mut messages,
+                    &mut deferred_messages,
+                    &mut pending_tool_call_ids,
+                    &call_id,
+                    tool_search_output_text(status, execution, tools),
+                );
             }
             ResponseItem::Reasoning { content, .. } => {
                 if let Some(text) = reasoning_content_text(content.as_deref()) {
@@ -313,6 +327,16 @@ pub(crate) fn convert_request(
         &mut pending_assistant_content,
         &mut pending_tool_calls,
     );
+    for call_id in pending_tool_call_ids {
+        messages.push(ChatMessage {
+            role: "tool".to_string(),
+            content: Some(json!("aborted")),
+            reasoning_content: None,
+            tool_calls: None,
+            tool_call_id: Some(call_id),
+        });
+    }
+    messages.append(&mut deferred_messages);
     if let Some(reasoning_content) = pending_reasoning_content.take() {
         messages.push(ChatMessage {
             role: "assistant".to_string(),
@@ -344,6 +368,26 @@ pub(crate) fn convert_request(
     };
 
     Ok((chat_request, tool_kinds))
+}
+
+fn push_tool_output(
+    messages: &mut Vec<ChatMessage>,
+    deferred_messages: &mut Vec<ChatMessage>,
+    pending_tool_call_ids: &mut Vec<String>,
+    call_id: &str,
+    output: String,
+) {
+    messages.push(ChatMessage {
+        role: "tool".to_string(),
+        content: Some(json!(output)),
+        reasoning_content: None,
+        tool_calls: None,
+        tool_call_id: Some(call_id.to_string()),
+    });
+    pending_tool_call_ids.retain(|pending_call_id| pending_call_id != call_id);
+    if pending_tool_call_ids.is_empty() {
+        messages.append(deferred_messages);
+    }
 }
 
 fn flush_pending_assistant(
@@ -827,6 +871,10 @@ fn verbosity_to_string(verbosity: OpenAiVerbosity) -> String {
 }
 
 #[cfg(test)]
+#[path = "request_adjacency_tests.rs"]
+mod request_adjacency_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use codex_api::TextFormatType;
@@ -1175,13 +1223,16 @@ mod tests {
 
         let (chat, _) = convert_request(&request).expect("request should convert");
 
-        assert_eq!(chat.messages.len(), 1);
+        assert_eq!(chat.messages.len(), 2);
         assert_eq!(chat.messages[0].role, "assistant");
         assert_eq!(
             chat.messages[0].reasoning_content.as_deref(),
             Some("Need to inspect files.")
         );
         assert!(chat.messages[0].tool_calls.is_some());
+        assert_eq!(chat.messages[1].role, "tool");
+        assert_eq!(chat.messages[1].content, Some(json!("aborted")));
+        assert_eq!(chat.messages[1].tool_call_id.as_deref(), Some("call-1"));
     }
 
     #[test]

--- a/codex-rs/chat-wire-compat/src/request_adjacency_tests.rs
+++ b/codex-rs/chat-wire-compat/src/request_adjacency_tests.rs
@@ -1,0 +1,198 @@
+use super::*;
+use pretty_assertions::assert_eq;
+
+fn request_with_input(input: Vec<ResponseItem>) -> ResponsesApiRequest {
+    ResponsesApiRequest {
+        model: "gpt-5.6".to_string(),
+        instructions: String::new(),
+        input,
+        tools: Some(vec![json!({
+            "type": "function",
+            "name": "Bash",
+            "description": "Run a command",
+            "parameters": { "type": "object" }
+        })]),
+        tool_choice: "auto".to_string(),
+        parallel_tool_calls: true,
+        reasoning: None,
+        store: false,
+        stream: true,
+        stream_options: None,
+        include: Vec::new(),
+        service_tier: None,
+        prompt_cache_key: None,
+        client_metadata: None,
+        text: None,
+    }
+}
+
+fn function_call(call_id: &str) -> ResponseItem {
+    ResponseItem::FunctionCall {
+        id: None,
+        name: "Bash".to_string(),
+        namespace: None,
+        arguments: json!({ "command": "pwd" }).to_string(),
+        call_id: call_id.to_string(),
+        internal_chat_message_metadata_passthrough: None,
+    }
+}
+
+fn function_output(call_id: &str, output: &str) -> ResponseItem {
+    ResponseItem::FunctionCallOutput {
+        id: None,
+        call_id: call_id.to_string(),
+        output: FunctionCallOutputPayload::from_text(output.to_string()),
+        internal_chat_message_metadata_passthrough: None,
+    }
+}
+
+fn text_message(role: &str, text: &str) -> ResponseItem {
+    ResponseItem::Message {
+        id: None,
+        role: role.to_string(),
+        content: vec![ContentItem::InputText {
+            text: text.to_string(),
+        }],
+        phase: None,
+        internal_chat_message_metadata_passthrough: None,
+    }
+}
+
+fn serialized_messages(messages: &[ChatMessage]) -> Value {
+    serde_json::to_value(messages).expect("chat messages should serialize")
+}
+
+#[test]
+fn defers_approval_notice_until_after_tool_output() {
+    let request = request_with_input(vec![
+        function_call("call-1"),
+        text_message(
+            "developer",
+            "Approved command prefix saved:\n[\"git\", \"status\"]",
+        ),
+        function_output("call-1", "done"),
+    ]);
+
+    let (chat, _) = convert_request(&request).expect("request should convert");
+
+    assert_eq!(
+        serialized_messages(&chat.messages),
+        json!([
+            {
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {
+                        "name": "Bash",
+                        "arguments": "{\"command\":\"pwd\"}"
+                    }
+                }]
+            },
+            {
+                "role": "tool",
+                "content": "done",
+                "tool_call_id": "call-1"
+            },
+            {
+                "role": "user",
+                "content": "Approved command prefix saved:\n[\"git\", \"status\"]"
+            }
+        ])
+    );
+}
+
+#[test]
+fn keeps_parallel_tool_outputs_adjacent_before_interleaved_messages() {
+    let request = request_with_input(vec![
+        function_call("call-1"),
+        function_call("call-2"),
+        text_message("developer", "approval updated"),
+        function_output("call-1", "first"),
+        text_message("user", "also check the hidden files"),
+        function_output("call-2", "second"),
+    ]);
+
+    let (chat, _) = convert_request(&request).expect("request should convert");
+
+    assert_eq!(
+        serialized_messages(&chat.messages),
+        json!([
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "Bash",
+                            "arguments": "{\"command\":\"pwd\"}"
+                        }
+                    },
+                    {
+                        "id": "call-2",
+                        "type": "function",
+                        "function": {
+                            "name": "Bash",
+                            "arguments": "{\"command\":\"pwd\"}"
+                        }
+                    }
+                ]
+            },
+            {
+                "role": "tool",
+                "content": "first",
+                "tool_call_id": "call-1"
+            },
+            {
+                "role": "tool",
+                "content": "second",
+                "tool_call_id": "call-2"
+            },
+            {
+                "role": "user",
+                "content": "approval updated"
+            },
+            {
+                "role": "user",
+                "content": "also check the hidden files"
+            }
+        ])
+    );
+}
+
+#[test]
+fn synthesizes_aborted_output_before_deferred_messages() {
+    let request = request_with_input(vec![
+        function_call("call-1"),
+        text_message("user", "continue without it"),
+    ]);
+
+    let (chat, _) = convert_request(&request).expect("request should convert");
+
+    assert_eq!(
+        serialized_messages(&chat.messages),
+        json!([
+            {
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {
+                        "name": "Bash",
+                        "arguments": "{\"command\":\"pwd\"}"
+                    }
+                }]
+            },
+            {
+                "role": "tool",
+                "content": "aborted",
+                "tool_call_id": "call-1"
+            },
+            {
+                "role": "user",
+                "content": "continue without it"
+            }
+        ])
+    );
+}

--- a/codex-rs/core/tests/suite/claude_code_chat.rs
+++ b/codex-rs/core/tests/suite/claude_code_chat.rs
@@ -1,0 +1,186 @@
+#![cfg(unix)]
+
+use anyhow::Result;
+use codex_model_provider_info::WireApi;
+use codex_protocol::models::PermissionProfile;
+use core_test_support::responses::start_mock_server;
+use core_test_support::skip_if_no_network;
+use core_test_support::test_codex::test_codex;
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use serde_json::json;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use wiremock::Mock;
+use wiremock::Request;
+use wiremock::Respond;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+
+struct ChatSequenceResponder {
+    next_response: AtomicUsize,
+    responses: Vec<String>,
+}
+
+impl Respond for ChatSequenceResponder {
+    fn respond(&self, _: &Request) -> ResponseTemplate {
+        let response_index = self.next_response.fetch_add(1, Ordering::SeqCst);
+        ResponseTemplate::new(200)
+            .insert_header("content-type", "text/event-stream")
+            .set_body_string(
+                self.responses
+                    .get(response_index)
+                    .expect("unexpected extra chat completion request")
+                    .clone(),
+            )
+    }
+}
+
+fn chat_sse(chunks: Vec<Value>) -> String {
+    let mut body = chunks
+        .into_iter()
+        .map(|chunk| format!("data: {chunk}\n\n"))
+        .collect::<String>();
+    body.push_str("data: [DONE]\n\n");
+    body
+}
+
+fn tool_call_response(call_id: &str) -> String {
+    let arguments =
+        json!({ "command": "printf 'GPT_CLAUDE_CHAT_OK\\n' > claude-chat-proof.txt" }).to_string();
+    chat_sse(vec![
+        json!({
+            "id": "chatcmpl-claude-tool",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "gpt-5.6-sol",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": "Bash",
+                            "arguments": arguments
+                        }
+                    }]
+                },
+                "finish_reason": null
+            }]
+        }),
+        json!({
+            "id": "chatcmpl-claude-tool",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "gpt-5.6-sol",
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "tool_calls"
+            }]
+        }),
+    ])
+}
+
+fn final_response() -> String {
+    chat_sse(vec![
+        json!({
+            "id": "chatcmpl-claude-final",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "gpt-5.6-sol",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "content": "done"
+                },
+                "finish_reason": null
+            }]
+        }),
+        json!({
+            "id": "chatcmpl-claude-final",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "gpt-5.6-sol",
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop"
+            }]
+        }),
+    ])
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gpt_model_runs_claude_code_harness_over_chat_completions() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id = "call-claude-chat-proof";
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ChatSequenceResponder {
+            next_response: AtomicUsize::new(0),
+            responses: vec![tool_call_response(call_id), final_response()],
+        })
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let mut builder = test_codex()
+        .with_model("gpt-5.6-sol")
+        .with_config(|config| {
+            config.harness = Some("claude-code".to_string());
+            config.model_provider.wire_api = WireApi::Chat;
+        });
+    let test = builder.build(&server).await?;
+
+    test.submit_turn_with_permission_profile(
+        "Create the requested proof file, then confirm completion.",
+        PermissionProfile::Disabled,
+    )
+    .await?;
+
+    assert_eq!(
+        std::fs::read_to_string(test.cwd.path().join("claude-chat-proof.txt"))?,
+        "GPT_CLAUDE_CHAT_OK\n"
+    );
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let chat_requests = requests
+        .iter()
+        .filter(|request| request.url.path() == "/v1/chat/completions")
+        .collect::<Vec<_>>();
+    assert_eq!(chat_requests.len(), 2);
+
+    let first_body: Value = serde_json::from_slice(&chat_requests[0].body)?;
+    assert_eq!(first_body["model"], "gpt-5.6-sol");
+    assert!(
+        first_body["messages"][0]["content"]
+            .as_str()
+            .is_some_and(|instructions| instructions.contains("Claude Code"))
+    );
+    assert!(
+        first_body["tools"]
+            .as_array()
+            .is_some_and(|tools| tools.iter().any(|tool| tool["function"]["name"] == "Bash"))
+    );
+
+    let second_body: Value = serde_json::from_slice(&chat_requests[1].body)?;
+    let messages = second_body["messages"]
+        .as_array()
+        .expect("second chat request should contain messages");
+    let assistant_index = messages
+        .iter()
+        .position(|message| message["role"] == "assistant" && message["tool_calls"].is_array())
+        .expect("second request should replay the Claude harness tool call");
+    assert_eq!(messages[assistant_index + 1]["role"], "tool");
+    assert_eq!(messages[assistant_index + 1]["tool_call_id"], call_id);
+
+    Ok(())
+}

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -39,6 +39,8 @@ mod approvals;
 mod audio_truncation;
 mod auto_review;
 mod catalog_permission_messages;
+#[cfg(unix)]
+mod claude_code_chat;
 mod cli_stream;
 mod client;
 mod client_websockets;


### PR DESCRIPTION
## Summary

- keep user and developer context updates after the complete Chat Completions tool-result group
- preserve strict adjacency for parallel function, custom, local-shell, and tool-search calls
- synthesize an explicit `aborted` result for incomplete groups before releasing deferred context
- add GPT-5.6 regressions for approval notices, queued user messages, and parallel calls

This is scoped to Open Interpreter's Chat Completions compatibility adapter. It does not change upstream Codex runtime or terminal behavior.

Fixes #1851

## Test plan

- [x] `cargo fmt --manifest-path codex-rs/Cargo.toml --package codex-chat-wire-compat`
- [ ] GitHub CI
