### PR TITLE
feat: Add support for Gemini 3.6 Flash and Gemini 3.5 Flash-Lite

### DIFF
--- a/codex-rs/codex-api/model_compatibility_catalog.json
+++ b/codex-rs/codex-api/model_compatibility_catalog.json
@@ -528,6 +528,25 @@
       "context_window": null
     },
     {
+      "id": "aiml/openai/gpt-image-2",
+      "aliases": [
+        "openai/gpt-image-2"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": null
+    },
+    {
       "id": "amazon-nova/nova-lite-v1",
       "aliases": [
         "nova-lite-v1"
@@ -788,6 +807,22 @@
         "text"
       ],
       "context_window": 32000
+    },
+    {
+      "id": "amazon.titan-embed-g1-text-02",
+      "aliases": [],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 8192
     },
     {
       "id": "amazon.titan-embed-image-v1",
@@ -1121,6 +1156,44 @@
       "context_window": 200000
     },
     {
+      "id": "anthropic.claude-fable-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
       "id": "anthropic.claude-haiku-4-5-20251001-v1:0",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
@@ -1218,10 +1291,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -1325,10 +1394,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -1362,10 +1427,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -1401,9 +1462,81 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
+          "effort": "low",
+          "description": "low"
         },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "anthropic.claude-opus-4-8",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "anthropic.claude-opus-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
         {
           "effort": "low",
           "description": "low"
@@ -1511,9 +1644,39 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
+          "effort": "low",
+          "description": "low"
         },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "anthropic.claude-sonnet-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
         {
           "effort": "low",
           "description": "low"
@@ -1525,6 +1688,10 @@
         {
           "effort": "high",
           "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
         }
       ],
       "supports_thinking_toggle": false,
@@ -2071,6 +2238,40 @@
       "context_window": 1000000
     },
     {
+      "id": "apiserpent/deep_search",
+      "aliases": [
+        "deep_search"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
+      "id": "apiserpent/search",
+      "aliases": [],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
       "id": "assemblyai/best",
       "aliases": [
         "best"
@@ -2152,10 +2353,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -2190,9 +2387,81 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
+          "effort": "low",
+          "description": "low"
         },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "au.anthropic.claude-opus-4-8",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "au.anthropic.claude-opus-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
         {
           "effort": "low",
           "description": "low"
@@ -2266,9 +2535,39 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
+          "effort": "low",
+          "description": "low"
         },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "au.anthropic.claude-sonnet-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
         {
           "effort": "low",
           "description": "low"
@@ -2280,6 +2579,10 @@
         {
           "effort": "high",
           "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
         }
       ],
       "supports_thinking_toggle": false,
@@ -2560,8 +2863,8 @@
       "aliases": [
         "eu/gpt-4o-mini-realtime-preview-2024-12-17"
       ],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -2581,8 +2884,8 @@
       "aliases": [
         "eu/gpt-4o-realtime-preview-2024-10-01"
       ],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -2602,8 +2905,8 @@
       "aliases": [
         "eu/gpt-4o-realtime-preview-2024-12-17"
       ],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -2877,6 +3180,340 @@
         "image"
       ],
       "context_window": 272000
+    },
+    {
+      "id": "azure/eu/gpt-5.4",
+      "aliases": [
+        "eu/gpt-5.4"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/eu/gpt-5.4-2026-03-05",
+      "aliases": [
+        "eu/gpt-5.4-2026-03-05"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/eu/gpt-5.5",
+      "aliases": [
+        "eu/gpt-5.5"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/eu/gpt-5.5-2026-04-23",
+      "aliases": [
+        "eu/gpt-5.5-2026-04-23"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/eu/gpt-5.6",
+      "aliases": [
+        "eu/gpt-5.6"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/eu/gpt-5.6-luna",
+      "aliases": [
+        "eu/gpt-5.6-luna"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/eu/gpt-5.6-sol",
+      "aliases": [
+        "eu/gpt-5.6-sol"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/eu/gpt-5.6-terra",
+      "aliases": [
+        "eu/gpt-5.6-terra"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
     },
     {
       "id": "azure/eu/o1-2024-12-17",
@@ -3930,8 +4567,8 @@
     {
       "id": "azure/gpt-4o-mini-realtime-preview-2024-12-17",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -3985,8 +4622,8 @@
     {
       "id": "azure/gpt-4o-realtime-preview-2024-10-01",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -4004,8 +4641,8 @@
     {
       "id": "azure/gpt-4o-realtime-preview-2024-12-17",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -5328,9 +5965,7 @@
     },
     {
       "id": "azure/gpt-5.5",
-      "aliases": [
-        "gpt-5.5"
-      ],
+      "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
       "visibility": "list",
       "supported_parameters": [
@@ -5373,9 +6008,7 @@
     },
     {
       "id": "azure/gpt-5.5-2026-04-23",
-      "aliases": [
-        "gpt-5.5-2026-04-23"
-      ],
+      "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
       "visibility": "list",
       "supported_parameters": [
@@ -5474,6 +6107,178 @@
         {
           "effort": "high",
           "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/gpt-5.6",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/gpt-5.6-luna",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/gpt-5.6-sol",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/gpt-5.6-terra",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
         }
       ],
       "supports_thinking_toggle": false,
@@ -5615,9 +6420,7 @@
     },
     {
       "id": "azure/gpt-image-2",
-      "aliases": [
-        "gpt-image-2"
-      ],
+      "aliases": [],
       "description": null,
       "visibility": "hide",
       "supported_parameters": [],
@@ -5656,8 +6459,8 @@
       "aliases": [
         "gpt-realtime-1.5-2026-02-23"
       ],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -5678,8 +6481,8 @@
       "aliases": [
         "gpt-realtime-2025-08-28"
       ],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -5700,8 +6503,8 @@
       "aliases": [
         "gpt-realtime-mini-2025-10-06"
       ],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -5716,6 +6519,24 @@
         "image"
       ],
       "context_window": 32000
+    },
+    {
+      "id": "azure/gpt-realtime-whisper",
+      "aliases": [
+        "gpt-realtime-whisper"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
     },
     {
       "id": "azure/hd/1024-x-1024/dall-e-3",
@@ -6695,6 +7516,25 @@
       "context_window": null
     },
     {
+      "id": "azure/speech/azure-stt",
+      "aliases": [
+        "azure-stt",
+        "speech/azure-stt"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
       "id": "azure/speech/azure-tts",
       "aliases": [
         "azure-tts",
@@ -7026,8 +7866,8 @@
       "aliases": [
         "us/gpt-4o-mini-realtime-preview-2024-12-17"
       ],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -7047,8 +7887,8 @@
       "aliases": [
         "us/gpt-4o-realtime-preview-2024-10-01"
       ],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -7068,8 +7908,8 @@
       "aliases": [
         "us/gpt-4o-realtime-preview-2024-12-17"
       ],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -7343,6 +8183,340 @@
         "image"
       ],
       "context_window": 272000
+    },
+    {
+      "id": "azure/us/gpt-5.4",
+      "aliases": [
+        "us/gpt-5.4"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/us/gpt-5.4-2026-03-05",
+      "aliases": [
+        "us/gpt-5.4-2026-03-05"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/us/gpt-5.5",
+      "aliases": [
+        "us/gpt-5.5"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/us/gpt-5.5-2026-04-23",
+      "aliases": [
+        "us/gpt-5.5-2026-04-23"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/us/gpt-5.6",
+      "aliases": [
+        "us/gpt-5.6"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/us/gpt-5.6-luna",
+      "aliases": [
+        "us/gpt-5.6-luna"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/us/gpt-5.6-sol",
+      "aliases": [
+        "us/gpt-5.6-sol"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure/us/gpt-5.6-terra",
+      "aliases": [
+        "us/gpt-5.6-terra"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
     },
     {
       "id": "azure/us/o1-2024-12-17",
@@ -7742,6 +8916,60 @@
       "context_window": 128000
     },
     {
+      "id": "azure_ai/MAI-Image-2.5",
+      "aliases": [
+        "MAI-Image-2.5"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
+      "id": "azure_ai/MAI-Image-2.5-Flash",
+      "aliases": [
+        "MAI-Image-2.5-Flash"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
+      "id": "azure_ai/MAI-Image-2e",
+      "aliases": [
+        "MAI-Image-2e"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
       "id": "azure_ai/Meta-Llama-3-70B-Instruct",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling",
@@ -8126,6 +9354,44 @@
       "context_window": 32768
     },
     {
+      "id": "azure_ai/claude-fable-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
       "id": "azure_ai/claude-haiku-4-5",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
@@ -8205,10 +9471,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -8243,10 +9505,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -8267,7 +9525,7 @@
         "text",
         "image"
       ],
-      "context_window": 200000
+      "context_window": 1000000
     },
     {
       "id": "azure_ai/claude-opus-4-7",
@@ -8280,10 +9538,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -8309,7 +9563,83 @@
         "text",
         "image"
       ],
-      "context_window": 200000
+      "context_window": 1000000
+    },
+    {
+      "id": "azure_ai/claude-opus-4-8",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "azure_ai/claude-opus-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
     },
     {
       "id": "azure_ai/claude-sonnet-4-5",
@@ -8357,9 +9687,39 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
+          "effort": "low",
+          "description": "low"
         },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "azure_ai/claude-sonnet-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
         {
           "effort": "low",
           "description": "low"
@@ -8371,6 +9731,10 @@
         {
           "effort": "high",
           "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
         }
       ],
       "supports_thinking_toggle": false,
@@ -8545,6 +9909,39 @@
       "context_window": 128000
     },
     {
+      "id": "azure_ai/deepseek-v3.1",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 131072
+    },
+    {
       "id": "azure_ai/deepseek-v3.2",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
@@ -8611,6 +10008,72 @@
         "text"
       ],
       "context_window": 163840
+    },
+    {
+      "id": "azure_ai/deepseek-v4-flash",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "azure_ai/deepseek-v4-pro",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1000000
     },
     {
       "id": "azure_ai/doc-intelligence/prebuilt-document",
@@ -9117,6 +10580,92 @@
       "context_window": 1050000
     },
     {
+      "id": "azure_ai/gpt-5.5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "azure_ai/gpt-5.5-2026-04-23",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
       "id": "azure_ai/gpt-oss-120b",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling",
@@ -9372,6 +10921,40 @@
       "supported_reasoning_levels": [],
       "supports_thinking_toggle": false,
       "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "azure_ai/kimi-k2.6",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
       "supports_parallel_tool_calls": false,
       "supports_search_tool": false,
       "input_modalities": [
@@ -13457,6 +15040,294 @@
       "context_window": 200000
     },
     {
+      "id": "bedrock_mantle/google.gemma-4-26b-a4b",
+      "aliases": [
+        "google.gemma-4-26b-a4b"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 256000
+    },
+    {
+      "id": "bedrock_mantle/google.gemma-4-31b",
+      "aliases": [
+        "google.gemma-4-31b"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 256000
+    },
+    {
+      "id": "bedrock_mantle/google.gemma-4-e2b",
+      "aliases": [
+        "google.gemma-4-e2b"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "bedrock_mantle/openai.gpt-5.4",
+      "aliases": [
+        "openai.gpt-5.4"
+      ],
+      "description": "Responses \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 272000
+    },
+    {
+      "id": "bedrock_mantle/openai.gpt-5.5",
+      "aliases": [
+        "openai.gpt-5.5"
+      ],
+      "description": "Responses \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 272000
+    },
+    {
+      "id": "bedrock_mantle/openai.gpt-5.6-luna",
+      "aliases": [
+        "openai.gpt-5.6-luna"
+      ],
+      "description": "Responses \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 272000
+    },
+    {
+      "id": "bedrock_mantle/openai.gpt-5.6-sol",
+      "aliases": [
+        "openai.gpt-5.6-sol"
+      ],
+      "description": "Responses \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 272000
+    },
+    {
+      "id": "bedrock_mantle/openai.gpt-5.6-terra",
+      "aliases": [
+        "openai.gpt-5.6-terra"
+      ],
+      "description": "Responses \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 272000
+    },
+    {
       "id": "bedrock_mantle/openai.gpt-oss-120b",
       "aliases": [
         "openai.gpt-oss-120b"
@@ -13593,6 +15464,42 @@
       "supports_search_tool": false,
       "input_modalities": [
         "text"
+      ],
+      "context_window": 131072
+    },
+    {
+      "id": "bedrock_mantle/xai.grok-4.3",
+      "aliases": [
+        "xai.grok-4.3"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
       ],
       "context_window": 131072
     },
@@ -14330,6 +16237,44 @@
       "context_window": 1000000
     },
     {
+      "id": "claude-fable-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
       "id": "claude-haiku-4-5",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
@@ -14511,10 +16456,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -14548,10 +16489,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -14587,10 +16524,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -14625,10 +16558,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -14662,10 +16591,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -14705,9 +16630,81 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
+          "effort": "low",
+          "description": "low"
         },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "claude-opus-4-8",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "claude-opus-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
         {
           "effort": "low",
           "description": "low"
@@ -14884,10 +16881,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -14909,6 +16902,216 @@
         "image"
       ],
       "context_window": 1000000
+    },
+    {
+      "id": "claude-sonnet-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "cloudflare/@cf/aisingapore/gemma-sea-lion-v4-27b-it",
+      "aliases": [
+        "@cf/aisingapore/gemma-sea-lion-v4-27b-it",
+        "aisingapore/gemma-sea-lion-v4-27b-it",
+        "gemma-sea-lion-v4-27b-it"
+      ],
+      "description": "Chat-compatible",
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "cloudflare/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
+      "aliases": [
+        "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
+        "deepseek-ai/deepseek-r1-distill-qwen-32b"
+      ],
+      "description": "Chat-compatible \u2022 Reasoning effort",
+      "visibility": "hide",
+      "supported_parameters": [
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 80000
+    },
+    {
+      "id": "cloudflare/@cf/google/gemma-2b-it-lora",
+      "aliases": [
+        "@cf/google/gemma-2b-it-lora",
+        "gemma-2b-it-lora",
+        "google/gemma-2b-it-lora"
+      ],
+      "description": "Chat-compatible",
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 8192
+    },
+    {
+      "id": "cloudflare/@cf/google/gemma-4-26b-a4b-it",
+      "aliases": [
+        "@cf/google/gemma-4-26b-a4b-it"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 256000
+    },
+    {
+      "id": "cloudflare/@cf/google/gemma-7b-it-lora",
+      "aliases": [
+        "@cf/google/gemma-7b-it-lora",
+        "gemma-7b-it-lora",
+        "google/gemma-7b-it-lora"
+      ],
+      "description": "Chat-compatible",
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 3500
+    },
+    {
+      "id": "cloudflare/@cf/ibm-granite/granite-4.0-h-micro",
+      "aliases": [
+        "@cf/ibm-granite/granite-4.0-h-micro",
+        "granite-4.0-h-micro",
+        "ibm-granite/granite-4.0-h-micro"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 131000
+    },
+    {
+      "id": "cloudflare/@cf/meta-llama/llama-2-7b-chat-hf-lora",
+      "aliases": [
+        "@cf/meta-llama/llama-2-7b-chat-hf-lora",
+        "llama-2-7b-chat-hf-lora",
+        "meta-llama/llama-2-7b-chat-hf-lora"
+      ],
+      "description": "Chat-compatible",
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 8192
     },
     {
       "id": "cloudflare/@cf/meta/llama-2-7b-chat-fp16",
@@ -14951,6 +17154,150 @@
       "context_window": 2048
     },
     {
+      "id": "cloudflare/@cf/meta/llama-3.1-8b-instruct-fp8",
+      "aliases": [
+        "@cf/meta/llama-3.1-8b-instruct-fp8",
+        "llama-3.1-8b-instruct-fp8",
+        "meta/llama-3.1-8b-instruct-fp8"
+      ],
+      "description": "Chat-compatible",
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 32000
+    },
+    {
+      "id": "cloudflare/@cf/meta/llama-3.2-11b-vision-instruct",
+      "aliases": [
+        "@cf/meta/llama-3.2-11b-vision-instruct",
+        "llama-3.2-11b-vision-instruct",
+        "meta/llama-3.2-11b-vision-instruct"
+      ],
+      "description": "Chat-compatible",
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "cloudflare/@cf/meta/llama-3.2-1b-instruct",
+      "aliases": [
+        "@cf/meta/llama-3.2-1b-instruct",
+        "llama-3.2-1b-instruct",
+        "meta/llama-3.2-1b-instruct"
+      ],
+      "description": "Chat-compatible",
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 60000
+    },
+    {
+      "id": "cloudflare/@cf/meta/llama-3.2-3b-instruct",
+      "aliases": [
+        "@cf/meta/llama-3.2-3b-instruct",
+        "meta/llama-3.2-3b-instruct"
+      ],
+      "description": "Chat-compatible",
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 80000
+    },
+    {
+      "id": "cloudflare/@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+      "aliases": [
+        "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+        "llama-3.3-70b-instruct-fp8-fast",
+        "meta/llama-3.3-70b-instruct-fp8-fast"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 24000
+    },
+    {
+      "id": "cloudflare/@cf/meta/llama-4-scout-17b-16e-instruct",
+      "aliases": [
+        "@cf/meta/llama-4-scout-17b-16e-instruct",
+        "meta/llama-4-scout-17b-16e-instruct"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 131000
+    },
+    {
+      "id": "cloudflare/@cf/meta/llama-guard-3-8b",
+      "aliases": [
+        "@cf/meta/llama-guard-3-8b",
+        "meta/llama-guard-3-8b"
+      ],
+      "description": "Chat-compatible",
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 131072
+    },
+    {
       "id": "cloudflare/@cf/mistral/mistral-7b-instruct-v0.1",
       "aliases": [
         "@cf/mistral/mistral-7b-instruct-v0.1",
@@ -14969,6 +17316,389 @@
         "text"
       ],
       "context_window": 8192
+    },
+    {
+      "id": "cloudflare/@cf/mistral/mistral-7b-instruct-v0.2-lora",
+      "aliases": [
+        "@cf/mistral/mistral-7b-instruct-v0.2-lora",
+        "mistral-7b-instruct-v0.2-lora",
+        "mistral/mistral-7b-instruct-v0.2-lora"
+      ],
+      "description": "Chat-compatible",
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 15000
+    },
+    {
+      "id": "cloudflare/@cf/mistralai/mistral-small-3.1-24b-instruct",
+      "aliases": [
+        "@cf/mistralai/mistral-small-3.1-24b-instruct"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "cloudflare/@cf/moonshotai/kimi-k2.6",
+      "aliases": [
+        "@cf/moonshotai/kimi-k2.6",
+        "moonshotai/kimi-k2.6"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "cloudflare/@cf/moonshotai/kimi-k2.7-code",
+      "aliases": [
+        "@cf/moonshotai/kimi-k2.7-code",
+        "kimi-k2.7-code",
+        "moonshotai/kimi-k2.7-code"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "cloudflare/@cf/nvidia/nemotron-3-120b-a12b",
+      "aliases": [
+        "@cf/nvidia/nemotron-3-120b-a12b",
+        "nemotron-3-120b-a12b",
+        "nvidia/nemotron-3-120b-a12b"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 256000
+    },
+    {
+      "id": "cloudflare/@cf/openai/gpt-oss-120b",
+      "aliases": [
+        "@cf/openai/gpt-oss-120b"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "cloudflare/@cf/openai/gpt-oss-20b",
+      "aliases": [
+        "@cf/openai/gpt-oss-20b"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "cloudflare/@cf/qwen/qwen2.5-coder-32b-instruct",
+      "aliases": [
+        "@cf/qwen/qwen2.5-coder-32b-instruct",
+        "qwen/qwen2.5-coder-32b-instruct",
+        "qwen2.5-coder-32b-instruct"
+      ],
+      "description": "Chat-compatible",
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 32768
+    },
+    {
+      "id": "cloudflare/@cf/qwen/qwen3-30b-a3b-fp8",
+      "aliases": [
+        "@cf/qwen/qwen3-30b-a3b-fp8"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 32768
+    },
+    {
+      "id": "cloudflare/@cf/qwen/qwq-32b",
+      "aliases": [
+        "@cf/qwen/qwq-32b",
+        "qwen/qwq-32b"
+      ],
+      "description": "Chat-compatible \u2022 Reasoning effort",
+      "visibility": "hide",
+      "supported_parameters": [
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 24000
+    },
+    {
+      "id": "cloudflare/@cf/zai-org/glm-4.7-flash",
+      "aliases": [
+        "@cf/zai-org/glm-4.7-flash",
+        "zai-org/glm-4.7-flash"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 131072
+    },
+    {
+      "id": "cloudflare/@cf/zai-org/glm-5.2",
+      "aliases": [
+        "@cf/zai-org/glm-5.2",
+        "glm-5.2",
+        "zai-org/glm-5.2"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 262144
     },
     {
       "id": "cloudflare/@hf/thebloke/codellama-7b-instruct-awq",
@@ -15606,6 +18336,46 @@
         "text"
       ],
       "context_window": null
+    },
+    {
+      "id": "darkbloom/gemma-4-26b",
+      "aliases": [
+        "gemma-4-26b"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 131072
+    },
+    {
+      "id": "darkbloom/gpt-oss-20b",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 131072
     },
     {
       "id": "dashscope/qwen-coder",
@@ -16882,10 +19652,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -19484,6 +22250,72 @@
       "context_window": 98304
     },
     {
+      "id": "deepseek-v4-flash",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "deepseek-v4-pro",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1000000
+    },
+    {
       "id": "deepseek.v3-v1:0",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
@@ -19706,6 +22538,72 @@
         "text"
       ],
       "context_window": 163840
+    },
+    {
+      "id": "deepseek/deepseek-v4-flash",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "deepseek/deepseek-v4-pro",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1000000
     },
     {
       "id": "dolphin",
@@ -20282,6 +23180,44 @@
       "context_window": 200000
     },
     {
+      "id": "eu.anthropic.claude-fable-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
       "id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
@@ -20395,10 +23331,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -20432,10 +23364,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -20471,9 +23399,81 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
+          "effort": "low",
+          "description": "low"
         },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "eu.anthropic.claude-opus-4-8",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "eu.anthropic.claude-opus-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
         {
           "effort": "low",
           "description": "low"
@@ -20581,9 +23581,39 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
+          "effort": "low",
+          "description": "low"
         },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "eu.anthropic.claude-sonnet-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
         {
           "effort": "low",
           "description": "low"
@@ -20595,6 +23625,10 @@
         {
           "effort": "high",
           "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
         }
       ],
       "supports_thinking_toggle": false,
@@ -20861,6 +23895,25 @@
       "context_window": null
     },
     {
+      "id": "fal_ai/fal-ai/gemini-25-flash-image",
+      "aliases": [
+        "fal-ai/gemini-25-flash-image",
+        "gemini-25-flash-image"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
       "id": "fal_ai/fal-ai/ideogram/v3",
       "aliases": [
         "fal-ai/ideogram/v3",
@@ -20942,6 +23995,25 @@
       "context_window": null
     },
     {
+      "id": "fal_ai/fal-ai/nano-banana",
+      "aliases": [
+        "fal-ai/nano-banana",
+        "nano-banana"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
       "id": "fal_ai/fal-ai/recraft/v3/text-to-image",
       "aliases": [
         "fal-ai/recraft/v3/text-to-image",
@@ -20966,6 +24038,22 @@
         "fal-ai/stable-diffusion-v35-medium",
         "stable-diffusion-v35-medium"
       ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
+      "id": "fallback_generalizations",
+      "aliases": [],
       "description": null,
       "visibility": "hide",
       "supported_parameters": [],
@@ -22293,6 +25381,80 @@
       "context_window": 163840
     },
     {
+      "id": "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash",
+      "aliases": [
+        "accounts/fireworks/models/deepseek-v4-flash",
+        "fireworks/models/deepseek-v4-flash",
+        "models/deepseek-v4-flash"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1048576
+    },
+    {
+      "id": "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro",
+      "aliases": [
+        "accounts/fireworks/models/deepseek-v4-pro",
+        "fireworks/models/deepseek-v4-pro",
+        "models/deepseek-v4-pro"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1048576
+    },
+    {
       "id": "fireworks_ai/accounts/fireworks/models/devstral-small-2505",
       "aliases": [
         "accounts/fireworks/models/devstral-small-2505",
@@ -23023,6 +26185,80 @@
       "context_window": 202800
     },
     {
+      "id": "fireworks_ai/accounts/fireworks/models/glm-5p1",
+      "aliases": [
+        "accounts/fireworks/models/glm-5p1",
+        "fireworks/models/glm-5p1",
+        "models/glm-5p1"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 202800
+    },
+    {
+      "id": "fireworks_ai/accounts/fireworks/models/glm-5p2",
+      "aliases": [
+        "accounts/fireworks/models/glm-5p2",
+        "fireworks/models/glm-5p2",
+        "models/glm-5p2"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1048576
+    },
+    {
       "id": "fireworks_ai/accounts/fireworks/models/gpt-oss-120b",
       "aliases": [
         "accounts/fireworks/models/gpt-oss-120b",
@@ -23399,6 +26635,82 @@
       "context_window": 262144
     },
     {
+      "id": "fireworks_ai/accounts/fireworks/models/kimi-k2p6",
+      "aliases": [
+        "accounts/fireworks/models/kimi-k2p6",
+        "fireworks/models/kimi-k2p6",
+        "models/kimi-k2p6"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "fireworks_ai/accounts/fireworks/models/kimi-k2p7-code",
+      "aliases": [
+        "accounts/fireworks/models/kimi-k2p7-code",
+        "fireworks/models/kimi-k2p7-code",
+        "models/kimi-k2p7-code"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
       "id": "fireworks_ai/accounts/fireworks/models/llama-guard-2-8b",
       "aliases": [
         "accounts/fireworks/models/llama-guard-2-8b",
@@ -23445,7 +26757,6 @@
       "aliases": [
         "accounts/fireworks/models/llama-guard-3-8b",
         "fireworks/models/llama-guard-3-8b",
-        "llama-guard-3-8b",
         "models/llama-guard-3-8b"
       ],
       "description": "Chat-compatible",
@@ -24095,6 +27406,81 @@
         "text"
       ],
       "context_window": 204800
+    },
+    {
+      "id": "fireworks_ai/accounts/fireworks/models/minimax-m2p7",
+      "aliases": [
+        "accounts/fireworks/models/minimax-m2p7",
+        "fireworks/models/minimax-m2p7",
+        "models/minimax-m2p7"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 196608
+    },
+    {
+      "id": "fireworks_ai/accounts/fireworks/models/minimax-m3",
+      "aliases": [
+        "accounts/fireworks/models/minimax-m3",
+        "fireworks/models/minimax-m3",
+        "models/minimax-m3"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 512000
     },
     {
       "id": "fireworks_ai/accounts/fireworks/models/ministral-3-14b-instruct-2512",
@@ -26433,12 +29819,49 @@
       "context_window": 4096
     },
     {
+      "id": "fireworks_ai/accounts/fireworks/models/qwen3p7-plus",
+      "aliases": [
+        "accounts/fireworks/models/qwen3p7-plus",
+        "fireworks/models/qwen3p7-plus",
+        "models/qwen3p7-plus"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
       "id": "fireworks_ai/accounts/fireworks/models/qwq-32b",
       "aliases": [
         "accounts/fireworks/models/qwq-32b",
         "fireworks/models/qwq-32b",
-        "models/qwq-32b",
-        "qwq-32b"
+        "models/qwq-32b"
       ],
       "description": "Chat-compatible",
       "visibility": "hide",
@@ -26664,48 +30087,6 @@
       "context_window": 32768
     },
     {
-      "id": "fireworks_ai/accounts/fireworks/models/whisper-v3",
-      "aliases": [
-        "accounts/fireworks/models/whisper-v3",
-        "fireworks/models/whisper-v3",
-        "models/whisper-v3",
-        "whisper-v3"
-      ],
-      "description": null,
-      "visibility": "hide",
-      "supported_parameters": [],
-      "supported_reasoning_levels": [],
-      "supports_thinking_toggle": false,
-      "reasoning_control": "none",
-      "supports_parallel_tool_calls": false,
-      "supports_search_tool": false,
-      "input_modalities": [
-        "text"
-      ],
-      "context_window": 4096
-    },
-    {
-      "id": "fireworks_ai/accounts/fireworks/models/whisper-v3-turbo",
-      "aliases": [
-        "accounts/fireworks/models/whisper-v3-turbo",
-        "fireworks/models/whisper-v3-turbo",
-        "models/whisper-v3-turbo",
-        "whisper-v3-turbo"
-      ],
-      "description": null,
-      "visibility": "hide",
-      "supported_parameters": [],
-      "supported_reasoning_levels": [],
-      "supports_thinking_toggle": false,
-      "reasoning_control": "none",
-      "supports_parallel_tool_calls": false,
-      "supports_search_tool": false,
-      "input_modalities": [
-        "text"
-      ],
-      "context_window": 4096
-    },
-    {
       "id": "fireworks_ai/accounts/fireworks/models/yi-34b",
       "aliases": [
         "accounts/fireworks/models/yi-34b",
@@ -26831,6 +30212,185 @@
       "context_window": 32768
     },
     {
+      "id": "fireworks_ai/accounts/fireworks/routers/glm-5p1-fast",
+      "aliases": [
+        "accounts/fireworks/routers/glm-5p1-fast",
+        "fireworks/routers/glm-5p1-fast",
+        "routers/glm-5p1-fast"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 202800
+    },
+    {
+      "id": "fireworks_ai/accounts/fireworks/routers/kimi-k2p6-fast",
+      "aliases": [
+        "accounts/fireworks/routers/kimi-k2p6-fast",
+        "fireworks/routers/kimi-k2p6-fast",
+        "routers/kimi-k2p6-fast"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "fireworks_ai/accounts/fireworks/routers/kimi-k2p7-code-fast",
+      "aliases": [
+        "accounts/fireworks/routers/kimi-k2p7-code-fast",
+        "fireworks/routers/kimi-k2p7-code-fast",
+        "routers/kimi-k2p7-code-fast"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "fireworks_ai/deepseek-v4-flash",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1048576
+    },
+    {
+      "id": "fireworks_ai/deepseek-v4-pro",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1048576
+    },
+    {
       "id": "fireworks_ai/glm-4p7",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
@@ -26864,6 +30424,171 @@
       "context_window": 202800
     },
     {
+      "id": "fireworks_ai/glm-5p1",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 202800
+    },
+    {
+      "id": "fireworks_ai/glm-5p1-fast",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 202800
+    },
+    {
+      "id": "fireworks_ai/glm-5p2",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1048576
+    },
+    {
+      "id": "fireworks_ai/gpt-oss-120b",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 131072
+    },
+    {
+      "id": "fireworks_ai/gpt-oss-20b",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 131072
+    },
+    {
       "id": "fireworks_ai/kimi-k2p5",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling",
@@ -26879,6 +30604,142 @@
       "supports_search_tool": false,
       "input_modalities": [
         "text"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "fireworks_ai/kimi-k2p6",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "fireworks_ai/kimi-k2p6-fast",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "fireworks_ai/kimi-k2p7-code",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "fireworks_ai/kimi-k2p7-code-fast",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
       ],
       "context_window": 262144
     },
@@ -26900,6 +30761,73 @@
         "text"
       ],
       "context_window": 204800
+    },
+    {
+      "id": "fireworks_ai/minimax-m2p7",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 196608
+    },
+    {
+      "id": "fireworks_ai/minimax-m3",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 512000
     },
     {
       "id": "fireworks_ai/nomic-ai/nomic-embed-text-v1",
@@ -26938,6 +30866,40 @@
         "text"
       ],
       "context_window": 8192
+    },
+    {
+      "id": "fireworks_ai/qwen3p7-plus",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
     },
     {
       "id": "fireworks_ai/thenlper/gte-base",
@@ -27765,6 +31727,25 @@
       "context_window": 1048576
     },
     {
+      "id": "gemini-3-pro-image",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Search",
+      "visibility": "hide",
+      "supported_parameters": [
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 65536
+    },
+    {
       "id": "gemini-3-pro-image-preview",
       "aliases": [],
       "description": "Chat-compatible \u2022 Search",
@@ -27819,6 +31800,25 @@
       "context_window": 1048576
     },
     {
+      "id": "gemini-3.1-flash-image",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Search",
+      "visibility": "hide",
+      "supported_parameters": [
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 65536
+    },
+    {
       "id": "gemini-3.1-flash-image-preview",
       "aliases": [],
       "description": "Chat-compatible \u2022 Search",
@@ -27836,6 +31836,41 @@
         "image"
       ],
       "context_window": 65536
+    },
+    {
+      "id": "gemini-3.1-flash-lite",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1048576
     },
     {
       "id": "gemini-3.1-flash-lite-preview",
@@ -27965,6 +32000,76 @@
     },
     {
       "id": "gemini-3.5-flash",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1048576
+    },
+    {
+      "id": "gemini-3.5-flash-lite",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1048576
+    },
+    {
+      "id": "gemini-3.6-flash",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
       "visibility": "list",
@@ -28182,6 +32287,38 @@
       "reasoning_control": "none",
       "supports_parallel_tool_calls": true,
       "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1048576
+    },
+    {
+      "id": "gemini-omni-flash-preview",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Reasoning effort",
+      "visibility": "hide",
+      "supported_parameters": [
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
       "input_modalities": [
         "text",
         "image"
@@ -28790,6 +32927,25 @@
       "context_window": 1048576
     },
     {
+      "id": "gemini/gemini-3-pro-image",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Search",
+      "visibility": "hide",
+      "supported_parameters": [
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 65536
+    },
+    {
       "id": "gemini/gemini-3-pro-image-preview",
       "aliases": [],
       "description": "Chat-compatible \u2022 Search",
@@ -28844,6 +33000,25 @@
       "context_window": 1048576
     },
     {
+      "id": "gemini/gemini-3.1-flash-image",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Search",
+      "visibility": "hide",
+      "supported_parameters": [
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 65536
+    },
+    {
       "id": "gemini/gemini-3.1-flash-image-preview",
       "aliases": [],
       "description": "Chat-compatible \u2022 Search",
@@ -28861,6 +33036,41 @@
         "image"
       ],
       "context_window": 65536
+    },
+    {
+      "id": "gemini/gemini-3.1-flash-lite",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1048576
     },
     {
       "id": "gemini/gemini-3.1-flash-lite-preview",
@@ -28992,6 +33202,76 @@
     },
     {
       "id": "gemini/gemini-3.5-flash",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1048576
+    },
+    {
+      "id": "gemini/gemini-3.5-flash-lite",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1048576
+    },
+    {
+      "id": "gemini/gemini-3.6-flash",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
       "visibility": "list",
@@ -29252,6 +33532,40 @@
       "reasoning_control": "none",
       "supports_parallel_tool_calls": true,
       "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1048576
+    },
+    {
+      "id": "gemini/gemini-omni-flash-preview",
+      "aliases": [
+        "gemini-omni-flash-preview"
+      ],
+      "description": "Chat-compatible \u2022 Reasoning effort",
+      "visibility": "hide",
+      "supported_parameters": [
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
       "input_modalities": [
         "text",
         "image"
@@ -29746,33 +34060,15 @@
     {
       "id": "github_copilot/claude-opus-4.5",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "description": "Chat-compatible \u2022 Tool calling",
       "visibility": "list",
       "supported_parameters": [
         "tools",
-        "tool_choice",
-        "reasoning_effort"
+        "tool_choice"
       ],
-      "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
-          "effort": "low",
-          "description": "low"
-        },
-        {
-          "effort": "medium",
-          "description": "medium"
-        },
-        {
-          "effort": "high",
-          "description": "high"
-        }
-      ],
+      "supported_reasoning_levels": [],
       "supports_thinking_toggle": false,
-      "reasoning_control": "effort",
+      "reasoning_control": "none",
       "supports_parallel_tool_calls": true,
       "supports_search_tool": false,
       "input_modalities": [
@@ -30297,6 +34593,48 @@
       "context_window": 128000
     },
     {
+      "id": "github_copilot/mai-code-1-flash",
+      "aliases": [
+        "mai-code-1-flash"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "github_copilot/mai-code-1-flash-internal",
+      "aliases": [
+        "mai-code-1-flash-internal"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 128000
+    },
+    {
       "id": "github_copilot/text-embedding-3-small",
       "aliases": [],
       "description": null,
@@ -30414,6 +34752,44 @@
       "context_window": 1000000
     },
     {
+      "id": "global.anthropic.claude-fable-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
       "id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
@@ -30459,10 +34835,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -30496,10 +34868,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -30535,9 +34903,81 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
+          "effort": "low",
+          "description": "low"
         },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "global.anthropic.claude-opus-4-8",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "global.anthropic.claude-opus-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
         {
           "effort": "low",
           "description": "low"
@@ -30645,9 +35085,39 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
+          "effort": "low",
+          "description": "low"
         },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "global.anthropic.claude-sonnet-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
         {
           "effort": "low",
           "description": "low"
@@ -30659,6 +35129,10 @@
         {
           "effort": "high",
           "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
         }
       ],
       "supports_thinking_toggle": false,
@@ -30732,33 +35206,15 @@
     {
       "id": "gmi/anthropic/claude-opus-4.5",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "description": "Chat-compatible \u2022 Tool calling",
       "visibility": "list",
       "supported_parameters": [
         "tools",
-        "tool_choice",
-        "reasoning_effort"
+        "tool_choice"
       ],
-      "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
-          "effort": "low",
-          "description": "low"
-        },
-        {
-          "effort": "medium",
-          "description": "medium"
-        },
-        {
-          "effort": "high",
-          "description": "high"
-        }
-      ],
+      "supported_reasoning_levels": [],
       "supports_thinking_toggle": false,
-      "reasoning_control": "effort",
+      "reasoning_control": "none",
       "supports_parallel_tool_calls": false,
       "supports_search_tool": false,
       "input_modalities": [
@@ -30829,7 +35285,6 @@
     {
       "id": "gmi/deepseek-ai/DeepSeek-V3.2",
       "aliases": [
-        "DeepSeek-V3.2",
         "deepseek-ai/DeepSeek-V3.2"
       ],
       "description": "Chat-compatible \u2022 Tool calling",
@@ -31691,8 +36146,8 @@
     {
       "id": "gpt-4o-mini-realtime-preview",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -31710,8 +36165,8 @@
     {
       "id": "gpt-4o-mini-realtime-preview-2024-12-17",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -31866,8 +36321,8 @@
     {
       "id": "gpt-4o-realtime-preview",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -31885,8 +36340,8 @@
     {
       "id": "gpt-4o-realtime-preview-2024-12-17",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -31904,8 +36359,8 @@
     {
       "id": "gpt-4o-realtime-preview-2025-06-03",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -32375,7 +36830,7 @@
         "text",
         "image"
       ],
-      "context_window": 128000
+      "context_window": 400000
     },
     {
       "id": "gpt-5-pro-2025-10-06",
@@ -32414,7 +36869,7 @@
         "text",
         "image"
       ],
-      "context_window": 128000
+      "context_window": 400000
     },
     {
       "id": "gpt-5-search-api",
@@ -33185,7 +37640,7 @@
         "text",
         "image"
       ],
-      "context_window": 272000
+      "context_window": 1050000
     },
     {
       "id": "gpt-5.4-mini-2026-03-17",
@@ -33228,7 +37683,7 @@
         "text",
         "image"
       ],
-      "context_window": 272000
+      "context_window": 1050000
     },
     {
       "id": "gpt-5.4-nano",
@@ -33271,7 +37726,7 @@
         "text",
         "image"
       ],
-      "context_window": 272000
+      "context_window": 1050000
     },
     {
       "id": "gpt-5.4-nano-2026-03-17",
@@ -33314,7 +37769,7 @@
         "text",
         "image"
       ],
-      "context_window": 272000
+      "context_window": 1050000
     },
     {
       "id": "gpt-5.4-pro",
@@ -33567,6 +38022,178 @@
       "context_window": 1050000
     },
     {
+      "id": "gpt-5.6",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "gpt-5.6-luna",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "gpt-5.6-sol",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
+      "id": "gpt-5.6-terra",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "none"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1050000
+    },
+    {
       "id": "gpt-audio",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling",
@@ -33783,8 +38410,8 @@
     {
       "id": "gpt-realtime",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -33803,8 +38430,8 @@
     {
       "id": "gpt-realtime-1.5",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -33823,8 +38450,8 @@
     {
       "id": "gpt-realtime-2",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -33841,10 +38468,50 @@
       "context_window": 32000
     },
     {
+      "id": "gpt-realtime-2.1",
+      "aliases": [],
+      "description": "Tool calling",
+      "visibility": "hide",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "gpt-realtime-2.1-mini",
+      "aliases": [],
+      "description": "Tool calling",
+      "visibility": "hide",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 128000
+    },
+    {
       "id": "gpt-realtime-2025-08-28",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -33863,8 +38530,8 @@
     {
       "id": "gpt-realtime-mini",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -33883,8 +38550,8 @@
     {
       "id": "gpt-realtime-mini-2025-10-06",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -33903,8 +38570,8 @@
     {
       "id": "gpt-realtime-mini-2025-12-15",
       "aliases": [],
-      "description": "Chat-compatible \u2022 Tool calling",
-      "visibility": "list",
+      "description": "Tool calling",
+      "visibility": "hide",
       "supported_parameters": [
         "tools",
         "tool_choice"
@@ -33919,6 +38586,22 @@
         "image"
       ],
       "context_window": 128000
+    },
+    {
+      "id": "gpt-realtime-whisper",
+      "aliases": [],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
     },
     {
       "id": "gradient_ai/alibaba-qwen3-32b",
@@ -34453,9 +39136,7 @@
     },
     {
       "id": "groq/whisper-large-v3",
-      "aliases": [
-        "whisper-large-v3"
-      ],
+      "aliases": [],
       "description": null,
       "visibility": "hide",
       "supported_parameters": [],
@@ -35066,6 +39747,27 @@
       "context_window": 131072
     },
     {
+      "id": "inception/mercury-2",
+      "aliases": [
+        "mercury-2"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 128000
+    },
+    {
       "id": "j2-light",
       "aliases": [],
       "description": null,
@@ -35335,6 +40037,124 @@
       "context_window": 200000
     },
     {
+      "id": "jp.anthropic.claude-opus-4-7",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "minimal",
+          "description": "minimal"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "jp.anthropic.claude-opus-4-8",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "jp.anthropic.claude-opus-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
       "id": "jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
@@ -35380,9 +40200,39 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
+          "effort": "low",
+          "description": "low"
         },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "jp.anthropic.claude-sonnet-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
         {
           "effort": "low",
           "description": "low"
@@ -35394,6 +40244,10 @@
         {
           "effort": "high",
           "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
         }
       ],
       "supports_thinking_toggle": false,
@@ -36010,6 +40864,325 @@
         "text"
       ],
       "context_window": 131072
+    },
+    {
+      "id": "libertai/bge-m3",
+      "aliases": [],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 8192
+    },
+    {
+      "id": "libertai/deepseek-v4-flash",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 200000
+    },
+    {
+      "id": "libertai/deepseek-v4-flash-thinking",
+      "aliases": [
+        "deepseek-v4-flash-thinking"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 200000
+    },
+    {
+      "id": "libertai/gemma-4-31b-it",
+      "aliases": [
+        "gemma-4-31b-it"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "libertai/gemma-4-31b-it-thinking",
+      "aliases": [
+        "gemma-4-31b-it-thinking"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "libertai/hermes-3-8b-tee",
+      "aliases": [
+        "hermes-3-8b-tee"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 16000
+    },
+    {
+      "id": "libertai/qwen3.5-122b-a10b",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "libertai/qwen3.5-122b-a10b-thinking",
+      "aliases": [
+        "qwen3.5-122b-a10b-thinking"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "libertai/qwen3.6-27b",
+      "aliases": [
+        "qwen3.6-27b"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "libertai/qwen3.6-27b-thinking",
+      "aliases": [
+        "qwen3.6-27b-thinking"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "libertai/qwen3.6-35b-a3b",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "libertai/qwen3.6-35b-a3b-thinking",
+      "aliases": [
+        "qwen3.6-35b-a3b-thinking"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
     },
     {
       "id": "linkup/search",
@@ -37134,6 +42307,51 @@
       "context_window": 128000
     },
     {
+      "id": "meta/muse-spark-1.1",
+      "aliases": [
+        "muse-spark-1.1"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "minimal",
+          "description": "minimal"
+        },
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1048576
+    },
+    {
       "id": "meta_llama/Llama-3.3-70B-Instruct",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling",
@@ -37437,6 +42655,42 @@
       "supports_search_tool": false,
       "input_modalities": [
         "text"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "minimax/MiniMax-M3",
+      "aliases": [
+        "MiniMax-M3"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
       ],
       "context_window": 1000000
     },
@@ -38357,6 +43611,48 @@
       "context_window": 262144
     },
     {
+      "id": "mistral/ministral-8b-2512",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "mistral/ministral-8b-latest",
+      "aliases": [
+        "ministral-8b-latest"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
       "id": "mistral/mistral-embed",
       "aliases": [],
       "description": null,
@@ -38551,6 +43847,64 @@
       "context_window": 131072
     },
     {
+      "id": "mistral/mistral-medium-2508",
+      "aliases": [
+        "mistral-medium-2508"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 131072
+    },
+    {
+      "id": "mistral/mistral-medium-2604",
+      "aliases": [
+        "mistral-medium-2604"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
+    },
+    {
       "id": "mistral/mistral-medium-3-1-2508",
       "aliases": [
         "mistral-medium-3-1-2508"
@@ -38573,31 +43927,117 @@
       "context_window": 131072
     },
     {
-      "id": "mistral/mistral-medium-latest",
+      "id": "mistral/mistral-medium-3-5",
       "aliases": [
-        "mistral-medium-latest"
+        "mistral-medium-3-5"
       ],
-      "description": "Chat-compatible \u2022 Tool calling",
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
       "visibility": "list",
       "supported_parameters": [
         "tools",
-        "tool_choice"
+        "tool_choice",
+        "reasoning_effort"
       ],
-      "supported_reasoning_levels": [],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
       "supports_thinking_toggle": false,
-      "reasoning_control": "none",
+      "reasoning_control": "effort",
       "supports_parallel_tool_calls": false,
       "supports_search_tool": false,
       "input_modalities": [
         "text",
         "image"
       ],
-      "context_window": 131072
+      "context_window": 262144
+    },
+    {
+      "id": "mistral/mistral-medium-latest",
+      "aliases": [
+        "mistral-medium-latest"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 262144
     },
     {
       "id": "mistral/mistral-ocr-2505-completion",
       "aliases": [
         "mistral-ocr-2505-completion"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
+      "id": "mistral/mistral-ocr-2512",
+      "aliases": [
+        "mistral-ocr-2512"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
+      "id": "mistral/mistral-ocr-4-0",
+      "aliases": [
+        "mistral-ocr-4-0"
       ],
       "description": null,
       "visibility": "hide",
@@ -39107,9 +44547,7 @@
     },
     {
       "id": "moonshot/kimi-k2.6",
-      "aliases": [
-        "kimi-k2.6"
-      ],
+      "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
       "visibility": "list",
       "supported_parameters": [
@@ -39587,10 +45025,7 @@
     },
     {
       "id": "nebius/BAAI/bge-multilingual-gemma2",
-      "aliases": [
-        "BAAI/bge-multilingual-gemma2",
-        "bge-multilingual-gemma2"
-      ],
+      "aliases": [],
       "description": null,
       "visibility": "hide",
       "supported_parameters": [],
@@ -40224,8 +45659,7 @@
     {
       "id": "novita/baai/bge-m3",
       "aliases": [
-        "baai/bge-m3",
-        "bge-m3"
+        "baai/bge-m3"
       ],
       "description": null,
       "visibility": "hide",
@@ -41026,7 +46460,6 @@
     {
       "id": "novita/meta-llama/llama-3.2-3b-instruct",
       "aliases": [
-        "llama-3.2-3b-instruct",
         "meta-llama/llama-3.2-3b-instruct"
       ],
       "description": "Chat-compatible \u2022 Tool calling",
@@ -41048,7 +46481,6 @@
     {
       "id": "novita/meta-llama/llama-3.3-70b-instruct",
       "aliases": [
-        "llama-3.3-70b-instruct",
         "meta-llama/llama-3.3-70b-instruct"
       ],
       "description": "Chat-compatible \u2022 Tool calling",
@@ -41589,10 +47021,7 @@
     },
     {
       "id": "novita/qwen/qwen3-30b-a3b-fp8",
-      "aliases": [
-        "qwen/qwen3-30b-a3b-fp8",
-        "qwen3-30b-a3b-fp8"
-      ],
+      "aliases": [],
       "description": "Chat-compatible \u2022 Reasoning effort",
       "visibility": "hide",
       "supported_parameters": [
@@ -41724,9 +47153,7 @@
     },
     {
       "id": "novita/qwen/qwen3-coder-30b-a3b-instruct",
-      "aliases": [
-        "qwen/qwen3-coder-30b-a3b-instruct"
-      ],
+      "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling",
       "visibility": "list",
       "supported_parameters": [
@@ -41785,9 +47212,7 @@
     },
     {
       "id": "novita/qwen/qwen3-embedding-8b",
-      "aliases": [
-        "qwen/qwen3-embedding-8b"
-      ],
+      "aliases": [],
       "description": null,
       "visibility": "hide",
       "supported_parameters": [],
@@ -43379,6 +48804,24 @@
       "context_window": 256000
     },
     {
+      "id": "oci/cohere.command-a-reasoning",
+      "aliases": [
+        "cohere.command-a-reasoning"
+      ],
+      "description": "Chat-compatible",
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 256000
+    },
+    {
       "id": "oci/cohere.command-a-reasoning-08-2025",
       "aliases": [
         "cohere.command-a-reasoning-08-2025"
@@ -43414,6 +48857,28 @@
       "supports_search_tool": false,
       "input_modalities": [
         "text"
+      ],
+      "context_window": 256000
+    },
+    {
+      "id": "oci/cohere.command-a-vision",
+      "aliases": [
+        "cohere.command-a-vision"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
       ],
       "context_window": 256000
     },
@@ -43592,6 +49057,25 @@
       "supports_search_tool": false,
       "input_modalities": [
         "text"
+      ],
+      "context_window": 512
+    },
+    {
+      "id": "oci/cohere.embed-multilingual-image-v3.0",
+      "aliases": [
+        "cohere.embed-multilingual-image-v3.0"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
       ],
       "context_window": 512
     },
@@ -43776,6 +49260,27 @@
       "context_window": 128000
     },
     {
+      "id": "oci/meta.llama-3.1-8b-instruct",
+      "aliases": [
+        "meta.llama-3.1-8b-instruct"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 128000
+    },
+    {
       "id": "oci/meta.llama-3.2-11b-vision-instruct",
       "aliases": [
         "meta.llama-3.2-11b-vision-instruct"
@@ -43878,9 +49383,10 @@
       "supports_parallel_tool_calls": false,
       "supports_search_tool": false,
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
-      "context_window": 512000
+      "context_window": 1048576
     },
     {
       "id": "oci/meta.llama-4-scout-17b-16e-instruct",
@@ -43901,7 +49407,115 @@
       "input_modalities": [
         "text"
       ],
-      "context_window": 192000
+      "context_window": 10485760
+    },
+    {
+      "id": "oci/openai.gpt-5",
+      "aliases": [
+        "openai.gpt-5"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 272000
+    },
+    {
+      "id": "oci/openai.gpt-5-mini",
+      "aliases": [
+        "openai.gpt-5-mini"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 272000
+    },
+    {
+      "id": "oci/openai.gpt-5-nano",
+      "aliases": [
+        "openai.gpt-5-nano"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 272000
     },
     {
       "id": "oci/xai.grok-3",
@@ -45062,10 +50676,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -45099,10 +50709,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -45249,10 +50855,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -45626,6 +51228,43 @@
       "context_window": 1048576
     },
     {
+      "id": "openrouter/google/gemini-3.1-flash-lite",
+      "aliases": [
+        "google/gemini-3.1-flash-lite"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1048576
+    },
+    {
       "id": "openrouter/google/gemini-3.1-flash-lite-preview",
       "aliases": [
         "google/gemini-3.1-flash-lite-preview"
@@ -45931,7 +51570,6 @@
     {
       "id": "openrouter/mistralai/ministral-8b-2512",
       "aliases": [
-        "ministral-8b-2512",
         "mistralai/ministral-8b-2512"
       ],
       "description": "Chat-compatible \u2022 Tool calling",
@@ -46015,10 +51653,7 @@
     },
     {
       "id": "openrouter/mistralai/mistral-small-3.1-24b-instruct",
-      "aliases": [
-        "mistral-small-3.1-24b-instruct",
-        "mistralai/mistral-small-3.1-24b-instruct"
-      ],
+      "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling",
       "visibility": "list",
       "supported_parameters": [
@@ -47009,8 +52644,7 @@
     {
       "id": "openrouter/qwen/qwen3.5-122b-a10b",
       "aliases": [
-        "qwen/qwen3.5-122b-a10b",
-        "qwen3.5-122b-a10b"
+        "qwen/qwen3.5-122b-a10b"
       ],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
       "visibility": "list",
@@ -47119,10 +52753,7 @@
     },
     {
       "id": "openrouter/qwen/qwen3.5-397b-a17b",
-      "aliases": [
-        "qwen/qwen3.5-397b-a17b",
-        "qwen3.5-397b-a17b"
-      ],
+      "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
       "visibility": "list",
       "supported_parameters": [
@@ -47381,6 +53012,79 @@
       "context_window": 262144
     },
     {
+      "id": "openrouter/xiaomi/mimo-v2.5",
+      "aliases": [
+        "mimo-v2.5",
+        "xiaomi/mimo-v2.5"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1048576
+    },
+    {
+      "id": "openrouter/xiaomi/mimo-v2.5-pro",
+      "aliases": [
+        "mimo-v2.5-pro",
+        "xiaomi/mimo-v2.5-pro"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1048576
+    },
+    {
       "id": "openrouter/z-ai/glm-4.6",
       "aliases": [
         "z-ai/glm-4.6"
@@ -47490,7 +53194,6 @@
     {
       "id": "openrouter/z-ai/glm-4.7-flash",
       "aliases": [
-        "glm-4.7-flash",
         "z-ai/glm-4.7-flash"
       ],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
@@ -47528,6 +53231,41 @@
       "id": "openrouter/z-ai/glm-5",
       "aliases": [
         "z-ai/glm-5"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 202752
+    },
+    {
+      "id": "openrouter/z-ai/glm-5.1",
+      "aliases": [
+        "z-ai/glm-5.1"
       ],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
       "visibility": "list",
@@ -48060,34 +53798,16 @@
       "aliases": [
         "anthropic/claude-opus-4-5"
       ],
-      "description": "Responses \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "description": "Responses \u2022 Tool calling \u2022 Search",
       "visibility": "list",
       "supported_parameters": [
         "tools",
         "tool_choice",
-        "reasoning_effort",
         "web_search_options"
       ],
-      "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
-          "effort": "low",
-          "description": "low"
-        },
-        {
-          "effort": "medium",
-          "description": "medium"
-        },
-        {
-          "effort": "high",
-          "description": "high"
-        }
-      ],
+      "supported_reasoning_levels": [],
       "supports_thinking_toggle": false,
-      "reasoning_control": "effort",
+      "reasoning_control": "none",
       "supports_parallel_tool_calls": false,
       "supports_search_tool": true,
       "input_modalities": [
@@ -48898,6 +54618,190 @@
       "context_window": null
     },
     {
+      "id": "pinstripes/ps/deepseek-v4-flash",
+      "aliases": [
+        "ps/deepseek-v4-flash"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 163840
+    },
+    {
+      "id": "pinstripes/ps/glm-4.5-air",
+      "aliases": [
+        "ps/glm-4.5-air"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "pinstripes/ps/minimax-m2.7",
+      "aliases": [
+        "minimax-m2.7",
+        "ps/minimax-m2.7"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1000192
+    },
+    {
+      "id": "pinstripes/ps/qwen3-30b-a3b",
+      "aliases": [
+        "ps/qwen3-30b-a3b"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 131072
+    },
+    {
+      "id": "pinstripes/ps/qwen3-coder-30b-a3b",
+      "aliases": [
+        "ps/qwen3-coder-30b-a3b",
+        "qwen3-coder-30b-a3b"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 131072
+    },
+    {
+      "id": "pinstripes/ps/qwen3.6-35b-a3b",
+      "aliases": [
+        "ps/qwen3.6-35b-a3b"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 131072
+    },
+    {
       "id": "publicai/BSC-LT/ALIA-40b-instruct_Q8_0",
       "aliases": [
         "ALIA-40b-instruct_Q8_0",
@@ -49329,6 +55233,42 @@
       "id": "recraft/recraftv3",
       "aliases": [
         "recraftv3"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
+      "id": "reducto/parse-legacy",
+      "aliases": [
+        "parse-legacy"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
+      "id": "reducto/parse-v3",
+      "aliases": [
+        "parse-v3"
       ],
       "description": null,
       "visibility": "hide",
@@ -50624,6 +56564,25 @@
       "input_modalities": [
         "text"
       ],
+      "context_window": 131072
+    },
+    {
+      "id": "sambanova/DeepSeek-V3.2",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
       "context_window": 32768
     },
     {
@@ -50813,7 +56772,7 @@
       "input_modalities": [
         "text"
       ],
-      "context_window": 204800
+      "context_window": 196608
     },
     {
       "id": "sambanova/QwQ-32B",
@@ -50881,6 +56840,23 @@
         "text"
       ],
       "context_window": 8192
+    },
+    {
+      "id": "sambanova/gemma-4-31B-it",
+      "aliases": [],
+      "description": "Chat-compatible",
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 131072
     },
     {
       "id": "sambanova/gpt-oss-120b",
@@ -50984,6 +56960,414 @@
       "context_window": 8192
     },
     {
+      "id": "scaleway/BAAI/bge-multilingual-gemma2",
+      "aliases": [],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
+      "id": "scaleway/google/gemma-3-27b-it",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 40000
+    },
+    {
+      "id": "scaleway/google/gemma-4-26b-a4b-it",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 256000
+    },
+    {
+      "id": "scaleway/hcompany/holo2-30b-a3b",
+      "aliases": [
+        "hcompany/holo2-30b-a3b",
+        "holo2-30b-a3b"
+      ],
+      "description": "Chat-compatible \u2022 Reasoning effort",
+      "visibility": "hide",
+      "supported_parameters": [
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 22000
+    },
+    {
+      "id": "scaleway/meta/llama-3.3-70b-instruct",
+      "aliases": [
+        "meta/llama-3.3-70b-instruct"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "scaleway/mistralai/devstral-2-123b-instruct-2512",
+      "aliases": [
+        "devstral-2-123b-instruct-2512",
+        "mistralai/devstral-2-123b-instruct-2512"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 200000
+    },
+    {
+      "id": "scaleway/mistralai/mistral-medium-3.5-128b",
+      "aliases": [
+        "mistral-medium-3.5-128b",
+        "mistralai/mistral-medium-3.5-128b"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 256000
+    },
+    {
+      "id": "scaleway/mistralai/mistral-small-3.2-24b-instruct-2506",
+      "aliases": [
+        "mistral-small-3.2-24b-instruct-2506",
+        "mistralai/mistral-small-3.2-24b-instruct-2506"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "scaleway/mistralai/pixtral-12b-2409",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "scaleway/mistralai/voxtral-small-24b-2507",
+      "aliases": [
+        "mistralai/voxtral-small-24b-2507",
+        "voxtral-small-24b-2507"
+      ],
+      "description": "Chat-compatible",
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 32000
+    },
+    {
+      "id": "scaleway/openai/gpt-oss-120b",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "scaleway/openai/whisper-large-v3",
+      "aliases": [
+        "openai/whisper-large-v3"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
+      "id": "scaleway/qwen/qwen3-235b-a22b-instruct-2507",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 256000
+    },
+    {
+      "id": "scaleway/qwen/qwen3-coder-30b-a3b-instruct",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "scaleway/qwen/qwen3-embedding-8b",
+      "aliases": [],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
+      "id": "scaleway/qwen/qwen3.5-397b-a17b",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 256000
+    },
+    {
+      "id": "scaleway/qwen/qwen3.6-35b-a3b",
+      "aliases": [
+        "qwen/qwen3.6-35b-a3b"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 256000
+    },
+    {
       "id": "searxng/search",
       "aliases": [],
       "description": null,
@@ -51018,18 +57402,170 @@
     {
       "id": "snowflake/claude-3-5-sonnet",
       "aliases": [],
-      "description": "Chat-compatible",
-      "visibility": "hide",
-      "supported_parameters": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
       "supported_reasoning_levels": [],
       "supports_thinking_toggle": false,
       "reasoning_control": "none",
       "supports_parallel_tool_calls": false,
       "supports_search_tool": false,
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
-      "context_window": 18000
+      "context_window": 200000
+    },
+    {
+      "id": "snowflake/claude-3-7-sonnet",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 200000
+    },
+    {
+      "id": "snowflake/claude-4-opus",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 200000
+    },
+    {
+      "id": "snowflake/claude-4-sonnet",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 200000
+    },
+    {
+      "id": "snowflake/claude-haiku-4-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 200000
+    },
+    {
+      "id": "snowflake/claude-sonnet-4-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 200000
+    },
+    {
+      "id": "snowflake/claude-sonnet-4-6",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 200000
     },
     {
       "id": "snowflake/deepseek-r1",
@@ -51060,7 +57596,7 @@
       "input_modalities": [
         "text"
       ],
-      "context_window": 32768
+      "context_window": 128000
     },
     {
       "id": "snowflake/gemma-7b",
@@ -51185,9 +57721,12 @@
       "aliases": [
         "llama3.1-405b"
       ],
-      "description": "Chat-compatible",
-      "visibility": "hide",
-      "supported_parameters": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
       "supported_reasoning_levels": [],
       "supports_thinking_toggle": false,
       "reasoning_control": "none",
@@ -51201,9 +57740,12 @@
     {
       "id": "snowflake/llama3.1-70b",
       "aliases": [],
-      "description": "Chat-compatible",
-      "visibility": "hide",
-      "supported_parameters": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
       "supported_reasoning_levels": [],
       "supports_thinking_toggle": false,
       "reasoning_control": "none",
@@ -51271,9 +57813,33 @@
       "aliases": [
         "llama3.3-70b"
       ],
-      "description": "Chat-compatible",
-      "visibility": "hide",
-      "supported_parameters": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "snowflake/llama4-maverick",
+      "aliases": [
+        "llama4-maverick"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
       "supported_reasoning_levels": [],
       "supports_thinking_toggle": false,
       "reasoning_control": "none",
@@ -51321,9 +57887,12 @@
       "aliases": [
         "mistral-large2"
       ],
-      "description": "Chat-compatible",
-      "visibility": "hide",
-      "supported_parameters": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
       "supported_reasoning_levels": [],
       "supports_thinking_toggle": false,
       "reasoning_control": "none",
@@ -51349,6 +57918,106 @@
         "text"
       ],
       "context_window": 32000
+    },
+    {
+      "id": "snowflake/openai-gpt-4.1",
+      "aliases": [
+        "openai-gpt-4.1"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 300000
+    },
+    {
+      "id": "snowflake/openai-gpt-5",
+      "aliases": [
+        "openai-gpt-5"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 300000
+    },
+    {
+      "id": "snowflake/openai-gpt-5-mini",
+      "aliases": [
+        "openai-gpt-5-mini"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "snowflake/openai-gpt-5-nano",
+      "aliases": [
+        "openai-gpt-5-nano"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 5000000
     },
     {
       "id": "snowflake/reka-core",
@@ -51405,6 +58074,42 @@
       "context_window": 4096
     },
     {
+      "id": "snowflake/snowflake-arctic-embed-l-v2.0",
+      "aliases": [
+        "snowflake-arctic-embed-l-v2.0"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 8192
+    },
+    {
+      "id": "snowflake/snowflake-arctic-embed-m-v2.0",
+      "aliases": [
+        "snowflake-arctic-embed-m-v2.0"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 8192
+    },
+    {
       "id": "snowflake/snowflake-llama-3.1-405b",
       "aliases": [
         "snowflake-llama-3.1-405b"
@@ -51427,7 +58132,46 @@
       "aliases": [
         "snowflake-llama-3.3-70b"
       ],
-      "description": "Chat-compatible",
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 128000
+    },
+    {
+      "id": "soniox/stt-async-v4",
+      "aliases": [
+        "stt-async-v4"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 8000
+    },
+    {
+      "id": "soniox/stt-async-v5",
+      "aliases": [
+        "stt-async-v5"
+      ],
+      "description": null,
       "visibility": "hide",
       "supported_parameters": [],
       "supported_reasoning_levels": [],
@@ -52392,6 +59136,405 @@
       "context_window": null
     },
     {
+      "id": "tencent/deepseek-v4-flash",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "tencent/deepseek-v4-pro",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "tensormesh/MiniMaxAI/MiniMax-M2.5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 196608
+    },
+    {
+      "id": "tensormesh/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "tensormesh/Qwen/Qwen3.5-397B-A17B-FP8",
+      "aliases": [
+        "Qwen/Qwen3.5-397B-A17B-FP8",
+        "Qwen3.5-397B-A17B-FP8"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "tensormesh/Qwen/Qwen3.6-27B-FP8",
+      "aliases": [
+        "Qwen/Qwen3.6-27B-FP8",
+        "Qwen3.6-27B-FP8"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 262144
+    },
+    {
+      "id": "tensormesh/deepseek-ai/DeepSeek-V4-Flash",
+      "aliases": [
+        "DeepSeek-V4-Flash",
+        "deepseek-ai/DeepSeek-V4-Flash"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 32768
+    },
+    {
+      "id": "tensormesh/google/gemma-4-31B-it",
+      "aliases": [
+        "google/gemma-4-31B-it"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 32768
+    },
+    {
+      "id": "tensormesh/lukealonso/GLM-5.1-NVFP4-MTP",
+      "aliases": [
+        "GLM-5.1-NVFP4-MTP",
+        "lukealonso/GLM-5.1-NVFP4-MTP"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 202752
+    },
+    {
+      "id": "tensormesh/moonshotai/Kimi-K2.6",
+      "aliases": [
+        "Kimi-K2.6",
+        "moonshotai/Kimi-K2.6"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 32768
+    },
+    {
+      "id": "tensormesh/openai/gpt-oss-120b",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 131072
+    },
+    {
+      "id": "tensormesh/openai/gpt-oss-20b",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 131072
+    },
+    {
       "id": "text-completion-codestral/codestral-2405",
       "aliases": [],
       "description": null,
@@ -52410,6 +59553,24 @@
     {
       "id": "text-completion-codestral/codestral-latest",
       "aliases": [],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 32000
+    },
+    {
+      "id": "text-completion-inception/mercury-edit-2",
+      "aliases": [
+        "mercury-edit-2"
+      ],
       "description": null,
       "visibility": "hide",
       "supported_parameters": [],
@@ -52646,6 +59807,22 @@
         "text"
       ],
       "context_window": 8192
+    },
+    {
+      "id": "tinyfish/search",
+      "aliases": [],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
     },
     {
       "id": "together-ai-21.1b-41b",
@@ -52899,10 +60076,7 @@
     },
     {
       "id": "together_ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
-      "aliases": [
-        "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
-        "Qwen3-Coder-480B-A35B-Instruct-FP8"
-      ],
+      "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling",
       "visibility": "list",
       "supported_parameters": [
@@ -53989,6 +61163,44 @@
       "context_window": 200000
     },
     {
+      "id": "us.anthropic.claude-fable-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
       "id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
@@ -54102,10 +61314,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -54139,10 +61347,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -54178,9 +61382,81 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
+          "effort": "low",
+          "description": "low"
         },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "us.anthropic.claude-opus-4-8",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "us.anthropic.claude-opus-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
         {
           "effort": "low",
           "description": "low"
@@ -54288,9 +61564,39 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
+          "effort": "low",
+          "description": "low"
         },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "us.anthropic.claude-sonnet-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
         {
           "effort": "low",
           "description": "low"
@@ -54302,6 +61608,10 @@
         {
           "effort": "high",
           "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
         }
       ],
       "supports_thinking_toggle": false,
@@ -55245,10 +62555,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -55282,10 +62588,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -56926,6 +64228,24 @@
       "context_window": null
     },
     {
+      "id": "vertex_ai/chirp_3",
+      "aliases": [
+        "chirp_3"
+      ],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
+    },
+    {
       "id": "vertex_ai/claude-3-5-haiku",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling",
@@ -57172,6 +64492,84 @@
       "context_window": 200000
     },
     {
+      "id": "vertex_ai/claude-fable-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "vertex_ai/claude-fable-5@default",
+      "aliases": [
+        "claude-fable-5@default"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
       "id": "vertex_ai/claude-haiku-4-5",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
@@ -57329,10 +64727,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -57369,10 +64763,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -57406,10 +64796,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -57447,10 +64833,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -57484,10 +64866,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -57529,9 +64907,83 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
+          "effort": "low",
+          "description": "low"
         },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "vertex_ai/claude-opus-4-8",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "vertex_ai/claude-opus-4-8@default",
+      "aliases": [
+        "claude-opus-4-8@default"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
         {
           "effort": "low",
           "description": "low"
@@ -57594,6 +65046,84 @@
         "image"
       ],
       "context_window": 200000
+    },
+    {
+      "id": "vertex_ai/claude-opus-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "vertex_ai/claude-opus-5@default",
+      "aliases": [
+        "claude-opus-5@default"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
     },
     {
       "id": "vertex_ai/claude-sonnet-4",
@@ -57711,10 +65241,6 @@
       ],
       "supported_reasoning_levels": [
         {
-          "effort": "minimal",
-          "description": "minimal"
-        },
-        {
           "effort": "low",
           "description": "low"
         },
@@ -57750,10 +65276,6 @@
         "reasoning_effort"
       ],
       "supported_reasoning_levels": [
-        {
-          "effort": "minimal",
-          "description": "minimal"
-        },
         {
           "effort": "low",
           "description": "low"
@@ -57801,6 +65323,84 @@
         {
           "effort": "high",
           "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "vertex_ai/claude-sonnet-5",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1000000
+    },
+    {
+      "id": "vertex_ai/claude-sonnet-5@default",
+      "aliases": [
+        "claude-sonnet-5@default"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        },
+        {
+          "effort": "xhigh",
+          "description": "xhigh"
         }
       ],
       "supports_thinking_toggle": false,
@@ -58113,6 +65713,22 @@
       "context_window": 1048576
     },
     {
+      "id": "vertex_ai/gemini-3-pro-image",
+      "aliases": [],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 65536
+    },
+    {
       "id": "vertex_ai/gemini-3-pro-image-preview",
       "aliases": [],
       "description": null,
@@ -58164,6 +65780,22 @@
       "context_window": 1048576
     },
     {
+      "id": "vertex_ai/gemini-3.1-flash-image",
+      "aliases": [],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 65536
+    },
+    {
       "id": "vertex_ai/gemini-3.1-flash-image-preview",
       "aliases": [],
       "description": null,
@@ -58178,6 +65810,41 @@
         "text"
       ],
       "context_window": 65536
+    },
+    {
+      "id": "vertex_ai/gemini-3.1-flash-lite",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1048576
     },
     {
       "id": "vertex_ai/gemini-3.1-flash-lite-preview",
@@ -58320,6 +65987,76 @@
       "context_window": 1048576
     },
     {
+      "id": "vertex_ai/gemini-3.5-flash-lite",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1048576
+    },
+    {
+      "id": "vertex_ai/gemini-3.6-flash",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 1048576
+    },
+    {
       "id": "vertex_ai/gemini-embedding-2",
       "aliases": [],
       "description": null,
@@ -58350,6 +66087,29 @@
         "text"
       ],
       "context_window": 8192
+    },
+    {
+      "id": "vertex_ai/google/gemma-4-26b-a4b-it-maas",
+      "aliases": [
+        "gemma-4-26b-a4b-it-maas",
+        "google/gemma-4-26b-a4b-it-maas"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice"
+      ],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 256000
     },
     {
       "id": "vertex_ai/imagegeneration@006",
@@ -60964,9 +68724,7 @@
     },
     {
       "id": "watsonx/mistralai/pixtral-12b-2409",
-      "aliases": [
-        "mistralai/pixtral-12b-2409"
-      ],
+      "aliases": [],
       "description": "Chat-compatible",
       "visibility": "hide",
       "supported_parameters": [],
@@ -62003,6 +69761,80 @@
       "context_window": 1000000
     },
     {
+      "id": "xai/grok-4.5",
+      "aliases": [
+        "grok-4.5"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 500000
+    },
+    {
+      "id": "xai/grok-4.5-latest",
+      "aliases": [
+        "grok-4.5-latest"
+      ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort \u2022 Search",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "web_search_options"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": true,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "context_window": 500000
+    },
+    {
       "id": "xai/grok-beta",
       "aliases": [
         "grok-beta"
@@ -62150,6 +69982,22 @@
         "image"
       ],
       "context_window": 8192
+    },
+    {
+      "id": "you_com/search",
+      "aliases": [],
+      "description": null,
+      "visibility": "hide",
+      "supported_parameters": [],
+      "supported_reasoning_levels": [],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "none",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": null
     },
     {
       "id": "zai.glm-4.7",
@@ -62459,6 +70307,39 @@
       "context_window": 200000
     },
     {
+      "id": "zai/glm-4.7-flash",
+      "aliases": [],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 200000
+    },
+    {
       "id": "zai/glm-5",
       "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
@@ -62496,6 +70377,39 @@
       "aliases": [
         "glm-5-code"
       ],
+      "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
+      "visibility": "list",
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "reasoning_effort"
+      ],
+      "supported_reasoning_levels": [
+        {
+          "effort": "low",
+          "description": "low"
+        },
+        {
+          "effort": "medium",
+          "description": "medium"
+        },
+        {
+          "effort": "high",
+          "description": "high"
+        }
+      ],
+      "supports_thinking_toggle": false,
+      "reasoning_control": "effort",
+      "supports_parallel_tool_calls": false,
+      "supports_search_tool": false,
+      "input_modalities": [
+        "text"
+      ],
+      "context_window": 200000
+    },
+    {
+      "id": "zai/glm-5.1",
+      "aliases": [],
       "description": "Chat-compatible \u2022 Tool calling \u2022 Reasoning effort",
       "visibility": "list",
       "supported_parameters": [


### PR DESCRIPTION
Closes #1856

### Description
This PR updates the model compatibility catalog by running the `write_model_compatibility_catalog.py` script. This adds support for Google's newly launched Gemini models:
- **Gemini 3.6 Flash** (`gemini-3.6-flash`)
- **Gemini 3.5 Flash-Lite** (`gemini-3.5-flash-lite`)

These models are now listed in the compatibility catalog with their full features (such as reasoning effort, parallel tool calling, search tools, etc.) to enable users to use them seamlessly.

### Testing
- Ran `just test -p codex-api` successfully (all 173 tests passed).