### PR TITLE
Fix Codex v0.146 model list tests

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/model_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/model_list.rs
@@ -110,6 +110,7 @@ async fn list_models_returns_all_models_with_large_limit() -> Result<()> {
                 limit: Some(100),
                 cursor: None,
                 include_hidden: None,
+                model_provider: None,
             },
         })
         .await?;
@@ -140,6 +141,7 @@ async fn list_models_includes_hidden_models() -> Result<()> {
                 limit: Some(100),
                 cursor: None,
                 include_hidden: Some(true),
+                model_provider: None,
             },
         })
         .await?;
@@ -222,6 +224,7 @@ openai_base_url = "{server_uri}/v1"
                 limit: Some(100),
                 cursor: None,
                 include_hidden: None,
+                model_provider: None,
             },
         })
         .await?;
@@ -281,6 +284,7 @@ async fn list_models_pagination_works() -> Result<()> {
                     limit: Some(1),
                     cursor: cursor.clone(),
                     include_hidden: None,
+                    model_provider: None,
                 },
             })
             .await?;


### PR DESCRIPTION
## Summary
- update four app-server model-list test requests for the new provider selector
- restore the cargo workspace test build after the v0.146 upstream merge

## Validation
- `cargo check -p codex-app-server --tests --locked`
- `just fix -p codex-app-server`
- `just fmt`
- `git diff --check`

Follow-up to #1859.